### PR TITLE
Detect and render `<emphasis role="strong|bold">` usage in manual

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -80,7 +80,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         ),
         'constructorsynopsis'   => 'format_methodsynopsis',
         'destructorsynopsis'    => 'format_methodsynopsis',
-        'emphasis'              => 'em',
+        'emphasis'              => 'format_emphasis',
         'enumname'              => 'span',
         'entry'                 => array (
             /* DEFAULT */          'format_entry',
@@ -1173,6 +1173,21 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $method;
     }
 
+    public function format_emphasis($open, $name, $attrs)
+    {
+        $name = "em";
+
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+            $role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
+            if ( $role == "strong" || $role == "bold" )
+                $name = "strong";
+        }
+
+        if ($open)
+            return "<{$name}>";
+        else
+            return "</{$name}>";
+    }
 
     public function format_fieldsynopsis($open, $name, $attrs) {
         $this->cchunk["fieldsynopsis"] = $this->dchunk["fieldsynopsis"];


### PR DESCRIPTION
`<emphasis role="strong">` and `<emphasis role="bold">` are used in manual (occurs ~600 times), but are rendered as same as `<emphasis>`.

This PR detects and render these cases as `<strong>` instead of `<em>`.

For example, in https://www.php.net/manual/en/features.commandline.options.php it's change from
![image](https://github.com/php/phd/assets/10078152/f55d9705-bb95-4840-bf66-4116b1ce22a8)
to
![image](https://github.com/php/phd/assets/10078152/9d8ab2f3-d8ff-4a8c-9a30-6ce3953f6613)

and in https://www.php.net/manual/en/mysqli.quickstart.dual-interface.php it's change from
![image](https://github.com/php/phd/assets/10078152/b834d484-02ed-403d-8cc5-2937743dcb8f)
to
![image](https://github.com/php/phd/assets/10078152/09ec72ab-a161-4a1b-972d-0aa7e9d5fe43)
