### PR TITLE
Support namespaced classes in <type> elements

### DIFF
--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -427,7 +427,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     }
 
     public function format_type_text($type, $tagname) {
-        $t = strtr(strtolower($type), "_", "-");
+        $t = strtr(strtolower($type), ["_" => "-", "\\" => "-"]);
         $href = $fragment = "";
 
         switch($t) {


### PR DESCRIPTION
Currently, automatic linking to the documentation pages of namespaced
classes is supported in some elements (e.g. in `<classsynopsisinfo>`),
but not in `<type>` elements, which can be seen in the `CommonMark`
documentation[1].  We catch up on that.

[1] <https://www.php.net/manual/en/book.cmark.php>

---

@krakjoe, you may like it:
![commonmark-node-methods](https://user-images.githubusercontent.com/2306138/75965547-3e9aef00-5ec9-11ea-926c-223e385db16f.jpg)
