### PR TITLE
PhD generates garbled chm on PHP 5.4.0 or later.

### DIFF
--- a/phpdotnet/phd/Package/PHP/CHM.php
+++ b/phpdotnet/phd/Package/PHP/CHM.php
@@ -295,7 +295,7 @@ class Package_PHP_CHM extends Package_PHP_ChunkedXHTML
     protected function appendChm($name, $ref, $hasChild) {
         if ($this->flags & Render::OPEN) {
             $charset = $this->LANGUAGES[Config::language()]["preferred_charset"];
-            $name = htmlspecialchars(iconv('UTF-8', $charset, html_entity_decode($name, ENT_QUOTES, 'UTF-8')), ENT_QUOTES);
+            $name = htmlspecialchars(iconv('UTF-8', $charset, html_entity_decode($name, ENT_QUOTES, 'UTF-8')), ENT_QUOTES, $charset);
 
             $this->currentTocDepth++;
             fwrite($this->hhpStream, "{$ref}\n");


### PR DESCRIPTION
### Description

PhD generates garbled chm on PHP 5.4.0 or later, because of htmlspecialchars spec change (newly supports some encodings, CP932 and the default value for the encoding parameter was changed to UTF-8).
http://php.net/manual/en/function.htmlspecialchars.php

This issue cannot be reproduced on PHP 5.3.x.
### How reproducible

Always on PHP 5.4.x, PHP 5.5.0
### How to reproduce
1. install PHP and the latest PhD (1.1.6 or git version)
2. svn co http://svn.php.net/repository/phpdoc/modules/doc-ja
3. php doc-base/configure.php --with-lang=ja --enable-xml-details --disable-libxml-check
4. phd -f chm -P PHP -L ja -d doc-base/.manual.xml
### Expected result

In the following files, the valeu of "name (&lt;param name="Name" value="..."&gt;) is not empty. not garbled.

output/php-chm/php_manual_ja.hhc
output/php-chm/php_manual_ja.hhk
### Actual Result

In the following files, the valeu of "name (&lt;param name="Name" value="..."&gt;) is empty.
this is because htmlspecialchars function's return value is empty by specifying default encoding.

output/php-chm/php_manual_ja.hhc
output/php-chm/php_manual_ja.hhk
### Suggesting fix

Pull request's source.
We should specify htmlspecialchars third parameter (encoding) with preferred_charset.
### Extended Notes

This fix emits E_NOTICE in some locale on PHP 5.3.x, because 'CP932' and some encodings are not supported on htmlspecialchars on PHP 5.3.x. But this is not affected because PHP 5.3.x fallback to ISO-8859-1.
