### PR TITLE
Do not render the strong tag unnecessarily

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -913,13 +913,17 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($open) {
             if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
                 $this->cchunk["classsynopsisinfo"]["ooclass"] = true;
-                return '<span class="modifier">class</span> <strong class="'.$name.'">';
+                return '<span class="modifier">class</span> ';
             }
 
-            return '<strong class="'.$name.'"> ';
+            return ' ';
         }
 
-        return "</strong>";
+        if ($this->cchunk["classsynopsisinfo"]["ooclass"] === true) {
+            $this->cchunk["classsynopsisinfo"]["ooclass"] = null;
+        }
+
+        return "";
     }
 
     public function format_classsynopsisinfo_oointerface_interfacename($open, $name, $attrs)
@@ -927,13 +931,17 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($open) {
             if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
                 $this->cchunk["classsynopsisinfo"]["ooclass"] = true;
-                return '<span class="modifier">interface</span> <strong class="classname">';
+                return '<span class="modifier">interface</span> ';
             }
 
-            return ' <strong class="'.$name.'">';
+            return ' ';
         }
 
-        return "</strong>";
+        if ($this->cchunk["classsynopsisinfo"]["ooclass"] === true) {
+            $this->cchunk["classsynopsisinfo"]["ooclass"] = null;
+        }
+
+        return "";
     }
 
     public function format_classsynopsisinfo($open, $name, $attrs)

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -10,7 +10,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         'classname'             => array(
             /* DEFAULT */          'span',
             'ooclass'           => array(
-                /* DEFAULT */      'strong',
+                /* DEFAULT */      'format_suppressed_tags',
                 'classsynopsisinfo' => 'format_classsynopsisinfo_ooclass_classname',
             ),
         ),


### PR DESCRIPTION
As noticed in https://github.com/php/phd/pull/52#discussion_r679999018

Requires a followup PR to https://github.com/php/web-php/blob/60a5f74b485075f8fbf2ceef988d343e0157666c/styles/theme-medium.css#L119 in order to display interface names on class synopses the same way as class names.