### PR TITLE
Keep the return value to something count-able

### DIFF
--- a/phpdotnet/phd/Format.php
+++ b/phpdotnet/phd/Format.php
@@ -451,7 +451,7 @@ abstract class Format extends ObjectStorage
             || !is_array($this->children[$id])
             || count($this->children[$id]) == 0
         ) {
-            return null;
+            return [];
         }
         return $this->children[$id];
     }


### PR DESCRIPTION
In PHP 7.2, `count` can only be used with arrays and `Countable` objects. Returning `null` here causes a lot of warnings when building the docs on PHP 7.2.