### PR TITLE
Add support for rendering more logical classsynopsis markup

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -66,7 +66,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         'classname'             => array(
             /* DEFAULT */          'span',
             'ooclass'           => array(
-                /* DEFAULT */      'strong',
+                'classsynopsis'         => 'format_classsynopsis_ooclass_classname',
                 'classsynopsisinfo' => 'format_classsynopsisinfo_ooclass_classname',
             ),
         ),
@@ -159,16 +159,18 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         'othercredit'           => 'format_div',
         'ooclass'               => array(
             /* DEFAULT */          'span',
-            'classsynopsis'     => 'format_div',
+            'classsynopsis'     => 'format_classsynopsis_ooclass',//'format_div',//
         ),
         'oointerface'           => array(
             /* DEFAULT */          'span',
+            'classsynopsis' => 'format_classsynopsis_oointerface',
             'classsynopsisinfo'    => 'format_classsynopsisinfo_oointerface',
         ),
         'interfacename'         => array(
             /* DEFAULT */          'span',
             'oointerface'       => array(
                 /* DEFAULT */          'span',
+                'classsynopsis' => 'format_classsynopsis_oointerface_interfacename',
                 'classsynopsisinfo' => 'format_classsynopsisinfo_oointerface_interfacename',
             ),
         ),
@@ -383,6 +385,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             /* DEFAULT */         false,
             'ooclass'          => array(
                 /* DEFAULT */     false,
+                // We keep this to work around the legacy behaviour of not displaying it
                 'classsynopsis' => 'format_classsynopsis_ooclass_classname_text',
             ),
         ),
@@ -422,11 +425,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     protected $cchunk      = array();
     /* Default Chunk variables */
     private $dchunk      = array(
-        "classsynopsis"            => array(
-            "close"                         => false,
-            "classname"                     => false,
-            "interface"                     => false, // bool: true when in interface
-        ),
+        "classsynopsis" => [
+            "close"        => false,
+            "classname"    => false,
+            "interface"    => false, // bool: true when in interface
+            "ooclass"      => false,
+            "oointerface"  => false,
+            "legacy"       => true, // legacy rendering
+        ],
         "classsynopsisinfo"        => array(
             "implements"                    => false,
             "ooclass"                       => false,
@@ -896,6 +902,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return "</div>\n";
     }
 
+    /** Legacy rendering functions for class synopsis tags that wraps the definition in a class synopsis info tag */
     public function format_classsynopsisinfo_oointerface($open, $name, $attrs) {
         if ($open) {
             if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
@@ -971,29 +978,139 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"]) && $attrs[Reader::XMLNS_DOCBOOK]["role"] == "comment") {
             return ' */</div>';
         }
+
+        assert($this->cchunk["classsynopsis"]["legacy"] === true);
         $this->cchunk["classsynopsis"]["close"] = true;
         return ' {</div>';
     }
 
-    public function format_classsynopsis($open, $name, $attrs) {
+    /** Class synopsis rendering for new/better markup */
+    public function format_classsynopsis_oointerface_interfacename($open, $name, $attrs, $props)
+    {
+        if ($this->cchunk["classsynopsis"]["legacy"] === true) {
+            return $this->transformFromMap($open, 'strong', $name, $attrs, $props);
+        }
+
         if ($open) {
-            // Think this just needs to be set on open and it will persist
-            // Will remove comment after review
-            if (
-                isset($attrs[Reader::XMLNS_DOCBOOK]["class"]) &&
-                $attrs[Reader::XMLNS_DOCBOOK]["class"] == "interface"
-            ) {
-                $this->cchunk["classsynopsis"]["interface"] = true;
+            /* If there has been a class prior this means that we are the first implementing interface
+             * thus mark the oointerface as already been rendered as the primary tag */
+            if ($this->cchunk["classsynopsis"]["ooclass"] === true) {
+                $this->cchunk["classsynopsis"]["oointerface"] = true;
+            }
+            /** Actual interface name in bold */
+            if ($this->cchunk["classsynopsis"]["oointerface"] === false) {
+
+                return '<span class="modifier">interface</span> ' . $this->transformFromMap($open, 'strong', $name, $attrs, $props);
+            }
+            /* Whitespace for next word */
+            return ' ';
+        }
+        /** Actual interface name in bold */
+        if ($this->cchunk["classsynopsis"]["oointerface"] === false) {
+            $this->cchunk["classsynopsis"]["oointerface"] = true;
+            return '</strong>';
+        }
+        /** We don't wrap extended interface in a tag */
+        if ($this->cchunk["classsynopsis"]['nb_list'] > 1) {
+            return ',';
+        }
+        return '';
+    }
+
+    public function format_classsynopsis_ooclass_classname($open, $name, $attrs, $props)
+    {
+        if ($this->cchunk["classsynopsis"]["legacy"] === true) {
+            return $this->transformFromMap($open, 'strong', $name, $attrs, $props);
+        }
+
+        if ($open) {
+            /** Actual class name in bold */
+            if ($this->cchunk["classsynopsis"]["ooclass"] === false) {
+
+                return '<span class="modifier">class</span> ' . $this->transformFromMap($open, 'strong', $name, $attrs, $props);
+            }
+            /* Whitespace for next word */
+            return ' ';
+        }
+        /** Actual class name in bold */
+        if ($this->cchunk["classsynopsis"]["ooclass"] === false) {
+            $this->cchunk["classsynopsis"]["ooclass"] = true;
+            return '</strong>';
+        }
+        /** We don't wrap extended class in a tag */
+        return '';
+    }
+
+    public function format_classsynopsis_ooclass($open, $name, $attrs, $props)
+    {
+        if ($this->cchunk["classsynopsis"]["legacy"] === true) {
+            return $this->format_div($open, $name, $attrs, $props);
+        }
+
+        /* Close list of classes + interfaces by "opening" class def with { */
+        if (!$open && --$this->cchunk["classsynopsis"]['nb_list'] === 0) {
+            return ' {</div>';
+        }
+        return '';
+    }
+
+    public function format_classsynopsis_oointerface($open, $name, $attrs, $props)
+    {
+        /* Used to be converted to a span */
+        if ($this->cchunk["classsynopsis"]["legacy"] === true) {
+            return $this->transformFromMap($open, 'span', $name, $attrs, $props);
+        }
+
+        /* Close list of classes + interfaces by "opening" class def with { */
+        if (!$open) {
+            if (--$this->cchunk["classsynopsis"]['nb_list'] === 0) {
+                return ' {</div>';
+            }
+        }
+        return '';
+    }
+
+    public function format_classsynopsis($open, $name, $attrs, $props) {
+        $this->cchunk["classsynopsis"] = $this->dchunk["classsynopsis"];
+
+        /** Legacy presentation does not use the class attribute */
+        $this->cchunk["classsynopsis"]['legacy'] = !isset($attrs[Reader::XMLNS_DOCBOOK]["class"]);
+
+        if ($this->cchunk["classsynopsis"]['legacy']) {
+            if ($open) {
+                // Think this just needs to be set on open and it will persist
+                // Will remove comment after review
+                if (
+                    isset($attrs[Reader::XMLNS_DOCBOOK]["class"]) &&
+                    $attrs[Reader::XMLNS_DOCBOOK]["class"] == "interface"
+                ) {
+                    $this->cchunk["classsynopsis"]["interface"] = true;
+                }
+
+                return '<div class="'.$name.'">';
             }
 
-            return '<div class="'.$name.'">';
-        }
-
-        if ($this->cchunk["classsynopsis"]["close"] === true) {
-            $this->cchunk["classsynopsis"]["close"] = false;
+            /* Just always force the ending } to close the class as an opening { should always be present
+            if ($this->cchunk["classsynopsis"]["close"] === true) {
+                $this->cchunk["classsynopsis"]["close"] = false;
+                return "}</div>";
+            }
+            return "</div>";
+            */
             return "}</div>";
         }
-        return "</div>";
+
+        /* New rendering for more sensible markup:
+         * We open a fake classsynopsisinfo div to not break the CSS expectations */
+        if ($open) {
+            $occurrences = substr_count($props['innerXml'], '</ooclass>')
+                + substr_count($props['innerXml'], '</oointerface>')
+                + substr_count($props['innerXml'], '</ooexception>');
+            $this->cchunk["classsynopsis"]['nb_list'] = $occurrences;
+            return '<div class="classsynopsis"><div class="classsynopsisinfo">';
+        } else {
+            return '}</div>';
+        }
     }
 
     public function format_classsynopsis_methodsynopsis_methodname_text($value, $tag) {
@@ -1020,6 +1137,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     public function format_classsynopsis_ooclass_classname_text($value, $tag) {
         $this->cchunk["classsynopsis"]["classname"] = $value;
+        // Do not render outside ooclass class name in legacy rendering.
+        if ($this->cchunk["classsynopsis"]["legacy"]) {
+            return '';
+        }
         return $this->TEXT($value);
     }
 

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -11,6 +11,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             /* DEFAULT */          'span',
             'ooclass'           => array(
                 /* DEFAULT */      'format_suppressed_tags',
+                'classsynopsis'     => 'format_classsynopsis_ooclass_classname',
                 'classsynopsisinfo' => 'format_classsynopsisinfo_ooclass_classname',
             ),
         ),
@@ -708,8 +709,12 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     }
 
     public function format_classsynopsis_ooclass_classname_text($value, $tag) {
-        /* intentionally not return the value, it will be printed out by <methodname> "soon" */
-        parent::format_classsynopsis_ooclass_classname_text($value, $tag);
+        $content = parent::format_classsynopsis_ooclass_classname_text($value, $tag);
+        /** Legacy behaviour for crappy markup */
+        if ($content === '') {
+            return '';
+        }
+        return $this->format_classname_text($content, $tag);
     }
 
     public function format_classname_text($value, $tag) {

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -7,14 +7,6 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         'appendix'              => 'format_container_chunk',
         'article'               => 'format_container_chunk',
         'book'                  => 'format_root_chunk',
-        'classname'             => array(
-            /* DEFAULT */          'span',
-            'ooclass'           => array(
-                /* DEFAULT */      'format_suppressed_tags',
-                'classsynopsis'     => 'format_classsynopsis_ooclass_classname',
-                'classsynopsisinfo' => 'format_classsynopsisinfo_ooclass_classname',
-            ),
-        ),
         'chapter'               => 'format_container_chunk',
         'colophon'              => 'format_chunk',
         'function'              => 'format_function',
@@ -91,15 +83,29 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     private $mytextmap = array(
         'acronym'               => 'format_acronym_text',
         'function'              => 'format_function_text',
-        'interfacename'         => 'format_classname_text',
-        'exceptionname'         => 'format_classname_text',
-        'classname'            => array(
-            /* DEFAULT */         'format_classname_text',
-            'ooclass'          => array(
-                /* DEFAULT */     'format_classname_text',
+        /** Those are used to retrieve the class/interface name to be able to remove it from method names */
+        'classname' => [
+            /* DEFAULT */ 'format_classname_text',
+            'ooclass' => [
+                /* DEFAULT */ 'format_classname_text',
+                /** This is also used by the legacy display to not display the class name at all */
                 'classsynopsis' => 'format_classsynopsis_ooclass_classname_text',
-            ),
-        ),
+            ]
+        ],
+        'exceptionname' => [
+            /* DEFAULT */ 'format_classname_text',
+            'ooexception' => [
+                /* DEFAULT */     'format_classname_text',
+                'classsynopsis' => 'format_classsynopsis_oo_name_text',
+            ]
+        ],
+        'interfacename' => [
+            /* DEFAULT */ 'format_classname_text',
+            'oointerface' => [
+                /* DEFAULT */     'format_classname_text',
+                'classsynopsis' => 'format_classsynopsis_oo_name_text',
+            ]
+        ],
         'methodname'            => array(
             /* DEFAULT */          'format_function_text',
             'constructorsynopsis' => array(
@@ -714,6 +720,11 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         if ($content === '') {
             return '';
         }
+        return $this->format_classname_text($content, $tag);
+    }
+
+    public function format_classsynopsis_oo_name_text($value, $tag) {
+        $content = parent::format_classsynopsis_oo_name_text($value, $tag);
         return $this->format_classname_text($content, $tag);
     }
 

--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -72,8 +72,12 @@ class Render extends ObjectStorage
 
                 $innerXml = "";
                 if (
-                    ($open && $r->name === "type") ||
-                    ($open && in_array($r->name, ["methodsynopsis", "constructorsynopsis", "destructorsynopsis"], true))
+                    $open &&
+                    (
+                        $r->name === "type" ||
+                        $r->name === "classsynopsis" ||
+                        in_array($r->name, ["methodsynopsis", "constructorsynopsis", "destructorsynopsis"], true)
+                    )
                 ) {
                     $innerXml = $r->readInnerXml();
                 }

--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -117,7 +117,7 @@ class Render extends ObjectStorage
                         continue;
                     }
 
-                    if (strncmp($tag ?? '', "format_", 7) !== 0) {
+                    if (/* !($tag instanceof \Closure) && */ !str_starts_with($tag ?? '', "format_")) {
                         $data = $format->transformFromMap($open, $tag, $name, $attrs, $props);
                     } else {
                         $data = $format->{$tag}($open, $name, $attrs, $props);


### PR DESCRIPTION
while allowing the old markup to render.

@mallardduck @heiglandreas

I'll push an example of some doc-en changes that would render this markup.

From my testing (which is not the most extensive) nothing is broken.