### PR TITLE
Don't render optional parameters in brackets

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -976,14 +976,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_methodsynopsis($open, $name, $attrs) {
         if ($open) {
-            $this->params = array("count" => 0, "opt" => 0, "content" => "", "ellipsis" => '');
+            $this->params = array("count" => 0, "opt" => false, "init" => false, "content" => "", "ellipsis" => '');
             $id = (isset($attrs[Reader::XMLNS_XML]["id"]) ? ' id="'.$attrs[Reader::XMLNS_XML]["id"].'"' : '');
             return '<div class="'.$name.' dc-description"'.$id.'>';
         }
         $content = "";
-        if ($this->params["opt"]) {
-            $content = str_repeat("]", $this->params["opt"]);
-        }
         $content .= " )";
 
         $content .= "</div>\n";
@@ -1007,6 +1004,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_initializer($open, $name, $attrs) {
         if ($open) {
+            $this->params["init"] = true;
             return '<span class="'.$name.'"> = ';
         }
         return '</span>';
@@ -1040,11 +1038,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                     $content .= " (";
                 }
                 if (isset($attrs[Reader::XMLNS_DOCBOOK]["choice"]) && $attrs[Reader::XMLNS_DOCBOOK]["choice"] == "opt") {
-                    $this->params["opt"]++;
-                    $content .= "[";
+                    $this->params["opt"] = true;
                 } else if($this->params["opt"]) {
-                    $content .= str_repeat("]", $this->params["opt"]);
-                    $this->params["opt"] = 0;
+                    $this->params["opt"] = false;
                 }
                 if ($this->params["count"]) {
                     $content .= ",";
@@ -1058,6 +1054,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 }
                 return $content;
         }
+        if ($this->params["opt"] && !$this->params["init"]) {
+            return " = ?</span>";
+        }
+        $this->params["init"] = false;
         return "</span>";
     }
 

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -427,11 +427,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             return parent::format_methodsynopsis($open, $name, $attrs);
         }
 
-        $content = "";
-        if ($this->params["opt"]) {
-            $content = str_repeat("]", $this->params["opt"]);
-        }
-        $content .= " )";
+        $content = " )";
 
         if ($this->cchunk["methodsynopsis"]["returntypes"]) {
             $types = [];


### PR DESCRIPTION
In PHP, parameters with a default value are optional, so there is no
need to enclose these in brackets.  For methodparams which do not have
an initializer, we use a question mark instead.

---

Before:
![before](https://user-images.githubusercontent.com/2306138/103489965-da162c80-4e18-11eb-85c8-1847111c116a.gif)

After:
![after](https://user-images.githubusercontent.com/2306138/103489974-e69a8500-4e18-11eb-8032-02ecdff3dfd3.gif)

This appears to be the simplest implementation; if we wanted, we could stick with the brackets for the generic renderer, and only drop these for the PHP renderer. And of course, the choice of the question mark for missing initializers is arbitrary and could be change; however, it would be preferable to have initializers for all functions anyway.

/cc @kocsismate

PS: if this PR gets accepted, we also have to adapt https://www.php.net/manual/en/about.prototypes.php accordingly.