### PR TITLE
changed join parameter order for PHP 7.4.0

### DIFF
--- a/phpdotnet/phd/Package/Generic/Manpage.php
+++ b/phpdotnet/phd/Package/Generic/Manpage.php
@@ -627,7 +627,7 @@ class Package_Generic_Manpage extends Format_Abstract_Manpage {
                         . ($parameter['initializer'] ? " = " . $parameter['initializer'] : "")
                         . ($parameter['optional'] ? "]" : "") );
         }
-        $ret = "\n(" . join($params, ", ") . ")";
+        $ret = "\n(" . join(", ", $params) . ")";
         $this->cchunk['methodsynopsis']['params'] = array();
 
         // finally write what is in the buffer


### PR DESCRIPTION
When I use PhD with PHP 7.4.0, I got the following warning flood.

```
        join(): Passing glue string after array is deprecated. Swap the parameters
[01:24:28 - E_DEPRECATED          ] /home/mumumu/.phpenv/versions/7.4.0/lib/php/phpdotnet/phd/Package/Generic/Manpage.php:630
```

Fixed the changed join parameter order, which warning suggests.