### PR TITLE
Fix GH-71: Code examples contain non-breaking spaces

### DIFF
--- a/phpdotnet/phd/Highlighter.php
+++ b/phpdotnet/phd/Highlighter.php
@@ -63,7 +63,7 @@ class Highlighter
 
         if ($role == 'php') {
             try {
-                return highlight_string($text, 1);
+                return str_replace('&nbsp;', ' ', highlight_string($text, 1));
             } catch (\ParseException $e) {
                 v("Parse error while highlighting PHP code: %s\nText: %s", (string) $e, $text, E_USER_WARNING);
 


### PR DESCRIPTION
Some browsers (notably Firefox ≥ 107) copy these NBSPs verbatim, what causes issues when pasting into text editors/IDE.  Since these NBSPs are generated by `highlight_string()` and there is no option to produce regular spaces instead, we replace them manually.

To preserve the desired code layout, this requires something like <https://github.com/php/web-php/pull/744>.

--- 

Note that this change only affects PHP code samples; there are other cases where PhD renders NBSPs, but these can be addressed when and if needed.
