### PR TITLE
Fix broken rendering of varnames in fieldsynopsis

### DIFF
--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -74,6 +74,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         ),
         'varname'               => array(
             /* DEFAULT */          'format_suppressed_tags',
+            'fieldsynopsis'     => 'format_fieldsynopsis_varname',
         ),
     );
     private $mytextmap = array(


### PR DESCRIPTION
A recent commit suppressed the tag formatting of `<varname>` elements
for `Package_PHP_XHTML`; this must not be done for `<varname>`s inside
of `<fieldsysnopsis>`, though.

---

The https://www.php.net/manual/en/mysqli.error.php for an example of the currently broken rendering.