### PR TITLE
Fix missing value issue

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -476,7 +476,7 @@ SQL;
                         $this->db->escapeString($id),
                         $this->db->escapeString($entry[1]),
                         $this->db->escapeString($entry[2]),
-                        $this->db->escapeString($entry[3])
+                        $this->db->escapeString($entry[3] ?? '')
                     );
                 }
             }


### PR DESCRIPTION
I am not clear on how or why this happens, but sometimes for me index 3 is missing, which results in a missing index warning followed by a null-parameter deprecation message.  This fix addresses both.