### PR TITLE
Fix PDF generation

### DIFF
--- a/phpdotnet/phd/Format/Abstract/PDF.php
+++ b/phpdotnet/phd/Format/Abstract/PDF.php
@@ -241,7 +241,7 @@ class PdfWriter {
                     $this->PAGE_HEIGHT - (self::VMARGIN + $this->vOffset), $textToAppend);
             }
             if ($textToAppend)
-                $this->current["char"] = $textToAppend{strlen($textToAppend)-1};
+                $this->current["char"] = $textToAppend[strlen($textToAppend)-1];
 
             // Offsets for next line
             if (!$isLastLine) {
@@ -302,7 +302,7 @@ class PdfWriter {
         $this->currentPage->textOut(self::HMARGIN + $this->hOffset + $this->permanentLeftSpacing,
             $this->PAGE_HEIGHT - (self::VMARGIN + $this->vOffset), $textToAppend);
         if ($textToAppend)
-            $this->current["char"] = $textToAppend{strlen($textToAppend)-1};
+            $this->current["char"] = $textToAppend[strlen($textToAppend)-1];
 
         $this->hOffset += $this->currentPage->getTextWidth($textToAppend);
 

--- a/phpdotnet/phd/Format/Abstract/PDF.php
+++ b/phpdotnet/phd/Format/Abstract/PDF.php
@@ -134,10 +134,10 @@ class PdfWriter {
 
     function __construct($pageWidth = 210, $pageHeight = 297) {
     	// Initialization of properties
-    	$this->haruDoc = new \HaruDoc;
-    	$this->haruDoc->addPageLabel(1, \HaruPage::NUM_STYLE_DECIMAL, 1, "Page ");
+    	$this->haruDoc = new Haru_HaruDoc;
+    	$this->haruDoc->addPageLabel(1, Haru_HaruPage::NUM_STYLE_DECIMAL, 1, "Page ");
 
-        $this->haruDoc->setPageMode(\HaruDoc::PAGE_MODE_USE_OUTLINE);
+        $this->haruDoc->setPageMode(Haru_HaruDoc::PAGE_MODE_USE_OUTLINE);
         $this->haruDoc->setPagesConfiguration(2);
 
     	// Page format
@@ -157,7 +157,7 @@ class PdfWriter {
     	$this->currentFontSize = 12;
     	$this->currentFontColor = array(0, 0, 0); // Black
     	$this->nextPage();
-    	$this->haruDoc->addPageLabel(1, \HaruPage::NUM_STYLE_DECIMAL, 1, "Page ");
+    	$this->haruDoc->addPageLabel(1, Haru_HaruPage::NUM_STYLE_DECIMAL, 1, "Page ");
     }
 
     public function getCurrentPage() {
@@ -531,7 +531,7 @@ class PdfWriter {
         } else {
             $this->pages[$this->currentPageNumber] = $this->haruDoc->addPage();
             $this->currentPage = $this->pages[$this->currentPageNumber];
-            $this->currentPage->setTextRenderingMode(\HaruPage::FILL);
+            $this->currentPage->setTextRenderingMode(Haru_HaruPage::FILL);
             $this->vOffset = $this->currentFontSize;
             $this->hOffset = ($this->hOffset ? $this->hOffset : 0);
             $footerToAppend = true;

--- a/phpdotnet/phd/Format/Abstract/PDF.php
+++ b/phpdotnet/phd/Format/Abstract/PDF.php
@@ -858,18 +858,18 @@ class PdfWriter {
             }
 
             $this->currentPage->moveTo($x, $this->PAGE_HEIGHT - self::VMARGIN - ($this->current["vOffset"]));
-            $this->currentPage->lineTo($x, $this->PAGE_HEIGHT - self::VMARGIN - ($this->current["row"]["vPosition"] % $this->PAGE_HEIGHT));
+            $this->currentPage->lineTo($x, $this->PAGE_HEIGHT - self::VMARGIN - ((int)$this->current["row"]["vPosition"] % (int)$this->PAGE_HEIGHT));
             $this->currentPage->stroke();
             $this->current["vOffset"] = $vOffset;
         }
         // Horizontal line
-        $this->currentPage->moveTo(self::HMARGIN + $this->current["leftSpacing"], $this->PAGE_HEIGHT - self::VMARGIN - ($this->current["row"]["vPosition"] % $this->PAGE_HEIGHT));
+        $this->currentPage->moveTo(self::HMARGIN + $this->current["leftSpacing"], $this->PAGE_HEIGHT - self::VMARGIN - ((int)$this->current["row"]["vPosition"] % (int)$this->PAGE_HEIGHT));
         $this->currentPage->lineTo($this->PAGE_WIDTH - self::HMARGIN - $this->current["rightSpacing"],
-            $this->PAGE_HEIGHT - self::VMARGIN - ($this->current["row"]["vPosition"] % $this->PAGE_HEIGHT));
+            $this->PAGE_HEIGHT - self::VMARGIN - ((int)$this->current["row"]["vPosition"] % (int)$this->PAGE_HEIGHT));
         $this->currentPage->stroke();
 
         // Store position
-        $this->vOffset = $this->current["row"]["vPosition"] % $this->PAGE_HEIGHT;
+        $this->vOffset = (int)$this->current["row"]["vPosition"] % (int)$this->PAGE_HEIGHT;
 
         // Store pages
         $last = array_pop($this->old);

--- a/phpdotnet/phd/Haru/HaruAnnotation.php
+++ b/phpdotnet/phd/Haru/HaruAnnotation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace phpdotnet\phd;
+
+class Haru_HaruAnnotation {
+    private $h = null;
+    private $ffi = null;
+
+    public function __construct($annotation_ref) {
+        $this->ffi = \FFI::load(__DIR__.'/hpdf.h');
+        $this->h = $annotation_ref;
+        if(is_null($this->h)) {
+            throw new Haru_HaruException('Cannot create HaruAnnotation handle');
+        }
+    }
+    public function setBorderStyle($width, $dash_on, $dash_off) {
+        $status = $this->ffi->HPDF_LinkAnnot_SetBorderStyle($this->h, $width, $dash_on, $dash_off);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+}

--- a/phpdotnet/phd/Haru/HaruDestination.php
+++ b/phpdotnet/phd/Haru/HaruDestination.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace phpdotnet\phd;
+
+class Haru_HaruDestination {
+    public $h = null;
+    private $ffi = null;
+
+    public function __construct($dest_ref) {
+        $this->ffi = \FFI::load(__DIR__.'/hpdf.h');
+        $this->h = $dest_ref;
+        if(is_null($this->h)) {
+            throw new Haru_HaruException('Cannot create HaruDestination handle');
+        }
+    }
+
+    public function setXYZ($left, $top, $zoom) {
+        $status = $this->ffi->HPDF_Destination_SetXYZ($this->h, $left, $top, $zoom);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+}

--- a/phpdotnet/phd/Haru/HaruDoc.php
+++ b/phpdotnet/phd/Haru/HaruDoc.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace phpdotnet\phd;
+
+class Haru_HaruDoc {
+    const COMP_ALL = 0x0F;
+    const PAGE_MODE_USE_OUTLINE = 1;
+
+    private $h = null;
+    private $ffi = null;
+
+    public function __construct() {
+        try {
+            $this->ffi = \FFI::load(__DIR__.'/hpdf.h');
+        } catch(\FFI\Exception $e) {
+            die($e->getFile() . ":" . $e->getLine() . ": " . $e->getMessage() . ". Is libharu installed?\n");
+        }
+        $this->h = $this->ffi->HPDF_New(null, null);
+        if(is_null($this->h)) {
+            throw new Haru_HaruException('Cannot create HaruDoc handle');
+        }
+    }
+
+    public function setCompressionMode($mode) {
+        $status = $this->ffi->HPDF_SetCompressionMode($this->h, $mode);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function addPageLabel($first_page, $style, $first_num, $string_prefix = null) {
+        $status = $this->ffi->HPDF_AddPageLabel($this->h, $first_page, $style, $first_num, $string_prefix);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function setPageMode($mode) {
+        $status = $this->ffi->HPDF_SetPageMode($this->h, $mode);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function setPagesConfiguration($page_per_pages) {
+        $status = $this->ffi->HPDF_SetPagesConfiguration($this->h, $page_per_pages);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function getFont($font_name, $encoding_name) {
+        $font_ref = $this->ffi->HPDF_GetFont($this->h, $font_name, $encoding_name);
+        if(is_null($font_ref)) {
+            throw new Haru_HaruException('Cannot create HaruFont handle');
+        }
+        $font = new Haru_HaruFont($font_ref);
+        return $font;
+    }
+
+    public function save($file_name) {
+        $status = $this->ffi->HPDF_SaveToFile($this->h, $file_name);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    // Note that the order of params differ from the underlying function
+    public function createOutline($title, $parent = null, $encoder = null) {
+        if($parent){
+            $parent = $parent->h;
+        }
+        $outline_ref = $this->ffi->HPDF_CreateOutline($this->h, $parent, $title, $encoder);
+        if(is_null($outline_ref)) {
+            throw new Haru_HaruException('Cannot create HaruOutline handle');
+        }
+        $outline = new Haru_HaruOutline($outline_ref);
+        return $outline;
+    }
+
+    public function addPage() {
+        $page_ref = $this->ffi->HPDF_AddPage($this->h);
+        if(is_null($page_ref)) {
+            throw new Haru_HaruException('Cannot create HaruPage handle');
+        }
+        $page = new Haru_HaruPage($page_ref);
+        return $page;
+    }
+
+    // TODO: this should return a new Haru_HaruImage instance
+    public function loadPNG($filename) {
+        $image_ref = $this->ffi->HPDF_LoadPngImageFromFile($this->h, $filename);
+        return $image_ref;
+    }
+
+    // TODO: this should return a new Haru_HaruImage instance
+    public function loadJPEG() {
+        $image_ref = $this->ffi->HPDF_LoadJpegImageFromFile($this->h, $filename);
+        return $image_ref;
+    }
+}

--- a/phpdotnet/phd/Haru/HaruException.php
+++ b/phpdotnet/phd/Haru/HaruException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace phpdotnet\phd;
+
+class Haru_HaruException extends \Exception {
+    public function __construct($message, $code = 0, Throwable $previous = null) {
+        switch($code) {
+            default:
+                if(!$message) {
+                    $message = "Error: libharu returned " . $code;
+                }
+        }
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/phpdotnet/phd/Haru/HaruFont.php
+++ b/phpdotnet/phd/Haru/HaruFont.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace phpdotnet\phd;
+
+class Haru_HaruFont {
+    public $h = null;
+    private $ffi = null;
+
+    public function __construct($font_ref) {
+        $this->ffi = \FFI::load(__DIR__.'/hpdf.h');
+        $this->h = $font_ref;
+        if(is_null($this->h)) {
+            throw new Haru_HaruException('Cannot create HaruFont handle');
+        }
+    }
+
+    public function measureText($text, $width, $font_size, $char_space, $word_space, $word_wrap = 0) {
+        $len = strlen($text);
+        if(!$len) {
+            return 0;
+        }
+        $str_ref_type = \FFI::arrayType($this->ffi->type("HPDF_BYTE"), [$len]);
+        $str_ref = $this->ffi->new($str_ref_type);
+        \FFI::memcpy($str_ref, $text, $len);
+        $fit_count = $this->ffi->HPDF_Font_MeasureText($this->h, $str_ref, $len, $width, $font_size, $char_space, $word_space, $word_wrap, null);
+        return (int)$fit_count;
+    }
+}

--- a/phpdotnet/phd/Haru/HaruOutline.php
+++ b/phpdotnet/phd/Haru/HaruOutline.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace phpdotnet\phd;
+
+class Haru_HaruOutline {
+    public $h = null;
+    private $ffi = null;
+
+    public function __construct($outline_ref) {
+        $this->ffi = \FFI::load(__DIR__.'/hpdf.h');
+        $this->h = $outline_ref;
+        if(is_null($this->h)) {
+            throw new Haru_HaruException('Cannot create HaruOutline handle');
+        }
+    }
+
+    public function setDestination($dest) {
+        $status = $this->ffi->HPDF_Outline_SetDestination($this->h, $dest->h);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function setOpened($opened)
+    {
+        $status = $this->ffi->HPDF_Outline_SetOpened($this->h, $opened);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+}

--- a/phpdotnet/phd/Haru/HaruPage.php
+++ b/phpdotnet/phd/Haru/HaruPage.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace phpdotnet\phd;
+
+class Haru_HaruPage {
+    const NUM_STYLE_DECIMAL = 0;
+    const FILL = 0;
+
+    private $h = null;
+    private $ffi = null;
+
+    public function __construct($page_ref) {
+        $this->ffi = \FFI::load(__DIR__.'/hpdf.h');
+        $this->h = $page_ref;
+        if(is_null($this->h)) {
+            throw new Haru_HaruException('Cannot create HaruPage handle');
+        }
+    }
+
+    public function setTextRenderingMode($mode) {
+        $status = $this->ffi->HPDF_Page_SetTextRenderingMode($this->h, $mode);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function setRGBStroke($r, $g, $b) {
+        $status = $this->ffi->HPDF_Page_SetRGBStroke($this->h, $r, $g, $b);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function setRGBFill($r, $g, $b) {
+        $status = $this->ffi->HPDF_Page_SetRGBFill($this->h, $r, $g, $b);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function setFontAndSize($font, $size) {
+        $font_ref = $font->h;
+        $status = $this->ffi->HPDF_Page_SetFontAndSize($this->h, $font_ref, $size);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function beginText() {
+        $status = $this->ffi->HPDF_Page_BeginText($this->h);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function getCharSpace() {
+        $char_space = $this->ffi->HPDF_Page_GetCharSpace($this->h);
+        return $char_space;
+    }
+
+    public function getWordSpace() {
+        $word_space = $this->ffi->HPDF_Page_GetWordSpace($this->h);
+        return $word_space;
+    }
+
+    public function textOut($x, $y, $text) {
+        $status = $this->ffi->HPDF_Page_TextOut($this->h, $x, $y, (string)$text);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function getTextWidth($text) {
+        $width = $this->ffi->HPDF_Page_TextWidth($this->h, (string)$text);
+        return $width;
+    }
+
+    public function endText() {
+        $status = $this->ffi->HPDF_Page_EndText($this->h);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function createDestination() {
+        $dest_ref = $this->ffi->HPDF_Page_CreateDestination($this->h);
+        if(is_null($dest_ref)) {
+            throw new Haru_HaruException('Cannot create HaruDestination handle');
+        }
+        $dest = new Haru_HaruDestination($dest_ref);
+        return $dest;
+    }
+
+    public function getHeight() {
+        $height = $this->ffi->HPDF_Page_GetHeight($this->h);
+        return $height;
+    }
+
+    public function setLineWidth($width) {
+        $status = $this->ffi->HPDF_Page_SetLineWidth($this->h, $width);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function setDash($pattern, $phase) {
+        $num_param = 0;
+        if($pattern) {
+            $num_param = count($pattern);
+            $pat_ref_type = \FFI::arrayType($this->ffi->type("HPDF_UINT16"), [$num_param]);
+            $pat_ref = $this->ffi->new($pat_ref_type);
+            for($i = 0; $i < $num_param; $i++) {
+                $pat_ref[$i] = $pattern[$i];
+            }
+            $pattern = $pat_ref;
+        }
+        $status = $this->ffi->HPDF_Page_SetDash($this->h, $pattern, $num_param, $phase);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function moveTo($x, $y) {
+        $status = $this->ffi->HPDF_Page_MoveTo($this->h, $x, $y);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function lineTo($x, $y) {
+        $status = $this->ffi->HPDF_Page_LineTo($this->h, $x, $y);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function stroke($close_path = false) {
+        if(!$close_path) {
+            $status = $this->ffi->HPDF_Page_Stroke($this->h);
+        } else {
+            $status = $this->ffi->HPDF_Page_ClosePathStroke($this->h);
+        }
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function createURLAnnotation($rectangle, $url) {
+        $rect_type = $this->ffi->type("HPDF_Rect");
+        $hpdf_rectangle = $this->ffi->new($rect_type);
+        $hpdf_rectangle->left = $rectangle[0];
+        $hpdf_rectangle->bottom = $rectangle[1];
+        $hpdf_rectangle->right = $rectangle[2];
+        $hpdf_rectangle->top = $rectangle[3];
+        $annotation_ref = $this->ffi->HPDF_Page_CreateURILinkAnnot($this->h, $hpdf_rectangle, $url);
+        if(is_null($annotation_ref)) {
+            throw new Haru_HaruException('Cannot create HaruAnnotation handle');
+        }
+        $annotation = new Haru_HaruAnnotation($annotation_ref);
+        return $annotation;
+    }
+
+    public function rectangle($x, $y, $width, $height) {
+        $status = $this->ffi->HPDF_Page_Rectangle($this->h, $x, $y, $width, $height);
+        if($status) {
+            throw new Haru_HaruException('', $status);
+        }
+    }
+
+    public function createLinkAnnotation($rectangle, $dest) {
+        $rect_type = $this->ffi->type("HPDF_Rect");
+        $hpdf_rectangle = $this->ffi->new($rect_type);
+        $hpdf_rectangle->left = $rectangle[0];
+        $hpdf_rectangle->bottom = $rectangle[1];
+        $hpdf_rectangle->right = $rectangle[2];
+        $hpdf_rectangle->top = $rectangle[3];
+        $annotation_ref = $this->ffi->HPDF_Page_CreateLinkAnnot($this->h, $hpdf_rectangle, $dest->h);
+        if(is_null($annotation_ref)) {
+            throw new Haru_HaruException('Cannot create HaruAnnotation handle');
+        }
+        $annotation = new Haru_HaruAnnotation($annotation_ref);
+        return $annotation;
+    }
+}

--- a/phpdotnet/phd/Haru/LICENSE
+++ b/phpdotnet/phd/Haru/LICENSE
@@ -1,0 +1,9 @@
+Copyright 2022 The PHP Documentation Team
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/phpdotnet/phd/Haru/hpdf.h
+++ b/phpdotnet/phd/Haru/hpdf.h
@@ -1,0 +1,244 @@
+#define FFI_LIB "/usr/lib/x86_64-linux-gnu/libhpdf-2.3.0.so"
+
+typedef enum _HPDF_PageNumStyle {
+    HPDF_PAGE_NUM_STYLE_DECIMAL = 0,
+    HPDF_PAGE_NUM_STYLE_UPPER_ROMAN,
+    HPDF_PAGE_NUM_STYLE_LOWER_ROMAN,
+    HPDF_PAGE_NUM_STYLE_UPPER_LETTERS,
+    HPDF_PAGE_NUM_STYLE_LOWER_LETTERS,
+    HPDF_PAGE_NUM_STYLE_EOF
+} HPDF_PageNumStyle;
+
+typedef enum _HPDF_PageMode {
+    HPDF_PAGE_MODE_USE_NONE = 0,
+    HPDF_PAGE_MODE_USE_OUTLINE,
+    HPDF_PAGE_MODE_USE_THUMBS,
+    HPDF_PAGE_MODE_FULL_SCREEN,
+/*  HPDF_PAGE_MODE_USE_OC,
+    HPDF_PAGE_MODE_USE_ATTACHMENTS,
+ */
+    HPDF_PAGE_MODE_EOF
+} HPDF_PageMode;
+
+typedef  unsigned long       HPDF_STATUS;
+typedef  unsigned int        HPDF_UINT;
+typedef  unsigned short      HPDF_UINT16;
+
+typedef void
+( *HPDF_Error_Handler)  (HPDF_STATUS   error_no,
+                                     HPDF_STATUS   detail_no,
+                                     void         *user_data);
+
+typedef void         *HPDF_HANDLE;
+typedef HPDF_HANDLE   HPDF_Doc;
+
+// HPDF_EXPORT is extern
+extern HPDF_Doc 
+HPDF_New  (HPDF_Error_Handler   user_error_fn,
+           void                *user_data);
+
+extern HPDF_STATUS
+HPDF_SetCompressionMode  (HPDF_Doc    pdf,
+                          HPDF_UINT   mode);
+
+extern HPDF_STATUS
+HPDF_AddPageLabel  (HPDF_Doc            pdf,
+                    HPDF_UINT           page_num,
+                    HPDF_PageNumStyle   style,
+                    HPDF_UINT           first_page,
+                    const char         *prefix);
+
+extern HPDF_STATUS
+HPDF_SetPageMode  (HPDF_Doc        pdf,
+                   HPDF_PageMode   mode);
+
+extern HPDF_STATUS
+HPDF_SetPagesConfiguration  (HPDF_Doc    pdf,
+                             HPDF_UINT   page_per_pages);
+
+typedef HPDF_HANDLE   HPDF_Dict;
+typedef HPDF_Dict HPDF_Font;
+
+extern HPDF_Font
+HPDF_GetFont  (HPDF_Doc     pdf,
+               const char  *font_name,
+               const char  *encoding_name);
+
+extern HPDF_STATUS
+HPDF_SaveToFile  (HPDF_Doc     pdf,
+                  const char  *file_name);
+
+typedef HPDF_HANDLE   HPDF_Encoder;
+typedef HPDF_HANDLE   HPDF_Outline;
+
+extern HPDF_Outline
+HPDF_CreateOutline  (HPDF_Doc       pdf,
+                     HPDF_Outline   parent,
+                     const char    *title,
+                     HPDF_Encoder   encoder);
+
+typedef HPDF_HANDLE HPDF_Page;
+
+extern HPDF_Page
+HPDF_AddPage  (HPDF_Doc   pdf);
+
+typedef HPDF_HANDLE   HPDF_Image;
+
+extern HPDF_Image
+HPDF_LoadPngImageFromFile (HPDF_Doc      pdf,
+                            const char    *filename);
+
+extern HPDF_Image
+HPDF_LoadJpegImageFromFile (HPDF_Doc      pdf,
+                            const char    *filename);
+
+typedef enum _HPDF_TextRenderingMode {
+    HPDF_FILL = 0,
+    HPDF_STROKE,
+    HPDF_FILL_THEN_STROKE,
+    HPDF_INVISIBLE,
+    HPDF_FILL_CLIPPING,
+    HPDF_STROKE_CLIPPING,
+    HPDF_FILL_STROKE_CLIPPING,
+    HPDF_CLIPPING,
+    HPDF_RENDERING_MODE_EOF
+} HPDF_TextRenderingMode;
+
+extern HPDF_STATUS
+HPDF_Page_SetTextRenderingMode  (HPDF_Page               page,
+                                 HPDF_TextRenderingMode  mode);
+
+typedef  float               HPDF_REAL;
+
+extern HPDF_STATUS
+HPDF_Page_SetRGBStroke  (HPDF_Page  page,
+                         HPDF_REAL  r,
+                         HPDF_REAL  g,
+                         HPDF_REAL  b);
+
+extern HPDF_STATUS
+HPDF_Page_SetRGBFill  (HPDF_Page  page,
+                       HPDF_REAL  r,
+                       HPDF_REAL  g,
+                       HPDF_REAL  b);
+
+extern HPDF_STATUS
+HPDF_Page_SetFontAndSize  (HPDF_Page  page,
+                           HPDF_Font  font,
+                           HPDF_REAL  size);
+
+extern HPDF_STATUS
+HPDF_Page_BeginText  (HPDF_Page  page);
+
+typedef  unsigned char       HPDF_BYTE;
+typedef  signed int          HPDF_BOOL;
+
+extern HPDF_UINT
+HPDF_Font_MeasureText (HPDF_Font          font,
+                       const HPDF_BYTE   *text,
+                       HPDF_UINT          len,
+                       HPDF_REAL          width,
+                       HPDF_REAL          font_size,
+                       HPDF_REAL          char_space,
+                       HPDF_REAL          word_space,
+                       HPDF_BOOL          wordwrap,
+                       HPDF_REAL         *real_width);
+
+extern HPDF_REAL
+HPDF_Page_GetCharSpace  (HPDF_Page   page);
+
+extern HPDF_REAL
+HPDF_Page_GetWordSpace  (HPDF_Page   page);
+
+extern HPDF_STATUS
+HPDF_Page_TextOut  (HPDF_Page    page,
+                    HPDF_REAL    xpos,
+                    HPDF_REAL    ypos,
+                    const char  *text);
+
+extern HPDF_REAL
+HPDF_Page_TextWidth  (HPDF_Page    page,
+                      const char  *text);
+
+extern HPDF_STATUS
+HPDF_Page_EndText  (HPDF_Page  page);
+
+typedef HPDF_HANDLE   HPDF_Destination;
+
+extern HPDF_Destination
+HPDF_Page_CreateDestination  (HPDF_Page   page);
+
+extern HPDF_STATUS
+HPDF_Destination_SetXYZ  (HPDF_Destination  dst,
+                          HPDF_REAL         left,
+                          HPDF_REAL         top,
+                          HPDF_REAL         zoom);
+
+extern HPDF_REAL
+HPDF_Page_GetHeight  (HPDF_Page   page);
+
+extern HPDF_STATUS
+HPDF_Outline_SetDestination (HPDF_Outline      outline,
+                             HPDF_Destination  dst);
+
+extern HPDF_STATUS
+HPDF_Outline_SetOpened  (HPDF_Outline  outline,
+                         HPDF_BOOL     opened);
+
+extern HPDF_STATUS
+HPDF_Page_SetLineWidth  (HPDF_Page  page,
+                         HPDF_REAL  line_width);
+
+extern HPDF_STATUS
+HPDF_Page_SetDash  (HPDF_Page           page,
+                    const HPDF_UINT16  *dash_ptn,
+                    HPDF_UINT           num_param,
+                    HPDF_UINT           phase);
+
+extern HPDF_STATUS
+HPDF_Page_MoveTo  (HPDF_Page    page,
+                   HPDF_REAL    x,
+                   HPDF_REAL    y);
+
+extern HPDF_STATUS
+HPDF_Page_LineTo  (HPDF_Page    page,
+                   HPDF_REAL    x,
+                   HPDF_REAL    y);
+
+extern HPDF_STATUS
+HPDF_Page_Stroke  (HPDF_Page  page);
+
+extern HPDF_STATUS
+HPDF_Page_ClosePathStroke  (HPDF_Page  page);
+
+typedef  struct _HPDF_Rect {
+    HPDF_REAL  left;
+    HPDF_REAL  bottom;
+    HPDF_REAL  right;
+    HPDF_REAL  top;
+} HPDF_Rect;
+
+typedef HPDF_HANDLE   HPDF_Annotation;
+
+extern HPDF_Annotation
+HPDF_Page_CreateURILinkAnnot  (HPDF_Page     page,
+                               HPDF_Rect     rect,
+                               const char   *uri);
+
+extern HPDF_STATUS
+HPDF_LinkAnnot_SetBorderStyle  (HPDF_Annotation  annot,
+                                HPDF_REAL        width,
+                                HPDF_UINT16      dash_on,
+                                HPDF_UINT16      dash_off);
+
+extern HPDF_STATUS
+HPDF_Page_Rectangle  (HPDF_Page  page,
+                      HPDF_REAL  x,
+                      HPDF_REAL  y,
+                      HPDF_REAL  width,
+                      HPDF_REAL  height);
+
+extern HPDF_Annotation
+HPDF_Page_CreateLinkAnnot  (HPDF_Page          page,
+                            HPDF_Rect          rect,
+                            HPDF_Destination   dst);

--- a/phpdotnet/phd/Package/Generic/PDF.php
+++ b/phpdotnet/phd/Package/Generic/PDF.php
@@ -266,7 +266,7 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
         "links-to-resolve"      => array(
             /* $id => array( $target ), */
         ),
-        "refname"               => "",
+        "refname"               => array(),
         "table"                 => false,
         "verbatim-block"        => false,
         "segmentedlist"         => array(

--- a/phpdotnet/phd/Package/PHP/BigPDF.php
+++ b/phpdotnet/phd/Package/PHP/BigPDF.php
@@ -35,8 +35,8 @@ class Package_PHP_BigPDF extends Package_PHP_PDF {
             $this->cchunk = $this->dchunk;
             $pdfDoc = new PdfWriter();
             try {
-                $pdfDoc->setCompressionMode(\HaruDoc::COMP_ALL);
-            } catch (\HaruException $e) {
+                $pdfDoc->setCompressionMode(Haru_HaruDoc::COMP_ALL);
+            } catch (Haru_HaruException $e) {
                 v("PDF Compression failed, you need to compile libharu with Zlib...", E_USER_WARNING);
             }
             parent::setPdfDoc($pdfDoc);

--- a/phpdotnet/phd/Package/PHP/PDF.php
+++ b/phpdotnet/phd/Package/PHP/PDF.php
@@ -149,8 +149,8 @@ class Package_PHP_PDF extends Package_Generic_PDF {
             $this->cchunk = $this->dchunk;
             $pdfDoc = new PdfWriter();
             try {
-                $pdfDoc->setCompressionMode(\HaruDoc::COMP_ALL);
-            } catch (\HaruException $e) {
+                $pdfDoc->setCompressionMode(Haru_HaruDoc::COMP_ALL);
+            } catch (Haru_HaruException $e) {
                 v("PDF Compression failed, you need to compile libharu with Zlib...", E_USER_WARNING);
             }
             parent::setPdfDoc($pdfDoc);

--- a/phpdotnet/phd/Package/PHP/PDF.php
+++ b/phpdotnet/phd/Package/PHP/PDF.php
@@ -118,7 +118,6 @@ class Package_PHP_PDF extends Package_Generic_PDF {
             break;
 
         case Render::INIT:
-            if (!class_exists("HaruDoc")) die ("PDF output needs libharu & haru/pecl extensions... Please install them and start PhD again.\n");
             $this->setOutputDir(Config::output_dir() . strtolower($this->getFormatName()) . DIRECTORY_SEPARATOR);
             if(!file_exists($this->getOutputDir()) || is_file($this->getOutputDir())) mkdir($this->getOutputDir(), 0777, true) or die("Can't create the cache directory.\n");
             break;


### PR DESCRIPTION
This is a first step into fixing the PDF generation.

This is done by substituting the now unmaintained libharu extension with a minimal FFI pakcage.

There are still a few nits that need fixing in the new implementation, but this first patch set is enough to revive the pdf docs generation.

I am aware there was a discussion regarding removing the pdf support from this repository. In case there is no interest in re-generating pdf docs, we can just close this PR :)