### PR TITLE
Add support for properly rendering nullable types

### DIFF
--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -420,13 +420,20 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     }
 
     public function format_type_if_object_or_pseudo_text($type, $tagname) {
-        if (in_array(strtolower($type), array("bool", "int", "double", "boolean", "integer", "float", "string", "array", "object", "resource", "null"))) {
+        $mandatory = $type[0] === '?' ? substr($type, 1) : $type;
+        if (in_array(strtolower($mandatory), array("bool", "int", "double", "boolean", "integer", "float", "string", "array", "object", "resource", "null"))) {
             return false;
         }
         return self::format_type_text($type, $tagname);
     }
 
     public function format_type_text($type, $tagname) {
+        if ($type[0] === '?') {
+            $prefix = '?';
+            $type = substr($type, 1);
+        } else {
+            $prefix = '';
+        }
         $t = strtr(strtolower($type), "_", "-");
         $href = $fragment = "";
 
@@ -468,12 +475,12 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         }
 
         if ($href && $this->chunked) {
-            return '<a href="' .$href. $this->getExt().($fragment ? "#$fragment" : ""). '" class="' .$tagname. ' ' .$type. '">' .$type. '</a>';
+            return $prefix. '<a href="' .$href. $this->getExt().($fragment ? "#$fragment" : ""). '" class="' .$tagname. ' ' .$type. '">' .$type. '</a>';
         }
         if ($href) {
-            return '<a href="#' .($fragment ? $fragment : $href). '" class="' .$tagname. ' ' .$type. '">' .$type. '</a>';
+            return $prefix. '<a href="#' .($fragment ? $fragment : $href). '" class="' .$tagname. ' ' .$type. '">' .$type. '</a>';
         }
-        return '<span class="' .$tagname. ' ' .$type. '">' .$type. '</span>';
+        return $prefix. '<span class="' .$tagname. ' ' .$type. '">' .$type. '</span>';
     }
 
     public function format_example_title($open, $name, $attrs, $props) {


### PR DESCRIPTION
While it is already possible to write types with the nullable type mark
(`?`) (and some extensions already make use of this), these types are
not linked to the respective classes or interfaces.  So we make sure
that the type lookup ignores the question mark, and we put it outside
the link.

This is a bit hackish, because it would be better to introduce proper
support for union types; however, these are only supported as of
DocBook 5.2, and since we're still using 4.5, we would have to upgrade
first.

---

Looks like this:

![phd-nullable](https://user-images.githubusercontent.com/2306138/75897878-8b36e980-5e39-11ea-84b8-75908c771fac.jpg)
