### PR TITLE
Set LIBXML_PARSEHUGE

### DIFF
--- a/render.php
+++ b/render.php
@@ -76,7 +76,7 @@ $reader = make_reader();
 
 
 // Set reader LIBXML options
-$readerOpts = 0;
+$readerOpts = LIBXML_PARSEHUGE;
 if (Config::process_xincludes()) {
     $readerOpts |= LIBXML_XINCLUDE;
 }


### PR DESCRIPTION
I'm getting

```
[18:56:04 - E_WARNING             ] /home/niels/php-docs/phd/phpdotnet/phd/Render.php:49
	XMLReader::read(): /home/niels/php-docs/doc-base/.manual.xml:321087: parser error : internal error: Huge input lookup
[18:56:04 - E_WARNING             ] /home/niels/php-docs/phd/phpdotnet/phd/Render.php:49
	XMLReader::read():   <par
[18:56:04 - E_WARNING             ] /home/niels/php-docs/phd/phpdotnet/phd/Render.php:49
	XMLReader::read():   ^
```

if I don't pass this option, causing the docs build to fail.