### PR TITLE
Add total number of functions and methods to the index

### DIFF
--- a/phpdotnet/phd/PI/PHPDOCHandler.php
+++ b/phpdotnet/phd/PI/PHPDOCHandler.php
@@ -60,9 +60,9 @@ class PI_PHPDOCHandler extends PIHandler {
                             $longdesc = $info[$filename][1] ? " - {$info[$filename][0]}" : "";
                             $ret .= '<li><a href="'.$filename. '" class="index">' .$data. '</a>' . $longdesc . '</li>'."\n";
                         }
-                        $ret .= "</ul></li></ul>\n\n";
+                        $ret .= "</ul></li></ul>\n";
+                        $ret .= "<p>Total number of functions and methods: " . count($refs) . "</p>\n\n";
                         return $ret;
-                        break;
 
                     case "examples":
                         $ret = "<ul class='gen-index index-for-{$matches["value"]}'>";


### PR DESCRIPTION
Apparently, users are interested in this number; there are constantly
new user notes which mention this number (a lot of these have been
deleted in the past).  This patch would display the total number of
functions and methods, so users won't need to calculate for themselves.

As it is now, i18n is completely missing.  We would need to define an
XML entity in language-snippets.ent for this.