### PR TITLE
Reformat methodsynopsis whitespaces

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -974,14 +974,28 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $this->TEXT($value);
     }
 
-    public function format_methodsynopsis($open, $name, $attrs) {
+    public function format_methodsynopsis($open, $name, $attrs, $props) {
         if ($open) {
-            $this->params = array("count" => 0, "opt" => false, "init" => false, "content" => "", "ellipsis" => '');
+
+            $this->params = array(
+                "count" => 0,
+                "opt" => false,
+                "init" => false,
+                "content" => "",
+                "ellipsis" => '',
+                "paramCount" => substr_count($props["innerXml"], "<methodparam")
+            );
+
             $id = (isset($attrs[Reader::XMLNS_XML]["id"]) ? ' id="'.$attrs[Reader::XMLNS_XML]["id"].'"' : '');
             return '<div class="'.$name.' dc-description"'.$id.'>';
         }
+
         $content = "";
-        $content .= " )";
+        if ($this->params["paramCount"] > 3) {
+            $content .= "<br>";
+        }
+
+        $content .= ")";
 
         $content .= "</div>\n";
 
@@ -1025,7 +1039,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_void($open, $name, $attrs, $props) {
         if ($props['sibling'] == 'methodname') {
-            return ' (';
+            return '(';
         } else {
             return '<span class="type"><span class="type void">void</span></span>';
         }
@@ -1034,8 +1048,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     public function format_methodparam($open, $name, $attrs) {
         if ($open) {
             $content = '';
-                if ($this->params["count"] == 0) {
-                    $content .= " (";
+                if ($this->params["count"] === 0) {
+                    $content .= "(";
+                    if ($this->params["paramCount"] > 3) {
+                        $content .= "<br>&nbsp;&nbsp;&nbsp;&nbsp;";
+                    }
                 }
                 if (isset($attrs[Reader::XMLNS_DOCBOOK]["choice"]) && $attrs[Reader::XMLNS_DOCBOOK]["choice"] == "opt") {
                     $this->params["opt"] = true;
@@ -1044,8 +1061,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 }
                 if ($this->params["count"]) {
                     $content .= ",";
+                    if ($this->params["paramCount"] > 3) {
+                        $content .= "<br>&nbsp;&nbsp;&nbsp;&nbsp;";
+                    } else {
+                        $content .= " ";
+                    }
                 }
-                $content .= ' <span class="methodparam">';
+                $content .= '<span class="methodparam">';
                 ++$this->params["count"];
                 if (isset($attrs[Reader::XMLNS_DOCBOOK]["rep"]) && $attrs[Reader::XMLNS_DOCBOOK]["rep"] == "repeat") {
                     $this->params["ellipsis"] = '...';

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -422,12 +422,17 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
 
     }
 
-    public function format_methodsynopsis($open, $name, $attrs) {
+    public function format_methodsynopsis($open, $name, $attrs, $props) {
         if ($open) {
-            return parent::format_methodsynopsis($open, $name, $attrs);
+            return parent::format_methodsynopsis($open, $name, $attrs, $props);
         }
 
-        $content = " )";
+        $content = "";
+        if ($this->params["paramCount"] > 3) {
+            $content .= "<br>";
+        }
+
+        $content .= ")";
 
         if ($this->cchunk["methodsynopsis"]["returntypes"]) {
             $types = [];
@@ -442,7 +447,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             if (count($types) > 1) {
                 $type = '<span class="type">' . $type . '</span>';
             }
-            $content .= ' : ' . $type;
+            $content .= ': ' . $type;
         }
 
         $content .= "</div>\n";


### PR DESCRIPTION
This PR removes some unnecessary whitespace characters from the methodsynopses.

So
```php
openssl_csr_sign ( mixed $csr , mixed $cacert , mixed $priv_key , int $days , array $configargs = ? , int $serial = 0 ) : resource
```

becomes

```php
openssl_csr_sign (mixed $csr , mixed $cacert , mixed $priv_key , int $days , array $configargs = ? , int $serial = 0 ): resource
```

Unfortunately, a few unnecessary whitespace characters still remain, and I couldn't yet find out how to remove them as well :/ For me, it looks like some whitespace characters from the XML get rendered directly to the HTML (e.g. around the `,`). Is it possible?