### PR TITLE
Support variadic parameters

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -997,10 +997,19 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             return '';
         }
         if ($open) {
+            $class = 'parameter';
+            $et = $ellipsis = '';
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                return ' <code class="parameter reference">&$';
+                $role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
+                if (preg_match('/\breference\b/', $role)) {
+                    $class .= ' reference';
+                    $et = '&';
+                }
+                if (preg_match('/\bvariadic\b/', $role)) {
+                    $ellipsis = '...';
+                }
             }
-            return ' <code class="parameter">$';
+            return " <code class=\"{$class}\">{$et}{$ellipsis}$";
         }
         return "</code>";
     }
@@ -1017,10 +1026,19 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             return '';
         }
         if ($open) {
+            $class = 'parameter';
+            $et = $ellipsis = '';
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                return '<code class="parameter reference">&';
+                $role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
+                if (preg_match('/\breference\b/', $role)) {
+                    $class .= ' reference';
+                    $et = '&';
+                }
+                if (preg_match('/\bvariadic\b/', $role)) {
+                    $ellipsis = '...';
+                }
             }
-            return '<code class="parameter">';
+            return " <code class=\"{$class}\">{$et}{$ellipsis}";
         }
         return "</code>";
     }


### PR DESCRIPTION
So far, PhD does not support variadic parameters.  Instead the manual
follows the convention to use `...` as parameter name, which is then
rendered as `$...` in the docs.  However, as of PHP 5.6.0 variadic
parameters are supported using the syntax `...$args`; therefore, we are
going to support this notation for PhD.

While DocBook supports a `<varargs>` element, this cannot be used in
combination with named parameters.  Therefore, we use the `role`
attribute of the `<parameter>` element to declare variadic parameters.
Since the `role` attribute is already used to designate reference
parameters, we support the following values now: `"reference"`,
`"variadic"` and `"reference variadic"`; additional whitespace as well
as swapping the order of the words is supported.

---

After applying this patch to the docs:
````.patch
Index: sscanf.xml
===================================================================
--- sscanf.xml	(revision 350547)
+++ sscanf.xml	(working copy)
@@ -12,7 +12,7 @@
    <type>mixed</type><methodname>sscanf</methodname>
    <methodparam><type>string</type><parameter>str</parameter></methodparam>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">...</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter role="reference variadic">args</parameter></methodparam>
   </methodsynopsis>
   <para>
    The function <function>sscanf</function> is the input analog of
@@ -72,7 +72,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter role="variadic">args</parameter></term>
      <listitem>
       <para>
        Optionally pass in variables by reference that will contain the parsed values.
````
We get the following output for the `sscanf()` page:
![signature](https://user-images.githubusercontent.com/2306138/92997772-09c1c180-f516-11ea-8eb9-691550def8df.gif)
![parameters](https://user-images.githubusercontent.com/2306138/92997773-0a5a5800-f516-11ea-882e-b0678d02c26a.gif)

Old-style pseudo-variadics (i.e. `...`) are rendered like before, but of course the manual should be updated to use proper variadic parameters.
