### PR TITLE
Remove curly brace array offset

### DIFF
--- a/phpdotnet/phd/Format/Abstract/PDF.php
+++ b/phpdotnet/phd/Format/Abstract/PDF.php
@@ -241,7 +241,7 @@ class PdfWriter {
                     $this->PAGE_HEIGHT - (self::VMARGIN + $this->vOffset), $textToAppend);
             }
             if ($textToAppend)
-                $this->current["char"] = $textToAppend{strlen($textToAppend)-1};
+                $this->current["char"] = $textToAppend[strlen($textToAppend)-1];
 
             // Offsets for next line
             if (!$isLastLine) {
@@ -302,7 +302,7 @@ class PdfWriter {
         $this->currentPage->textOut(self::HMARGIN + $this->hOffset + $this->permanentLeftSpacing,
             $this->PAGE_HEIGHT - (self::VMARGIN + $this->vOffset), $textToAppend);
         if ($textToAppend)
-            $this->current["char"] = $textToAppend{strlen($textToAppend)-1};
+            $this->current["char"] = $textToAppend[strlen($textToAppend)-1];
 
         $this->hOffset += $this->currentPage->getTextWidth($textToAppend);
 


### PR DESCRIPTION
Curly braces for array access were deprecated in PHP 7.4.  It looks like the extension this class uses (https://pecl.php.net/package/haru/1.0.4) isn't maintained and is no longer compatible with PHP - might be safe to remove it?