### PR TITLE
Add rendering logic for interfaces

### DIFF
--- a/phpdotnet/phd/Package/Generic/PDF.php
+++ b/phpdotnet/phd/Package/Generic/PDF.php
@@ -277,6 +277,7 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
         "classsynopsis"         => array(
             "close"             => false,
             "classname"         => false,
+            "interface"         => false, // bool: true when in interface
         ),
         "classsynopsisinfo"     => array(
             "implements"        => false,
@@ -932,7 +933,12 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
         if ($open) {
             if ($this->cchunk["classsynopsisinfo"]["implements"] === false) {
                 $this->cchunk["classsynopsisinfo"]["implements"] = true;
-                $this->pdfDoc->appendText(" implements");
+                if ($this->cchunk["classsynopsis"]["interface"]) {
+                    $this->pdfDoc->appendText(" extends");
+                } else {
+                    $this->pdfDoc->appendText(" implements");
+                }
+
                 return '';
             }
             $this->pdfDoc->appendText(",");
@@ -943,6 +949,13 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
 
     public function format_classsynopsis($open, $name, $attrs, $props) {
         if ($open) {
+            if (
+                isset($attrs[Reader::XMLNS_DOCBOOK]["class"]) &&
+                $attrs[Reader::XMLNS_DOCBOOK]["class"] == 'interface'
+            ) {
+                $this->cchunk["classsynopsis"]["interface"] = true;
+            }
+
             return $this->format_para($open, $name, $attrs, $props);
         }
 

--- a/phpdotnet/phd/Package/Generic/PDF.php
+++ b/phpdotnet/phd/Package/Generic/PDF.php
@@ -951,7 +951,7 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
         if ($open) {
             if (
                 isset($attrs[Reader::XMLNS_DOCBOOK]["class"]) &&
-                $attrs[Reader::XMLNS_DOCBOOK]["class"] == 'interface'
+                $attrs[Reader::XMLNS_DOCBOOK]["class"] == "interface"
             ) {
                 $this->cchunk["classsynopsis"]["interface"] = true;
             }

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -425,6 +425,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         "classsynopsis"            => array(
             "close"                         => false,
             "classname"                     => false,
+            "interface"                     => false, // bool: true when in interface
         ),
         "classsynopsisinfo"        => array(
             "implements"                    => false,
@@ -903,6 +904,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
             if ($this->cchunk["classsynopsisinfo"]["implements"] === false) {
                 $this->cchunk["classsynopsisinfo"]["implements"] = true;
+                if ($this->cchunk["classsynopsis"]["interface"]) {
+                    return '<span class="'.$name.'"><span class="modifier">extends</span> ';
+                }
+
                 return '<span class="'.$name.'"><span class="modifier">implements</span> ';
             }
 
@@ -917,6 +922,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($open) {
             if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
                 $this->cchunk["classsynopsisinfo"]["ooclass"] = true;
+                if ($this->cchunk["classsynopsis"]["interface"]) {
+                    return '<span class="modifier">interface</span> ';
+                }
+
                 return '<span class="modifier">class</span> ';
             }
 
@@ -968,6 +977,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_classsynopsis($open, $name, $attrs) {
         if ($open) {
+            // Think this just needs to be set on open and it will persist
+            if (
+                isset($attrs[Reader::XMLNS_DOCBOOK]["class"]) &&
+                $attrs[Reader::XMLNS_DOCBOOK]["class"] == 'interface'
+            ) {
+                $this->cchunk["classsynopsis"]["interface"] = true;
+            }
+
             return '<div class="'.$name.'">';
         }
 

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -978,9 +978,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     public function format_classsynopsis($open, $name, $attrs) {
         if ($open) {
             // Think this just needs to be set on open and it will persist
+            // Will remove comment after review
             if (
                 isset($attrs[Reader::XMLNS_DOCBOOK]["class"]) &&
-                $attrs[Reader::XMLNS_DOCBOOK]["class"] == 'interface'
+                $attrs[Reader::XMLNS_DOCBOOK]["class"] == "interface"
             ) {
                 $this->cchunk["classsynopsis"]["interface"] = true;
             }


### PR DESCRIPTION
- Adds cchunk variable for tracking if a classsynopsis is actually an interface
- Render extends instead of implements for interfaces
- Render interface instead of class


After this is merged in, then this PR will render DS as interfaces now: https://github.com/php/doc-en/pull/2549