### PR TITLE
Render return type in PHP 7 style

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -426,6 +426,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         "fieldsynopsis"            => array(
             "modifier"                      => "public",
         ),
+        "methodsynopsis"           => array(
+            "returntype"           => false,
+        ),
         "co"                       => 0,
         "callouts"                 => 0,
         "segmentedlist"            => array(


### PR DESCRIPTION
This change moves the return type name to the right-hand side of the
function/method prototypes, along the same lines as PHP 7 code.

**Before:**

    int time ( void )

**After:**

    time ( void ) : int

While this is a step towards PHP 7 style, there are still some
departures. Notably:
- No conversion to valid scalar type names is done (e.g. converting
`<type>boolean</type>` to ` : bool`)
- Pseudo-types and other invalid type names are used (e.g. resource,
mixed)