### PR TITLE
Support variadic parameters – take 2

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -976,7 +976,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_methodsynopsis($open, $name, $attrs) {
         if ($open) {
-            $this->params = array("count" => 0, "opt" => 0, "content" => "", "repeatable" => '');
+            $this->params = array("count" => 0, "opt" => 0, "content" => "", "ellipsis" => '');
             $id = (isset($attrs[Reader::XMLNS_XML]["id"]) ? ' id="'.$attrs[Reader::XMLNS_XML]["id"].'"' : '');
             return '<div class="'.$name.' dc-description"'.$id.'>';
         }

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -976,7 +976,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_methodsynopsis($open, $name, $attrs) {
         if ($open) {
-            $this->params = array("count" => 0, "opt" => 0, "content" => "");
+            $this->params = array("count" => 0, "opt" => 0, "content" => "", "repeatable" => '');
             $id = (isset($attrs[Reader::XMLNS_XML]["id"]) ? ' id="'.$attrs[Reader::XMLNS_XML]["id"].'"' : '');
             return '<div class="'.$name.' dc-description"'.$id.'>';
         }
@@ -998,9 +998,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                return ' <code class="parameter reference">&$';
+                return ' <code class="parameter reference">&' . $this->params["ellipsis"] . '$';
             }
-            return ' <code class="parameter">$';
+            return ' <code class="parameter">' . $this->params["ellipsis"] . '$';
         }
         return "</code>";
     }
@@ -1051,6 +1051,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 }
                 $content .= ' <span class="methodparam">';
                 ++$this->params["count"];
+                if (isset($attrs[Reader::XMLNS_DOCBOOK]["rep"]) && $attrs[Reader::XMLNS_DOCBOOK]["rep"] == "repeat") {
+                    $this->params["ellipsis"] = '...';
+                } else {
+                    $this->params["ellipsis"] = '';
+                }
                 return $content;
         }
         return "</span>";


### PR DESCRIPTION
So far, PhD does not support variadic parameters.  Instead the manual
follows the convention to use `...` as parameter name, which is then
rendered as `$...` in the docs.  However, as of PHP 5.6.0 variadic
parameters are supported using the syntax `...$args`; therefore, we are
going to support this notation for PhD.

While DocBook supports a `<varargs>` element, this cannot be used in
combination with named parameters.  Therefore, we use the `rep`
attribute of the `<methodparam>` element to designate variadic
parameters.

---

What I don't like about this solution is the semantic mismatch. Consider, e.g. `array_merge(array ...$arrays)`; it is not actually `$arrays` which is repeatable, but rather `$array`. Maybe I'm too nit-picky here.

TODO:
- [ ] adapt non XHTML based formats
- [ ] fix parameter linking for web-php