### PR TITLE
Fix: Stop invoking useless function

### DIFF
--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -204,7 +204,6 @@ $setup["toc_deprecated"] = $TOC_DEPRECATED;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
 
-manual_header();
 ?>
 ';
     }


### PR DESCRIPTION
This pull request

- [x] stops invoking a useless function `manual_header()`

💁‍♂️ For reference, see https://github.com/php/web-php/pull/584.