### PR TITLE
Support standard DocBook annotations XML attribute for chunking

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -357,8 +357,15 @@ SQL;
                 $this->isChunk[] = false;
                 return false;
             }
-            $this->isChunk[] = isset($attrs[Reader::XMLNS_PHD]['chunk'])
-                    ? $attrs[Reader::XMLNS_PHD]['chunk'] == "true" : true;
+
+            /* Legacy way to mark chunks */
+            if (isset($attrs[Reader::XMLNS_PHD]['chunk'])) {
+                $this->isChunk[] = $attrs[Reader::XMLNS_PHD]['chunk'] == "true";
+            } elseif (isset($attrs[Reader::XMLNS_DOCBOOK]['annotations'])) {
+                $this->isChunk[] = !str_contains($attrs[Reader::XMLNS_DOCBOOK]['annotations'], 'chunk:false');
+            } else {
+                $this->isChunk[] = true;
+            }
 
             if (end($this->isChunk)) {
                 $this->chunks[] = $id;

--- a/phpdotnet/phd/Package/Generic/TocFeed.php
+++ b/phpdotnet/phd/Package/Generic/TocFeed.php
@@ -311,9 +311,14 @@ abstract class Package_Generic_TocFeed extends Format
             return '';
         }
 
-        if (isset($attrs[Reader::XMLNS_PHD]['chunk'])
-            && $attrs[Reader::XMLNS_PHD]['chunk'] == 'false'
-        ) {
+        $isChunked = true;
+        /* Legacy way to mark chunks */
+        if (isset($attrs[Reader::XMLNS_PHD]['chunk'])) {
+            $isChunked = $attrs[Reader::XMLNS_PHD]['chunk'] != 'false';
+        } elseif (isset($attrs[Reader::XMLNS_DOCBOOK]['annotations'])) {
+            $isChunked = !str_contains($attrs[Reader::XMLNS_DOCBOOK]['annotations'], 'chunk:false');
+        }
+        if (!$isChunked) {
             //not chunked? no feed!
             return '';
         }


### PR DESCRIPTION
This would allow us to use more conformant DocBook markup in the docs

This ignores the PEAR and Generic/XHTML renderers.