### PR TITLE
Correct continue usage within a switch block

### DIFF
--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -82,7 +82,7 @@ class Render extends ObjectStorage
                 $this->STACK[$depth] = $name;
 
                 if ($name == "notatag")
-                    continue;
+                    break;
 
                 foreach($this as $format) {
                     $map = $this[$format][\XMLReader::ELEMENT];


### PR DESCRIPTION
`continue` within a `switch` block works exactly the same as `break` and is normally a mistake. There's no code after the switch so presumably `continue 2` was not intended here, so this PR just changes it to `break` to avoid warnings in PHP 7.3