### PR TITLE
Add support for displaying class/interface on class synopsis pages

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -163,7 +163,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             /* DEFAULT */          'span',
             'classsynopsisinfo'    => 'format_classsynopsisinfo_oointerface',
         ),
-        'interfacename'         => 'span',
+        'interfacename'         => array(
+            /* DEFAULT */          'span',
+            'oointerface'       => array(
+                /* DEFAULT */          'span',
+                'classsynopsisinfo' => 'format_classsynopsisinfo_oointerface_interfacename',
+            ),
+        ),
         'exceptionname'         => 'span',
         'option'                => 'format_option',
         'orderedlist'           => 'format_orderedlist',
@@ -886,32 +892,57 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_classsynopsisinfo_oointerface($open, $name, $attrs) {
         if ($open) {
+            if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
+                return '<span class="' . $name . '">';
+            }
+
             if ($this->cchunk["classsynopsisinfo"]["implements"] === false) {
                 $this->cchunk["classsynopsisinfo"]["implements"] = true;
                 return '<span class="'.$name.'"><span class="modifier">implements</span> ';
             }
+
             return '<span class="'.$name.'">, ';
         }
 
         return "</span>";
     }
+
     public function format_classsynopsisinfo_ooclass_classname($open, $name, $attrs)
     {
         if ($open) {
             if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
                 $this->cchunk["classsynopsisinfo"]["ooclass"] = true;
-                return ' class <strong class="'.$name.'">';
+                return '<span class="modifier">class</span> <strong class="'.$name.'">';
             }
+
             return '<strong class="'.$name.'"> ';
         }
+
         return "</strong>";
     }
-    public function format_classsynopsisinfo($open, $name, $attrs) {
+
+    public function format_classsynopsisinfo_oointerface_interfacename($open, $name, $attrs)
+    {
+        if ($open) {
+            if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
+                $this->cchunk["classsynopsisinfo"]["ooclass"] = true;
+                return '<span class="modifier">interface</span> <strong class="classname">';
+            }
+
+            return ' <strong class="'.$name.'">';
+        }
+
+        return "</strong>";
+    }
+
+    public function format_classsynopsisinfo($open, $name, $attrs)
+    {
         $this->cchunk["classsynopsisinfo"] = $this->dchunk["classsynopsisinfo"];
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"]) && $attrs[Reader::XMLNS_DOCBOOK]["role"] == "comment") {
                 return '<div class="'.$name.' classsynopsisinfo_comment">/* ';
             }
+
             return '<div class="'.$name.'">';
         }
 

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -7,7 +7,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         'appendix'              => 'format_container_chunk',
         'article'               => 'format_container_chunk',
         'book'                  => 'format_root_chunk',
-        'classname'             => 'format_suppressed_tags',
+        'classname'             => array(
+            /* DEFAULT */          'span',
+            'ooclass'           => array(
+                /* DEFAULT */      'strong',
+                'classsynopsisinfo' => 'format_classsynopsisinfo_ooclass_classname',
+            ),
+        ),
         'chapter'               => 'format_container_chunk',
         'colophon'              => 'format_chunk',
         'function'              => 'format_function',


### PR DESCRIPTION
A few examples:

<img width="708" alt="class" src="https://user-images.githubusercontent.com/6057627/126907669-f894219f-a235-4b98-82b2-1e2b28bbc18b.png">

<img width="715" alt="class-final" src="https://user-images.githubusercontent.com/6057627/126907674-e7b730c5-c256-4e10-8b1a-b751b448b018.png">

<img width="691" alt="interface" src="https://user-images.githubusercontent.com/6057627/126907676-e8f8a089-4197-46f8-9b6b-6854eb44031b.png">

<img width="690" alt="class-extends" src="https://user-images.githubusercontent.com/6057627/126907679-0941095e-130a-40ee-8f9a-356cb60539a9.png">

<img width="690" alt="class-implements-one" src="https://user-images.githubusercontent.com/6057627/126907681-72da7dfc-41b6-4e3b-99ac-e5fc600c63f4.png">

<img width="757" alt="class-implements-many" src="https://user-images.githubusercontent.com/6057627/126907691-9d98f84f-688b-4c52-af09-6231181e47fa.png">

<img width="681" alt="class-extends-implements" src="https://user-images.githubusercontent.com/6057627/126907694-a1545fb1-ddfc-48e4-8b6a-ef0bf889105d.png">
