### PR TITLE
replaced <acronym> with <abbr> for HTML5.

### DIFF
--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -621,7 +621,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     public function format_acronym_text($value, $tag) {
         $resolved = $this->acronymInfo($value);
         if ($resolved) {
-            return '<addr title="' .$resolved. '">' .$value. '</addr>';
+            return '<abbr title="' .$resolved. '">' .$value. '</abbr>';
         }
         return '<abbr>'.$value.'</abbr>';
     }

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -621,9 +621,9 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     public function format_acronym_text($value, $tag) {
         $resolved = $this->acronymInfo($value);
         if ($resolved) {
-            return '<acronym title="' .$resolved. '">' .$value. '</acronym>';
+            return '<addr title="' .$resolved. '">' .$value. '</addr>';
         }
-        return '<acronym>'.$value.'</acronym>';
+        return '<abbr>'.$value.'</abbr>';
     }
 
     public function format_classsynopsis_fieldsynopsis_varname_text($value, $tag) {


### PR DESCRIPTION
In HTML5, `<acronym>` tag is classified as a non-conforming-features.

https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features