### PR TITLE
Improve the display of union and intersection types

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -428,6 +428,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         ),
         "methodsynopsis"           => array(
             "returntypes"           => [],
+            "type_separator"        => null,
         ),
         "co"                       => 0,
         "callouts"                 => 0,

--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -70,8 +70,11 @@ class Render extends ObjectStorage
                     $r->moveToElement();
                 }
 
-                $innerXml = null;
-                if (in_array($r->name, ["methodsynopsis", "constructorsynopsis", "destructorsynopsis"]) && $open) {
+                $innerXml = "";
+                if (
+                    ($open && $r->name === "type") ||
+                    ($open && in_array($r->name, ["methodsynopsis", "constructorsynopsis", "destructorsynopsis"], true))
+                ) {
                     $innerXml = $r->readInnerXml();
                 }
 


### PR DESCRIPTION
Simple nullable types are now displayed via using "?", while support for intersection types is reintroduced.

Examples for intersection types on the parameter and return type position (even though `X&null` is not valid):
<img width="800" alt="Screenshot 2021-07-25 at 21 39 36" src="https://user-images.githubusercontent.com/6057627/126911616-5564aaa8-d8ac-47d3-ab3a-0a16590ec7ba.png">

Examples for displaying "simple union types" via using "?":
<img width="605" alt="Screenshot 2021-07-25 at 21 46 37" src="https://user-images.githubusercontent.com/6057627/126911635-ba25da21-a949-43ef-ae31-22577ba787cc.png">
