### PR TITLE
Drop `\n` when highlighting

### DIFF
--- a/phpdotnet/phd/Highlighter.php
+++ b/phpdotnet/phd/Highlighter.php
@@ -63,7 +63,11 @@ class Highlighter
 
         if ($role == 'php') {
             try {
-                return str_replace('&nbsp;', ' ', highlight_string($text, 1));
+                $highlighted = highlight_string($text, 1);
+                $highlighted = str_replace('&nbsp;', ' ', $highlighted);
+                $highlighted = str_replace("\n", '', $highlighted);
+
+                return $highlighted;
             } catch (\ParseException $e) {
                 v("Parse error while highlighting PHP code: %s\nText: %s", (string) $e, $text, E_USER_WARNING);
 

--- a/phpdotnet/phd/Highlighter.php
+++ b/phpdotnet/phd/Highlighter.php
@@ -63,11 +63,10 @@ class Highlighter
 
         if ($role == 'php') {
             try {
-                $highlighted = highlight_string($text, 1);
-                $highlighted = str_replace('&nbsp;', ' ', $highlighted);
-                $highlighted = str_replace("\n", '', $highlighted);
-
-                return $highlighted;
+                return strtr(highlight_string($text, 1), [
+                    '&nbsp;' => ' ',
+                    "\n" => '',
+                ]);
             } catch (\ParseException $e) {
                 v("Parse error while highlighting PHP code: %s\nText: %s", (string) $e, $text, E_USER_WARNING);
 


### PR DESCRIPTION
In a second step the CSS will need to be adjusted.

------------

Actual newlines will be replaced by `<br />` during highlighting and the `\n` in the boilerplate conflicts with `white-space: pre;`.

see php/doc-en#2648