### PR TITLE
Remove whitespace before semicolons

### DIFF
--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -160,7 +160,12 @@ class Render extends ObjectStorage
 
                 case \XMLReader::WHITESPACE: /* {{{ */
                 case \XMLReader::SIGNIFICANT_WHITESPACE:
-                            /* WS is always WS */
+                /* The following if is to skip whitespace before closing semicolon after property name */
+                if (in_array($this->STACK[$r->depth - 1], ["fieldsynopsis"], true) &&
+                    in_array($this->STACK[$r->depth], ["varname"], true)
+                ) {
+                    break;
+                }
                 $retval  = $r->value;
                 foreach($this as $format) {
                     $format->appendData($retval);


### PR DESCRIPTION
The `in_array` is used to make it more compatible with https://github.com/php/phd/pull/38/files

This PR removes annoying and inconsistent whitespace before `;` in `<fieldsynopsis>` (properties). E.g. https://www.php.net/manual/en/class.mysqli-result.php