### PR TITLE
Fix #79747: __autoload not labeled as "Deprecated"

### DIFF
--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -125,7 +125,7 @@ class Package_PHP_Web extends Package_PHP_XHTML {
                         $sibling_short_desc,
                     );
 
-                    if (isset($this->deprecated[$sibling_short_desc])) {
+                    if ($this->deprecationInfo($sibling_short_desc) !== false) {
                         $toc_deprecated[] = $entry;
                     } else {
                         $toc[] = $entry;

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -535,6 +535,18 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         return false;
     }
 
+    public function deprecationInfo($funcname) {
+        $funcname = str_replace(
+                array("::", "-&gt;", "->", "__", "_", '$', '()'),
+                array("_",  "_",     "_",  "_",  "_", "",  ''),
+                strtolower($funcname));
+        if(isset($this->deprecated[$funcname])) {
+           return $this->deprecated[$funcname];
+        }
+        return false;
+    }
+
+
     public function acronymInfo($acronym) {
         return isset($this->acronyms[$acronym]) ? $this->acronyms[$acronym] : false;
     }


### PR DESCRIPTION
Although that info is available in version.xml, PhD does not recognize
it, because several special characters are replaced when putting the
function name into the array, but we missed to replace them back when
comparing with the actual function name.