### PR TITLE
make objectstorage::attach() compatible with splobjectstorage::attach()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-          version: ['5.6', '7.2', '7.4', '8.1']
+          version: ['7.1', '7.2', '7.4', '8.1']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PhD

--- a/README
+++ b/README
@@ -25,7 +25,7 @@ Installing the PhD renderer:
             for i in package_*.xml; do pear install $i; done
 
 Requirements:
-    - PHP 5.3
+    - PHP 7.1
     - DOM, libXML2, XMLReader and SQLite3.
 
 After installing PhD you can use the `phd` command

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1.0",
         "ext-dom": "*",
         "ext-sqlite3": "*",
         "ext-xmlreader": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -13,7 +13,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0",
+        "php": ">=7.1.0",
         "ext-dom": "*",
         "ext-sqlite3": "*",
         "ext-xmlreader": "*"

--- a/phpdotnet/phd/Format.php
+++ b/phpdotnet/phd/Format.php
@@ -335,12 +335,12 @@ abstract class Format extends ObjectStorage
     final public function registerTextMap(array $map) {
         $this->textmap = $map;
     }
-    final public function attach($obj, $inf = array()) {
+    final public function attach($obj, $inf = array()): void {
         if (!($obj instanceof $this) && get_class($obj) != get_class($this)) {
             throw new \InvalidArgumentException(get_class($this) . " themes *MUST* _inherit_ " .get_class($this). ", got " . get_class($obj));
         }
         $obj->notify(Render::STANDALONE, false);
-        return parent::attach($obj, $inf);
+        parent::attach($obj, $inf);
     }
     final public function getElementMap() {
         return $this->elementmap;

--- a/phpdotnet/phd/ObjectStorage.php
+++ b/phpdotnet/phd/ObjectStorage.php
@@ -3,9 +3,7 @@ namespace phpdotnet\phd;
 
 class ObjectStorage extends \SplObjectStorage
 {
-	// @todo This is a bug, as attach() has a return type of void.
-	#[\ReturnTypeWillChange]
-	public function attach($obj, $inf = array()) {
+	public function attach($obj, $inf = array()): void {
 		if (!($obj instanceof Format)) {
 			throw new \InvalidArgumentException(
                 'Only classess inheriting ' . __NAMESPACE__ . '\\Format supported'
@@ -18,7 +16,6 @@ class ObjectStorage extends \SplObjectStorage
 			);
 		}
 		parent::attach($obj, $inf);
-		return $obj;
 	}
 }
 

--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -27,7 +27,7 @@ class Render extends ObjectStorage
         return $tag;
     } /* }}} */
 
-    public function attach($obj, $inf = array()) { /* {{{ */
+    public function attach($obj, $inf = array()): void { /* {{{ */
         if (!($obj instanceof Format)) {
             throw new \InvalidArgumentException(
                 'All formats *MUST* inherit ' . __NAMESPACE__ . '\\Format'
@@ -35,7 +35,7 @@ class Render extends ObjectStorage
         }
         $obj->notify(Render::STANDALONE, true);
 
-        return parent::attach($obj, $inf);
+        parent::attach($obj, $inf);
     } /* }}} */
 
     public function execute(Reader $r) { /* {{{ */

--- a/render.php
+++ b/render.php
@@ -85,7 +85,8 @@ if (Config::process_xincludes()) {
 if (Index::requireIndexing()) {
     v("Indexing...", VERBOSE_INDEXING);
     // Create indexer
-    $format = $render->attach(new Index);
+    $format = new Index;
+    $render->attach($format);
 
     $reader->open(Config::xml_file(), NULL, $readerOpts);
     $render->execute($reader);

--- a/tests/TestRender.php
+++ b/tests/TestRender.php
@@ -20,7 +20,8 @@ class TestRender {
         $reader = new Reader();
         $render = new Render();
         if (Index::requireIndexing()) {
-           $format = $render->attach(new Index);
+           $format = new Index;
+           $render->attach($format);
            $reader->open(Config::xml_file());
            $render->execute($reader);
            $render->detach($format);


### PR DESCRIPTION
PhD's `ObjectStorage::attach()` method does not respect the declared return type from its parent class (`SplObjectStorage`): the latter declares the return type as `void`.

This will issue an `E_DEPRECATED` as of PHP 8.1.0. It is currently mitigated via the `#[\ReturnTypeWillChange]` attribute (added in 6c1af76a).

This PR removes that attribute and instead aligns the return type declaration (to return `void`), with associated fixes to not return anything and not try to use a return value.

Since declaring a `void` return type is only allowed as of PHP 7.1.0, this PR raises the minimum required PHP version for phd to that version. Since PHP 7.1 is super ancient and even PHP 7.3 will become EOL in a few weeks (at the time of writing) I'm making the executive decision that requiring 7.1 is fine (though feedback on this point in particular is welcomed). 🙃 