### PR TITLE
Fix constants link broken

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -63,9 +63,9 @@ class Index extends Format
     'titleabbrev'           => 'format_sdesc',
     'example'               => 'format_example',
     'refsect1'              => 'format_refsect1',
-    "row"                   => array(
+    'tbody'                 => array(
         /* DEFAULT */          null,
-        "tbody"             => 'format_row',
+        'row'               => 'format_row',
     ),
     'entry'                 => array(
         /* DEFAULT */          null,

--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -88,7 +88,7 @@ class Render extends ObjectStorage
                     "lang"     => $r->xmlLang,
                     "ns"       => $r->namespaceURI,
                     "sibling"  => $lastdepth >= $depth ? $this->STACK[$depth] : "",
-                    "innerXml"  => $innerXml,
+                    "innerXml" => $innerXml,
                     "depth"    => $depth,
                 );
 


### PR DESCRIPTION
Fix #87 

<img width="459" alt="image" src="https://github.com/php/phd/assets/33931153/c70698a0-8fed-446e-8877-17e8dd69f5e9">


btw, there seems to be a problem with all the `<row xml:id` links.

e,g. https://www.php.net/manual/en/tokens.php

The `__TRAIT__` link is the current page and is correct after the fix.

<img width="626" alt="image" src="https://github.com/php/phd/assets/33931153/48721ecd-cb8b-4469-a6d4-ffe0b95db682">

--- 

Sorry, I committed to master by mistake. 😅 934be12873ce67e9db19586919afb2a45d791c91