### PR TITLE
Add support to render refentry tags as class and variable wrappers

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -34,7 +34,7 @@ class Index extends Format
     'phpdoc:classref'       => 'format_container_chunk',
     'phpdoc:varentry'       => 'format_chunk',
     'preface'               => 'format_chunk',
-    'refentry'              => 'format_chunk',
+    'refentry'              => 'format_refentry',
     'reference'             => 'format_container_chunk',
     'sect1'                 => 'format_chunk',
     'section'               => array(
@@ -338,6 +338,20 @@ SQL;
                 $this->currentMembership = null;
             }
             return $this->format_chunk($open, $name, $attrs, $props);
+        }
+        return $this->format_chunk($open, $name, $attrs, $props);
+    }
+
+    public function format_refentry($open, $name, $attrs, $props) {
+        /* Note role attribute also has usage with "noversion" to not check version availability */
+        /* We overwrite the tag name to continue working with the usual indexing */
+        if (array_key_exists('role', $attrs)) {
+            return match ($attrs['role']) {
+                'class', 'enum' => $this->format_container_chunk($open, 'phpdoc:classref', $attrs, $props),
+                'exception' => $this->format_container_chunk($open, 'phpdoc:exceptionref', $attrs, $props),
+                'variable' => $this->format_chunk($open, 'phpdoc:varentry', $attrs, $props),
+                default => $this->format_chunk($open, $name, $attrs, $props),
+            };
         }
         return $this->format_chunk($open, $name, $attrs, $props);
     }

--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -345,8 +345,8 @@ SQL;
     public function format_refentry($open, $name, $attrs, $props) {
         /* Note role attribute also has usage with "noversion" to not check version availability */
         /* We overwrite the tag name to continue working with the usual indexing */
-        if (array_key_exists('role', $attrs)) {
-            return match ($attrs['role']) {
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+            return match ($attrs[Reader::XMLNS_DOCBOOK]['role']) {
                 'class', 'enum' => $this->format_container_chunk($open, 'phpdoc:classref', $attrs, $props),
                 'exception' => $this->format_container_chunk($open, 'phpdoc:exceptionref', $attrs, $props),
                 'variable' => $this->format_chunk($open, 'phpdoc:varentry', $attrs, $props),

--- a/phpdotnet/phd/Package/PHP/TocFeed.php
+++ b/phpdotnet/phd/Package/PHP/TocFeed.php
@@ -24,6 +24,7 @@ class Package_PHP_TocFeed extends Package_Generic_TocFeed
         'phpdoc:classref'       => 'format_chunk',
         'phpdoc:exceptionref'   => 'format_chunk',
         'phpdoc:varentry'       => 'format_chunk',
+        'refentry'              => 'format_chunk',
         'section'               => array(
             /* DEFAULT */          false,
             'sect1'                => 'format_chunk',

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -888,15 +888,17 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     public function format_refentry($open, $name, $attrs, $props) {
         /* Note role attribute also has usage with "noversion" to not check version availability */
         /* TODO This should be migrated to the annotations attribute */
-        if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]["annotations"])) {
+            $this->cchunk["verinfo"] = !str_contains($attrs[Reader::XMLNS_DOCBOOK]["annotations"], 'verify_info:false');
+        } else if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
             $this->cchunk["verinfo"] = !($attrs[Reader::XMLNS_DOCBOOK]["role"] == "noversion");
         } else {
             $this->cchunk["verinfo"] = true;
         }
 
         /* We overwrite the tag name to continue working with the usual indexing */
-        if (array_key_exists('role', $attrs)) {
-            return match ($attrs['role']) {
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+            return match ($attrs[Reader::XMLNS_DOCBOOK]['role']) {
                 'class', 'enum', 'exception' => $this->format_class_chunk($open, 'reference', $attrs, $props),
                 'variable' => $this->format_chunk($open, 'refentry', $attrs, $props),
                 default => $this->format_chunk($open, $name, $attrs, $props),
@@ -908,11 +910,8 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     public function format_class_chunk($open, $name, $attrs, $props) {
         if ($open) {
             $retval = $this->format_container_chunk($open, "reference", $attrs, $props);
-            if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                $this->cchunk["verinfo"] = !($attrs[Reader::XMLNS_DOCBOOK]["role"] == "noversion");
-            } else {
-                $this->cchunk["verinfo"] = true;
-            }
+            /* Classes must have version availability information */
+            $this->cchunk["verinfo"] = true;
             return $retval;
         }
         return $this->format_container_chunk($open, "reference", $attrs, $props);


### PR DESCRIPTION
This is one of the last remaining stepping stone to make the PHP documentation use the standard DocBook spec.