### PR TITLE
Support union types

### DIFF
--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -420,10 +420,15 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     }
 
     public function format_type_if_object_or_pseudo_text($type, $tagname) {
-        if (in_array(strtolower($type), array("bool", "int", "double", "boolean", "integer", "float", "string", "array", "object", "resource", "null"))) {
-            return false;
+        $res = [];
+        foreach (explode('|', $type) as $t) {
+            if (in_array(strtolower($t), array("bool", "int", "double", "boolean", "integer", "float", "string", "array", "object", "resource", "null"))) {
+                $res[] = $t;
+            } else {
+                $res[] = self::format_type_text($t, $tagname);
+            }
         }
-        return self::format_type_text($type, $tagname);
+        return implode('|', $res);
     }
 
     public function format_type_text($type, $tagname) {


### PR DESCRIPTION
For now we stick with the union type syntax introduced with PHP 8,
because proper union type markup[1] is only available as of DocBook
5.2, and we're still using version 4.5.  We do not support the nullable
type syntax (i.e. ? prefix) which has been introduced with PHP 7.1,
because this is just a shortcut for union types, and may not be
supported by future DocBook versions.

[1] <https://tdg.docbook.org/tdg/5.2/type.html>

---

This is an alternative to PR #22, which may not have been the best idea, although that PR would support some parts of the documentation which already use nullable types; these would have to be changed to union types.

Anyhow, union types would be rendered like this:

![union-types](https://user-images.githubusercontent.com/2306138/76700051-a7e1e580-66b3-11ea-96a9-7168e995f2a4.gif)
