### PR TITLE
Fix example id fetching

### DIFF
--- a/phpdotnet/phd/Format.php
+++ b/phpdotnet/phd/Format.php
@@ -147,7 +147,7 @@ abstract class Format extends ObjectStorage
         $this->sqlite->query('SELECT refname(docbook_id, sdesc) FROM ids WHERE element=\'refentry\'');
         $this->sqlite->query('SELECT varname(docbook_id, sdesc) FROM ids WHERE element=\'phpdoc:varentry\'');
         $this->sqlite->query('SELECT classname(docbook_id, sdesc) FROM ids WHERE element=\'phpdoc:exceptionref\' OR element=\'phpdoc:classref\'');
-        $this->sqlite->query('SELECT example(docbook_id) FROM ids WHERE element=\'example\' OR element=\'informalexample\'');
+        $this->sqlite->query('SELECT example(docbook_id) FROM ids WHERE element=\'example\'');
     }
 
     public function SQLiteIndex($context, $index, $id, $filename, $parent, $sdesc, $ldesc, $element, $previous, $next, $chunk) {


### PR DESCRIPTION
The `example-*` ids, for `example` elements that don't declare their own `xml:id`, are allocated during indexing.  The `N` is just a number that is incremented for each `example` seen (see `Index::format_example()`).

For rendering, the list of ids is fetched from the index to be used in the resulting HTML.  The list needs to be the same `example` elements in the same order for the offset-based lookups (in `Package_Generic_XHTML::format_example()`) to get the correct id.  

The code, before this proposed change, also included the ids for any `informalexample` elements when fetching from the index.  This results in too many items being in the list, so the offset-based lookups when rendering were fetching the wrong ids.