### PR TITLE
Add source details to PHP-Web pages

### DIFF
--- a/render.php
+++ b/render.php
@@ -45,6 +45,7 @@ if (!$conf) {
                         . "langs" . DIRECTORY_SEPARATOR,
         "phpweb_version_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'version.xml',
         "phpweb_acronym_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'entities' . DIRECTORY_SEPARATOR . 'acronyms.xml',
+        "phpweb_sources_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'sources.xml',
     ));
 }
 


### PR DESCRIPTION
See also php/doc-base#38 and php/web-php#434

Make the documentation source file information available in generated PHP-Web pages. 