### PR TITLE
Properly support union types

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -427,7 +427,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             "modifier"                      => "public",
         ),
         "methodsynopsis"           => array(
-            "returntype"           => false,
+            "returntypes"           => [],
         ),
         "co"                       => 0,
         "callouts"                 => 0,

--- a/phpdotnet/phd/Package/PHP/PDF.php
+++ b/phpdotnet/phd/Package/PHP/PDF.php
@@ -288,10 +288,6 @@ class Package_PHP_PDF extends Package_Generic_PDF {
             $href = "language.pseudo-types";
             $fragment = "language.types.$t";
             break;
-        case "array|object":
-            $href = "language.pseudo-types";
-            $fragment = "language.types.array-object";
-            break;
         default:
             /* Check if its a classname. */
             $t = strtolower(str_replace(array("_", "::", "->"), array("-", "-", "-"), $t));

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -154,8 +154,8 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         "refsynopsisdiv"               => null,
     );
 
-    /* Support for union types */
-    private $types = null;
+    /** @var int|null Number of already formatted types in the current union type */
+    private $num_types = null;
 
     protected $pihandlers = array(
         'dbhtml'        => 'PI_DBHTMLHandler',
@@ -313,15 +313,15 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         $retval = '';
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["class"])) {
-                $this->types = 0;
-            } elseif (isset($this->types)) {
-                if (!$is_return_type && $this->types > 0) $retval .= '|';
-                $this->types++;
+                $this->num_types = 0;
+            } elseif (isset($this->num_types)) {
+                if (!$is_return_type && $this->num_types > 0) $retval .= '|';
+                $this->num_types++;
             }
             if (!$is_return_type) $retval .= '<span class="type">';
         } else {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["class"])) {
-                $this->types = null;
+                $this->num_types = null;
             }
             if (!$is_return_type) $retval .= '</span>';
         }

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -70,10 +70,10 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         ),
         'type'                  => array(
             /* DEFAULT */          'format_type',
-            'methodsynopsis'    => 'format_methodsynopsis_type',
+            'methodsynopsis'    => 'format_suppressed_tags',
             'type'              => array(
                 /* DEFAULT */       'format_type',
-                'methodsynopsis' => 'format_methodsynopsis_type',
+                'methodsynopsis' => 'format_suppressed_tags',
             ),
         ),
         'varname'               => array(
@@ -309,29 +309,23 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         $retval = '<p class="verinfo">(' .(htmlspecialchars($verinfo, ENT_QUOTES, "UTF-8")). ')</p>';
         return $retval;
     }
-    private function do_format_type($open, $attrs, $is_return_type) {
+    public function format_type($open, $tag, $attrs, $props) {
         $retval = '';
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["class"])) {
                 $this->num_types = 0;
             } elseif (isset($this->num_types)) {
-                if (!$is_return_type && $this->num_types > 0) $retval .= '|';
+                if ($this->num_types > 0) $retval .= '|';
                 $this->num_types++;
             }
-            if (!$is_return_type) $retval .= '<span class="type">';
+            $retval .= '<span class="type">';
         } else {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["class"])) {
                 $this->num_types = null;
             }
-            if (!$is_return_type) $retval .= '</span>';
+            $retval .= '</span>';
         }
         return $retval;
-    }
-    public function format_type($open, $tag, $attrs, $props) {
-        return $this->do_format_type($open, $attrs, false);
-    }
-    public function format_methodsynopsis_type($open, $tag, $attrs, $props) {
-        return $this->do_format_type($open, $attrs, true);
     }
     public function format_refpurpose($open, $tag, $attrs, $props) {
         if ($open) {

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -483,10 +483,6 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             $href = "language.pseudo-types";
             $fragment = "language.types.$t";
             break;
-        case "array|object":
-            $href = "language.pseudo-types";
-            $fragment = "language.types.array-object";
-            break;
         default:
             /* Check if its a classname. */
             $href = Format::getFilename("class.$t");

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -154,7 +154,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         "refsynopsisdiv"               => null,
     );
 
-    /* Support for compound types */
+    /* Support for union types */
     private $types = null;
 
     protected $pihandlers = array(

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -106,13 +106,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         ),
         'refname'               => 'format_refname_text',
         'type'                  => array(
-            /* DEFAULT */          'format_type_text',
+            /* DEFAULT */          'format_type_if_object_or_pseudo_text',
             'classsynopsisinfo' => false,
             'fieldsynopsis'     => 'format_type_if_object_or_pseudo_text',
             'methodparam'       => 'format_type_if_object_or_pseudo_text',
             'methodsynopsis'    => 'format_type_methodsynopsis_text',
             'type'              => array(
-                /* DEFAULT */       'format_type_text',
+                /* DEFAULT */       'format_type_if_object_or_pseudo_text',
                 'methodsynopsis' => 'format_type_methodsynopsis_text',
             ),
         ),

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -318,7 +318,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
                 if (!$is_return_type && $this->types > 0) $retval .= '|';
                 $this->types++;
             }
-            if (!$is_return_type) $retval .= '<span type="class">';
+            if (!$is_return_type) $retval .= '<span class="type">';
         } else {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["class"])) {
                 $this->types = null;

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -69,7 +69,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             ),
         ),
         'type'                  => array(
-            /* DEFAULT */          'span',
+            /* DEFAULT */          'format_type',
             'methodsynopsis'    => 'format_suppressed_tags',
         ),
         'varname'               => array(
@@ -128,6 +128,8 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     /* Current Chunk settings */
     protected $cchunk          = array();
     /* Default Chunk settings */
+    private $types = null;
+    /* Support for compound types */
 
     protected $dchunk          = array(
         "phpdoc:classref"              => null,
@@ -295,6 +297,24 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         }
 
         $retval = '<p class="verinfo">(' .(htmlspecialchars($verinfo, ENT_QUOTES, "UTF-8")). ')</p>';
+        return $retval;
+    }
+    public function format_type($open, $tag, $attrs, $props) {
+        $retval = '';
+        if ($open) {
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]["class"])) {
+                $this->types = 0;
+            } elseif (isset($this->types)) {
+                if ($this->types > 0) $retval .= '|';
+                $this->types++;
+            }
+            $retval .= '<span type="class">';
+        } else {
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]["class"])) {
+                $this->types = null;
+            }
+            $retval .= '</span>';
+        }
         return $retval;
     }
     public function format_refpurpose($open, $tag, $attrs, $props) {

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -125,12 +125,11 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     private $versions = array();
     private $acronyms = array();
     protected $deprecated = array();
+
     /* Current Chunk settings */
     protected $cchunk          = array();
-    /* Default Chunk settings */
-    private $types = null;
-    /* Support for compound types */
 
+    /* Default Chunk settings */
     protected $dchunk          = array(
         "phpdoc:classref"              => null,
         "args"                         => null,
@@ -146,6 +145,9 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         "alternatives"                 => array(),
         "refsynopsisdiv"               => null,
     );
+
+    /* Support for compound types */
+    private $types = null;
 
     protected $pihandlers = array(
         'dbhtml'        => 'PI_DBHTMLHandler',


### PR DESCRIPTION
This is the cleaner alternative to PR #25, which supports nested
`<type>` elements, and renders them as union types in PHP 8 syntax.

---

This is just a quick and dirty POC for now, in the hope to get that going. Assuming our docbook would support nested types, the following patch to doc-en
````.diff
Index: strpos.xml
===================================================================
--- strpos.xml	(revision 350727)
+++ strpos.xml	(working copy)
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>int</type><methodname>strpos</methodname>
    <methodparam><type>string</type><parameter>haystack</parameter></methodparam>
-   <methodparam><type>mixed</type><parameter>needle</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>needle</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
````
would be rendered like
![Screenshot 2020-10-01 133429](https://user-images.githubusercontent.com/2306138/94804304-e2f6fc80-03ea-11eb-96a1-84f3b8e76bb8.gif)
Note that the predefined types are now rendered as links, which might not be the worst idea generally.