### PR TITLE
Supress whitespace in type elements

### DIFF
--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -178,6 +178,12 @@ class Render extends ObjectStorage
                 if ($this->STACK[$r->depth - 1] === "fieldsynopsis" && $this->STACK[$r->depth] === "varname") {
                     break;
                 }
+
+                /* The following if is to skip whitespace inside type elements */
+                if ($this->STACK[$r->depth - 1] === "type") {
+                    break;
+                }
+
                 $retval  = $r->value;
                 foreach($this as $format) {
                     $format->appendData($retval);


### PR DESCRIPTION
Union types can get pretty long, so it may make sense to split them
over multiple lines[1]; however, that adds undesired whitespace within
or at the end of the union type.  Thus, we supress this whitespace
generally.

[1] <https://github.com/php/doc-en/pull/783>