### PR TITLE
Improve parameter rendering

### DIFF
--- a/phpdotnet/phd/Package/Generic/Manpage.php
+++ b/phpdotnet/phd/Package/Generic/Manpage.php
@@ -583,10 +583,29 @@ class Package_Generic_Manpage extends Format_Abstract_Manpage {
     }
 
     public function format_parameter_method($open, $name, $attrs, $props) {
-        if ($open && isset($attrs[Reader::XMLNS_DOCBOOK]["role"]) && $attrs[Reader::XMLNS_DOCBOOK]["role"] == "reference") {
-            $this->cchunk['methodsynopsis']['params'][count($this->cchunk['methodsynopsis']['params'])-1]['reference'] = true;
+        if ($open) {
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+                $role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
+                switch ($role) {
+                    case 'reference':
+                        $this->cchunk['methodsynopsis']['params'][count($this->cchunk['methodsynopsis']['params'])-1]['role_symbol'] = '&';
+
+                        return '';
+                    case 'vararglist':
+                        $this->cchunk['methodsynopsis']['params'][count($this->cchunk['methodsynopsis']['params'])-1]['role_symbol'] = '...';
+
+                        return '';
+                    case 'reference_vararglist':
+                        $this->cchunk['methodsynopsis']['params'][count($this->cchunk['methodsynopsis']['params'])-1]['role_symbol'] = '&...';
+
+                        return '';
+                }
+            }
+
+            $this->cchunk['methodsynopsis']['params'][count($this->cchunk['methodsynopsis']['params'])-1]['role_symbol'] = '';
         }
-        return "";
+
+        return '';
     }
 
     public function format_parameter_method_text($value, $tag) {
@@ -622,7 +641,7 @@ class Package_Generic_Manpage extends Format_Abstract_Manpage {
         foreach ($this->cchunk['methodsynopsis']['params'] as $parameter) {
             array_push($params, ($parameter['optional'] ? "[" : "")
                         . $parameter['type'] . " "
-                        . ($parameter['reference'] ? " \\fI&\\fP" : " ")
+                        . ' \\fI' . $parameter['role_symbol'] , '\\fP'
                         . ($parameter['name'] ? "\\fI$" . $parameter['name'] . "\\fP" : "")
                         . ($parameter['initializer'] ? " = " . $parameter['initializer'] : "")
                         . ($parameter['optional'] ? "]" : "") );

--- a/phpdotnet/phd/Package/Generic/PDF.php
+++ b/phpdotnet/phd/Package/Generic/PDF.php
@@ -849,31 +849,66 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
 
     public function format_methodparam_parameter($open, $name, $attrs, $props) {
         if ($props["empty"]) return '';
+
         if ($open) {
-            if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                $this->pdfDoc->setFont(PdfWriter::FONT_VERBATIM, 10);
-                $this->pdfDoc->appendText(" &$");
-                return '';
-            }
             $this->pdfDoc->setFont(PdfWriter::FONT_VERBATIM, 10);
-            $this->pdfDoc->appendText(" $");
+
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+                $role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
+                switch ($role) {
+                    case 'reference':
+                        $this->pdfDoc->appendText('&$');
+
+                        return '';
+                    case 'vararglist':
+                        $this->pdfDoc->appendText('...$');
+
+                        return '';
+                    case 'reference_vararglist':
+                        $this->pdfDoc->appendText('&...$');
+
+                        return '';
+                }
+            }
+
+            $this->pdfDoc->appendText(' $');
+
             return '';
         }
+
         $this->pdfDoc->revertFont();
         return '';
     }
 
     public function format_parameter($open, $name, $attrs, $props) {
         if ($props["empty"]) return '';
+
         if ($open) {
-            if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                $this->pdfDoc->setFont(PdfWriter::FONT_VERBATIM_ITALIC, 10);
-                $this->pdfDoc->appendText(" &");
-                return '';
+            $this->pdfDoc->setFont(PdfWriter::FONT_VERBATIM, 10);
+
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+                $role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
+                switch ($role) {
+                    case 'reference':
+                        $this->pdfDoc->appendText('&$');
+
+                        return '';
+                    case 'vararglist':
+                        $this->pdfDoc->appendText('...$');
+
+                        return '';
+                    case 'reference_vararglist':
+                        $this->pdfDoc->appendText('&...$');
+
+                        return '';
+                }
             }
-            $this->pdfDoc->setFont(PdfWriter::FONT_VERBATIM_ITALIC, 10);
+
+            $this->pdfDoc->appendText(' $');
+
             return '';
         }
+
         $this->pdfDoc->revertFont();
         return '';
     }

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -996,13 +996,24 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($props["empty"]) {
             return '';
         }
+
         if ($open) {
-            if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                return ' <code class="parameter reference">&$';
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+                $role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
+                switch ($role) {
+                    case 'reference':
+                        return ' <code class="parameter reference">&$';
+                    case 'vararglist':
+                        return ' <code class="parameter">...$';
+                    case 'reference_vararglist':
+                        return ' <code class="parameter">&...$';
+                }
             }
+
             return ' <code class="parameter">$';
         }
-        return "</code>";
+
+        return '</code>';
     }
 
     public function format_initializer($open, $name, $attrs) {
@@ -1011,18 +1022,30 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return '</span>';
     }
+
     public function format_parameter($open, $name, $attrs, $props)
     {
         if ($props["empty"]) {
             return '';
         }
+
         if ($open) {
-            if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                return '<code class="parameter reference">&';
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+                $role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
+                switch ($role) {
+                    case 'reference':
+                        return '<code class="parameter reference">&';
+                    case 'vararglist':
+                        return ' <code class="parameter">...';
+                    case 'reference_vararglist':
+                        return '<code class="parameter">&...';
+                }
             }
+
             return '<code class="parameter">';
         }
-        return "</code>";
+
+        return '</code>';
     }
 
     public function format_void($open, $name, $attrs, $props) {

--- a/phpdotnet/phd/Package/IDE/API/Param.php
+++ b/phpdotnet/phd/Package/IDE/API/Param.php
@@ -12,6 +12,8 @@
  */
 namespace phpdotnet\phd;
 
+use function substr;
+
 /**
  * Class to parse the function parameters.
  *
@@ -81,8 +83,15 @@ class Package_IDE_API_Param
     public function __toString()
     {
         $str = $this->getType();
-        $str .= (substr($this->getName(), 0, 1) != '$') ? ' $' : ' ';
-        $str .= $this->getName();
+        $str .= ' ';
+        if (substr($this->getName(), 0, 3) === '...') {
+            $str .= str_replace('...', '...$', $this->getName());
+        } elseif (substr($this->getName(), 0, 1) === '$') {
+            $str .= $this->getName();
+        } else {
+            $str .= '$';
+            $str .= $this->getName();
+        }
 
         if ($this->isOptional()) {
             $str .= ' = ';


### PR DESCRIPTION
_This is a reaction to https://github.com/php/doc-en/pull/55_

Allows to properly render:
- arguments
- arguments by reference
- varible-length argument lists
- varible-length argument lists passed by reference

----------

It will also require changes (see below) in docs repository (I will send PR) but did not find a non-BC breaking way because:

- params in docs are currently named as `...`
- the param name build is performed as `<tag>$` + `param_name` resulting in `<tag>$param_name`
- however, that does not work for variadic args as we need `...$args` instead of `$...args`

-----------

Current:

```xml
<methodparam choice="opt">
    <type>bool|float|int|string</type>
    <parameter>...</parameter>
</methodparam>
```

`sprintf ( string $format [, mixed $... ] ) : string`

This PR allows:

```xml
<methodparam choice="opt">
    <type>bool|float|int|string</type>
    <parameter role="vararglist">args</parameter>
</methodparam>
```

`sprintf ( string $format [, mixed ...$args ] ) : string`