### PR TITLE
Fix tests

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1,6 +1,7 @@
 <?php
 namespace phpdotnet\phd;
 
+#[\AllowDynamicProperties]
 abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     private $myelementmap = array( /* {{{ */
         'abstract'              => 'div', /* Docbook-xsl prints "abstract"... */
@@ -794,7 +795,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $this->CURRENT_CHUNK = $id;
         $this->notify(Render::CHUNK, Render::CLOSE);
         $toc = "";
-        if (!in_array($id, $this->TOC_WRITTEN)) {
+        if (!in_array($id, $this->TOC_WRITTEN ?? [])) {
             $toc = $this->createTOC($id, $name, $props);
         }
 
@@ -832,7 +833,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
         $toc = '<ol>';
         $desc = "";
-        if (!in_array($id, $this->TOC_WRITTEN)) {
+        if (!in_array($id, $this->TOC_WRITTEN ?? [])) {
             $toc = $this->createTOC($id, $name, $props);
         }
         $toc .= "</ol>\n";

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -766,7 +766,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     }
 
     public function format_container_chunk($open, $name, $attrs, $props) {
-        $this->CURRENT_CHUNK = $this->CURRENT_ID = $id = $attrs[Reader::XMLNS_XML]["id"];
+        $this->CURRENT_CHUNK = $this->CURRENT_ID = $id = $attrs[Reader::XMLNS_XML]["id"] ?? '';
 
         if ($this->isChunkedByAttributes($attrs)) {
             $this->cchunk = $this->dchunk;
@@ -809,7 +809,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     }
 
     public function format_root_chunk($open, $name, $attrs) {
-        $this->CURRENT_CHUNK = $this->CURRENT_ID = $id = $attrs[Reader::XMLNS_XML]["id"];
+        $this->CURRENT_CHUNK = $this->CURRENT_ID = $id = $attrs[Reader::XMLNS_XML]["id"] ?? '';
         if ($open) {
             $this->notify(Render::CHUNK, Render::OPEN);
             return '<div id="'.$id.'" class="'.$name.'">';

--- a/tests/php/bug49101-1.phpt
+++ b/tests/php/bug49101-1.phpt
@@ -5,7 +5,6 @@ Bug #49101 - Thick border again
 namespace phpdotnet\phd;
 
 require_once __DIR__ . "/../setup.php";
-require_once __DIR__ . "/../TestRender.php";
 require_once __DIR__ . "/TestChunkedXHTML.php";
 
 $formatclass = "TestChunkedXHTML";
@@ -25,6 +24,11 @@ $extra = array(
 );
 
 $render = new TestRender($formatclass, $opts, $extra);
+
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
+}
+
 $render->run();
 ?>
 --EXPECT--

--- a/tests/php/bug49101-2.phpt
+++ b/tests/php/bug49101-2.phpt
@@ -5,7 +5,6 @@ Bug #49101 - Thick border again - Big XHTML
 namespace phpdotnet\phd;
 
 require_once __DIR__ . "/../setup.php";
-require_once __DIR__ . "/../TestRender.php";
 require_once __DIR__ . "/TestBigXHTML.php";
 
 $formatclass = "TestBigXHTML";
@@ -25,6 +24,11 @@ $extra = array(
 );
 
 $render = new TestRender($formatclass, $opts, $extra);
+
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
+}
+
 $render->run();
 ?>
 --EXPECTF--

--- a/tests/php/bug49102-1.phpt
+++ b/tests/php/bug49102-1.phpt
@@ -5,7 +5,6 @@ Bug #49102 - Class reference pages don't normalize the methodnames in PhD trunk/
 namespace phpdotnet\phd;
 
 require_once __DIR__ . "/../setup.php";
-require_once __DIR__ . "/../TestRender.php";
 require_once __DIR__ . "/TestChunkedXHTML.php";
 
 $formatclass = "TestChunkedXHTML";
@@ -26,6 +25,11 @@ $extra = array(
 );
 
 $test = new TestRender($formatclass, $opts, $extra);
+
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
+}
+
 $test->run();
 ?>
 
@@ -42,73 +46,40 @@ Content:
         <h2 class="title">Class synopsis</h2>
 
     <div class="classsynopsis">
-        <div class="ooclass"></div>
+        <span class="ooclass"><strong class="classname"></strong></span>
 
         <div class="classsynopsisinfo">
             <span class="ooclass">
-                <strong class="classname">SplStack</strong>
+                <span class="modifier">class</span> <strong class="classname">SplStack</strong>
             </span>
 
              <span class="ooclass">
                 <span class="modifier">extends</span>
-                <strong class="classname">SplDoublyLinkedList</strong>
+                 <strong class="classname">SplDoublyLinkedList</strong>
             </span>
 
-            <span class="oointerface">implements 
-                <span class="interfacename"><strong class="interfacename">Iterator</strong></span>
-            </span>
-
-            <span class="oointerface">, 
-                <span class="interfacename"><strong class="interfacename">ArrayAccess</strong></span>
-            </span>
-
-            <span class="oointerface">, 
-                <span class="interfacename"><strong class="interfacename">Countable</strong></span>
-            </span>
-         {</div>
+            <span class="oointerface"><span class="modifier">implements</span> 
+                 <strong class="interfacename">Iterator</strong></span><span class="oointerface">,  <strong class="interfacename">ArrayAccess</strong></span><span class="oointerface">,  <strong class="interfacename">Countable</strong></span> {</div>
 
         <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
         <div class="constructorsynopsis dc-description">
-             <span class="methodname"><strong>__construct</strong></span>
-             ( <span class="methodparam">void</span>
-         )</div>
+            <span class="methodname"><strong>__construct</strong></span>()</div>
 
-        <div class="methodsynopsis dc-description">
-            <span class="type">void</span> <span class="methodname"><strong>setIteratorMode</strong></span>
-             ( <span class="methodparam"><span class="type">int</span> <code class="parameter">$mode</code></span>
-         )</div>
+        <div class="methodsynopsis dc-description"><span class="methodname"><strong>setIteratorMode</strong></span>(<span class="methodparam"><span class="type">int</span> <code class="parameter">$mode</code></span>): <span class="type"><span class="type void">void</span></span></div>
 
 
         <div class="classsynopsisinfo classsynopsisinfo_comment">/* Inherited methods */</div>
-        <div class="methodsynopsis dc-description">
-            <span class="type">mixed</span> <span class="methodname"><strong>SplDoublyLinkedList::bottom</strong></span>
-             ( <span class="methodparam">void</span>
-         )</div>
+        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::bottom</strong></span>(): <span class="type"><a href="language.types.declarations.html#language.types.declarations.mixed" class="type mixed">mixed</a></span></div>
 
-        <div class="methodsynopsis dc-description">
-            <span class="type">int</span> <span class="methodname"><strong>SplDoublyLinkedList::count</strong></span>
-             ( <span class="methodparam">void</span>
-         )</div>
+        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::count</strong></span>(): <span class="type">int</span></div>
 
-        <div class="methodsynopsis dc-description">
-            <span class="type">mixed</span> <span class="methodname"><strong>SplDoublyLinkedList::current</strong></span>
-             ( <span class="methodparam">void</span>
-         )</div>
+        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::current</strong></span>(): <span class="type"><a href="language.types.declarations.html#language.types.declarations.mixed" class="type mixed">mixed</a></span></div>
 
-        <div class="methodsynopsis dc-description">
-            <span class="type">int</span> <span class="methodname"><strong>SplDoublyLinkedList::getIteratorMode</strong></span>
-             ( <span class="methodparam">void</span>
-         )</div>
+        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::getIteratorMode</strong></span>(): <span class="type">int</span></div>
 
-        <div class="methodsynopsis dc-description">
-            <span class="type">bool</span> <span class="methodname"><strong>SplDoublyLinkedList::offsetExists</strong></span>
-             ( <span class="methodparam"><span class="type"><a href="language.pseudo-types.html#language.types.mixed" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>
-         )</div>
+        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::offsetExists</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.declarations.html#language.types.declarations.mixed" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>): <span class="type">bool</span></div>
 
-        <div class="methodsynopsis dc-description">
-            <span class="type">mixed</span> <span class="methodname"><strong>SplDoublyLinkedList::offsetGet</strong></span>
-             ( <span class="methodparam"><span class="type"><a href="language.pseudo-types.html#language.types.mixed" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>
-         )</div>
+        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::offsetGet</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.declarations.html#language.types.declarations.mixed" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>): <span class="type"><a href="language.types.declarations.html#language.types.declarations.mixed" class="type mixed">mixed</a></span></div>
 
     }</div>
 

--- a/tests/php/faq001.phpt
+++ b/tests/php/faq001.phpt
@@ -5,7 +5,6 @@ Testing a simple FAQ
 namespace phpdotnet\phd;
 
 require_once __DIR__ . "/../setup.php";
-require_once __DIR__ . "/../TestRender.php";
 require_once __DIR__ . "/TestChunkedXHTML.php";
 
 $formatclass = "TestChunkedXHTML";
@@ -25,6 +24,11 @@ $extra = array(
 );
 
 $render = new TestRender($formatclass, $opts, $extra);
+
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
+}
+
 $render->run();
 ?>
 --EXPECT--

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -1,19 +1,24 @@
 <?php
 namespace phpdotnet\phd;
 
-function autoload($name) {
-    $file = __DIR__ . "/../" . str_replace(array('\\', '_'), '/', $name) . '.php';
-    if (!$fp = fopen($file,'r', true)) {
-        throw new \Exception('Cannot find file for ' . $name . ': ' . $file);
-    }
-    fclose($fp);
-    require $file;
+define("__PHDDIR__", __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR);
+define("__INSTALLDIR__", "@php_dir@" == "@"."php_dir@" ? dirname(dirname(__DIR__)) : "@php_dir@");
 
-}
-spl_autoload_register(__NAMESPACE__ . '\\autoload');
+require_once __PHDDIR__ . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "Autoloader.php";
+require_once __PHDDIR__ . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "functions.php";
+require_once __PHDDIR__ . "tests" . DIRECTORY_SEPARATOR . "TestRender.php";
 
-require_once __DIR__ . "/../phpdotnet/phd/functions.php";
-require_once __DIR__ . "/../phpdotnet/phd/Config.php";
+spl_autoload_register(["phpdotnet\\phd\\Autoloader", "autoload"]);
+
+Config::init([
+    "lang_dir"  => __PHDDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPARATOR
+                    . "phd" . DIRECTORY_SEPARATOR . "data" . DIRECTORY_SEPARATOR
+                    . "langs" . DIRECTORY_SEPARATOR,
+    "phpweb_version_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'version.xml',
+    "phpweb_acronym_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'entities' . DIRECTORY_SEPARATOR . 'acronyms.xml',
+    "phpweb_sources_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'sources.xml',
+    "package_dirs" => [__PHDDIR__, __INSTALLDIR__],
+]);
 
 /*
 * vim600: sw=4 ts=4 syntax=php et

--- a/tests/xhtml/002.phpt
+++ b/tests/xhtml/002.phpt
@@ -2,470 +2,210 @@
 CALS Table rendering#002
 --FILE--
 <?php
+namespace phpdotnet\phd;
 
-require "include/PhDReader.class.php";
-require "include/PhDFormat.class.php";
-require "formats/xhtml.php";
+require_once __DIR__ . "/../setup.php";
+require_once __DIR__ . "/TestChunkedXHTML.php";
 
-$reader = new PhDReader(dirname(__FILE__) ."/data/002.xml");
-$format = new XHTMLPhDFormat($reader, array(), array());
+$formatclass = "TestChunkedXHTML";
+$xml_file = __DIR__ . "/data/002.xml";
 
-$map = $format->getMap();
+$opts = array(
+    "index"             => true,
+    "xml_root"          => dirname($xml_file),
+    "xml_file"          => $xml_file,
+    "output_dir"        => __DIR__ . "/output/",
+);
 
-while($reader->read()) {
-    $type = $reader->nodeType;
-    $name = $reader->name;
+$extra = array(
+    "lang_dir" => __PHDDIR__ . "phpdotnet/phd/data/langs/",
+    "phpweb_version_filename" => dirname($xml_file) . '/version.xml',
+    "phpweb_acronym_filename" => dirname($xml_file) . '/acronyms.xml',
+);
 
-    switch($type) {
-    case XMLReader::ELEMENT:
-    case XMLReader::END_ELEMENT:
-        $open = $type == XMLReader::ELEMENT;
+$render = new TestRender($formatclass, $opts, $extra);
 
-        $funcname = "format_$name";
-        if (isset($map[$name])) {
-            $tag = $map[$name];
-            if (is_array($tag)) {
-                $tag = $reader->notXPath($tag);
-            }
-            if (strncmp($tag, "format_", 7)) {
-                $retval = $format->transformFromMap($open, $tag, $name);
-                break;
-            }
-            $funcname = $tag;
-        }
-
-        $retval = $format->{$funcname}($open, $name);
-        break;
-
-    case XMLReader::TEXT:
-        $retval = htmlspecialchars($reader->value, ENT_QUOTES);
-        break;
-
-    case XMLReader::CDATA:
-        $retval = $format->CDATA($reader->value);
-        break;
-
-    case XMLReader::COMMENT:
-    case XMLReader::WHITESPACE:
-    case XMLReader::SIGNIFICANT_WHITESPACE:
-    case XMLReader::DOC_TYPE:
-        /* swallow it */
-        continue 2;
-
-    default:
-        trigger_error("Don't know how to handle {$name} {$type}", E_USER_ERROR);
-        return;
-    }
-    echo $retval, "\n";
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
 }
 
-$reader->close();
+$render->run();
 ?>
 --EXPECT--
+Filename: function.db2-set-option.html
+Content:
 <div id="function.db2-set-option" class="article">
-<table border="5">
-<h1 class="title">
-Resource-Parameter Matrix
-</h1>
-<colgroup>
+ <table class="doctable table">
+   <caption><strong>Resource-Parameter Matrix</strong></caption>
+   
+     <col style="text-align: center;" />
+     <col style="text-align: center;" />
+     <col style="text-align: center;" />
+     <col style="text-align: center;" />
+     <col style="text-align: center;" />
+     <thead>
+       <tr>
+         <th>Key</th>
+         <th>Value</th>
+         <th colspan="3">Resource Type</th>
+       </tr>
 
-<col align="center" />
-<col align="center" />
-<col align="center" />
-<col align="center" />
-<col align="center" />
-<thead valign="middle">
-<tr valign="middle">
-<th colspan="1">
-Key
-</th>
-<th colspan="1">
-Value
-</th>
-<th colspan="3">
-Resource Type
-</th>
-</tr>
+     </thead>
 
-</thead>
 
-<tbody valign="middle">
-<tr valign="middle">
-<td class="empty">&nbsp;</td><td class="empty">&nbsp;</td><td colspan="1" rowspan="1" align="left">
-Connection
-</td>
-<td colspan="1" rowspan="1" align="left">
-Statement
-</td>
-<td colspan="1" rowspan="1" align="left">
-Result Set
-</td>
-</tr>
+     <tbody class="tbody">
+       <tr>
+         <td class="empty">&nbsp;</td><td class="empty">&nbsp;</td><td>Connection</td>
+         <td>Statement</td>
+         <td>Result Set</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-autocommit
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_AUTOCOMMIT_ON
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>autocommit</td>
+         <td><code class="literal">DB2_AUTOCOMMIT_ON</code></td>
+         <td>X</td>
+         <td>-</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-autocommit
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_AUTOCOMMIT_OFF
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>autocommit</td>
+         <td><code class="literal">DB2_AUTOCOMMIT_OFF</code></td>
+         <td>X</td>
+         <td>-</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-cursor
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_SCROLLABLE
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>cursor</td>
+         <td><code class="literal">DB2_SCROLLABLE</code></td>
+         <td>-</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-cursor
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_FORWARD_ONLY
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>cursor</td>
+         <td><code class="literal">DB2_FORWARD_ONLY</code></td>
+         <td>-</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-binmode
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_BINARY
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>binmode</td>
+         <td><code class="literal">DB2_BINARY</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-binmode
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_CONVERT
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>binmode</td>
+         <td><code class="literal">DB2_CONVERT</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-binmode
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_PASSTHRU
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>binmode</td>
+         <td><code class="literal">DB2_PASSTHRU</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-db2_attr_case
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_CASE_LOWER
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>db2_attr_case</td>
+         <td><code class="literal">DB2_CASE_LOWER</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-db2_attr_case
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_CASE_UPPER
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>db2_attr_case</td>
+         <td><code class="literal">DB2_CASE_UPPER</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-db2_attr_case
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_CASE_NATURAL
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>db2_attr_case</td>
+         <td><code class="literal">DB2_CASE_NATURAL</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-deferred_prepare
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_DEFERRED_PREPARE_ON
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>deferred_prepare</td>
+         <td><code class="literal">DB2_DEFERRED_PREPARE_ON</code></td>
+         <td>-</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-deferred_prepare
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_DEFERRED_PREPARE_OFF
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>deferred_prepare</td>
+         <td><code class="literal">DB2_DEFERRED_PREPARE_OFF</code></td>
+         <td>-</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-i5_fetch_only
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_I5_FETCH_ON
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>i5_fetch_only</td>
+         <td><code class="literal">DB2_I5_FETCH_ON</code></td>
+         <td>-</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-i5_fetch_only
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-DB2_I5_FETCH_OFF
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>i5_fetch_only</td>
+         <td><code class="literal">DB2_I5_FETCH_OFF</code></td>
+         <td>-</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-userid
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-SQL_ATTR_INFO_USERID
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>userid</td>
+         <td><code class="literal">SQL_ATTR_INFO_USERID</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-acctstr
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-SQL_ATTR_INFO_ACCTSTR
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>acctstr</td>
+         <td><code class="literal">SQL_ATTR_INFO_ACCTSTR</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-applname
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-SQL_ATTR_INFO_APPLNAME
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>applname</td>
+         <td><code class="literal">SQL_ATTR_INFO_APPLNAME</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-wrkstnname
-</td>
-<td colspan="1" rowspan="1" align="left">
-<span class="literal">
-SQL_ATTR_INFO_WRKSTNNAME
-</span>
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
-X
-</td>
-<td colspan="1" rowspan="1" align="left">
--
-</td>
-</tr>
+       <tr>
+         <td>wrkstnname</td>
+         <td><code class="literal">SQL_ATTR_INFO_WRKSTNNAME</code></td>
+         <td>X</td>
+         <td>X</td>
+         <td>-</td>
+       </tr>
 
-</tbody>
-</colgroup>
-
-</table>
+     </tbody>
+   
+ </table>
 
 </div>
-

--- a/tests/xhtml/003.phpt
+++ b/tests/xhtml/003.phpt
@@ -2,547 +2,307 @@
 CALS Table rendering#003
 --FILE--
 <?php
+namespace phpdotnet\phd;
 
-require "include/PhDReader.class.php";
-require "include/PhDFormat.class.php";
-require "formats/xhtml.php";
+require_once __DIR__ . "/../setup.php";
+require_once __DIR__ . "/TestChunkedXHTML.php";
 
-$reader = new PhDReader(dirname(__FILE__) ."/data/003.xml");
-$format = new XHTMLPhDFormat($reader, array(), array());
+$formatclass = "TestChunkedXHTML";
+$xml_file = __DIR__ . "/data/003.xml";
 
-$map = $format->getMap();
+$opts = array(
+    "index"             => true,
+    "xml_root"          => dirname($xml_file),
+    "xml_file"          => $xml_file,
+    "output_dir"        => __DIR__ . "/output/",
+);
 
-while($reader->read()) {
-    $type = $reader->nodeType;
-    $name = $reader->name;
+$extra = array(
+    "lang_dir" => __PHDDIR__ . "phpdotnet/phd/data/langs/",
+    "phpweb_version_filename" => dirname($xml_file) . '/version.xml',
+    "phpweb_acronym_filename" => dirname($xml_file) . '/acronyms.xml',
+);
 
-    switch($type) {
-    case XMLReader::ELEMENT:
-    case XMLReader::END_ELEMENT:
-        $open = $type == XMLReader::ELEMENT;
+$render = new TestRender($formatclass, $opts, $extra);
 
-        $funcname = "format_$name";
-        if (isset($map[$name])) {
-            $tag = $map[$name];
-            if (is_array($tag)) {
-                $tag = $reader->notXPath($tag);
-            }
-            if (strncmp($tag, "format_", 7)) {
-                $retval = $format->transformFromMap($open, $tag, $name);
-                break;
-            }
-            $funcname = $tag;
-        }
-
-        $retval = $format->{$funcname}($open, $name);
-        break;
-
-    case XMLReader::TEXT:
-        $retval = htmlspecialchars($reader->value, ENT_QUOTES);
-        break;
-
-    case XMLReader::CDATA:
-        $retval = $format->CDATA($reader->value);
-        break;
-
-    case XMLReader::COMMENT:
-    case XMLReader::WHITESPACE:
-    case XMLReader::SIGNIFICANT_WHITESPACE:
-    case XMLReader::DOC_TYPE:
-        /* swallow it */
-        continue 2;
-
-    default:
-        trigger_error("Don't know how to handle {$name} {$type}", E_USER_ERROR);
-        return;
-    }
-    echo $retval, "\n";
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
 }
 
-$reader->close();
+$render->run();
 ?>
 --EXPECT--
+Filename: function.nl-langinfo.html
+Content:
 <div id="function.nl-langinfo" class="article">
-<table border="5">
-<h1 class="title">
-nl_langinfo Constants
-</h1>
-<colgroup>
+ <table class="doctable table">
+  <caption><strong>nl_langinfo Constants</strong></caption>
+  
+   <col />
+   <col />
+   <thead>
+    <tr>
+     <th>Constant</th>
+     <th>Description</th>
+    </tr>
 
-<col align="left" />
-<col align="left" />
-<thead valign="middle">
-<tr valign="middle">
-<th colspan="1">
-Constant
-</th>
-<th colspan="1">
-Description
-</th>
-</tr>
+   </thead>
 
-</thead>
+   <tbody class="tbody">
+    <tr>
+     <td colspan="2" style="text-align: center;"><em>LC_TIME Category Constants</em></td>
+    </tr>
 
-<tbody valign="middle">
-<tr valign="middle">
-<td colspan="2" rowspan="1" align="center">
-<em class="emphasis">
-LC_TIME Category Constants
-</em>
-</td>
-</tr>
+    <tr>
+     <td>ABDAY_(1-7)</td>
+     <td>Abbreviated name of n-th day of the week.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-ABDAY_(1-7)
-</td>
-<td colspan="1" rowspan="1" align="left">
-Abbreviated name of n-th day of the week.
-</td>
-</tr>
+    <tr>
+     <td>DAY_(1-7)</td>
+     <td>Name of the n-th day of the week (DAY_1 = Sunday).</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-DAY_(1-7)
-</td>
-<td colspan="1" rowspan="1" align="left">
-Name of the n-th day of the week (DAY_1 = Sunday).
-</td>
-</tr>
+    <tr>
+     <td>ABMON_(1-12)</td>
+     <td>Abbreviated name of the n-th month of the year.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-ABMON_(1-12)
-</td>
-<td colspan="1" rowspan="1" align="left">
-Abbreviated name of the n-th month of the year.
-</td>
-</tr>
+    <tr>
+     <td>MON_(1-12)</td>
+     <td>Name of the n-th month of the year.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-MON_(1-12)
-</td>
-<td colspan="1" rowspan="1" align="left">
-Name of the n-th month of the year.
-</td>
-</tr>
+    <tr>
+     <td>AM_STR</td>
+     <td>String for Ante meridian.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-AM_STR
-</td>
-<td colspan="1" rowspan="1" align="left">
-String for Ante meridian.
-</td>
-</tr>
+    <tr>
+     <td>PM_STR</td>
+     <td>String for Post meridian.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-PM_STR
-</td>
-<td colspan="1" rowspan="1" align="left">
-String for Post meridian.
-</td>
-</tr>
+    <tr>
+     <td>D_T_FMT</td>
+     <td>String that can be used as the format string for <span class="function">strftime</span> to represent time and date.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-D_T_FMT
-</td>
-<td colspan="1" rowspan="1" align="left">
-String that can be used as the format string for
-<a href="function.strftime.html">strftime</a>
- to represent time and date.
-</td>
-</tr>
+    <tr>
+     <td>D_FMT</td>
+     <td>String that can be used as the format string for <span class="function">strftime</span> to represent date.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-D_FMT
-</td>
-<td colspan="1" rowspan="1" align="left">
-String that can be used as the format string for
-<a href="function.strftime.html">strftime</a>
- to represent date.
-</td>
-</tr>
+    <tr>
+     <td>T_FMT</td>
+     <td>String that can be used as the format string for <span class="function">strftime</span> to represent time.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-T_FMT
-</td>
-<td colspan="1" rowspan="1" align="left">
-String that can be used as the format string for
-<a href="function.strftime.html">strftime</a>
- to represent time.
-</td>
-</tr>
+    <tr>
+     <td>T_FMT_AMPM</td>
+     <td>String that can be used as the format string for <span class="function">strftime</span> to represent time in 12-hour format with ante/post meridian.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-T_FMT_AMPM
-</td>
-<td colspan="1" rowspan="1" align="left">
-String that can be used as the format string for
-<a href="function.strftime.html">strftime</a>
- to represent time in 12-hour format with ante/post meridian.
-</td>
-</tr>
+    <tr>
+     <td>ERA</td>
+     <td>Alternate era.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-ERA
-</td>
-<td colspan="1" rowspan="1" align="left">
-Alternate era.
-</td>
-</tr>
+    <tr>
+     <td>ERA_YEAR</td>
+     <td>Year in alternate era format.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-ERA_YEAR
-</td>
-<td colspan="1" rowspan="1" align="left">
-Year in alternate era format.
-</td>
-</tr>
+    <tr>
+     <td>ERA_D_T_FMT</td>
+     <td>Date and time in alternate era format (string can be used in <span class="function">strftime</span>).</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-ERA_D_T_FMT
-</td>
-<td colspan="1" rowspan="1" align="left">
-Date and time in alternate era format (string can be used in
-<a href="function.strftime.html">strftime</a>
-).
-</td>
-</tr>
+    <tr>
+     <td>ERA_D_FMT</td>
+     <td>Date in alternate era format (string can be used in <span class="function">strftime</span>).</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-ERA_D_FMT
-</td>
-<td colspan="1" rowspan="1" align="left">
-Date in alternate era format (string can be used in
-<a href="function.strftime.html">strftime</a>
-).
-</td>
-</tr>
+    <tr>
+     <td>ERA_T_FMT</td>
+     <td>Time in alternate era format (string can be used in <span class="function">strftime</span>).</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-ERA_T_FMT
-</td>
-<td colspan="1" rowspan="1" align="left">
-Time in alternate era format (string can be used in
-<a href="function.strftime.html">strftime</a>
-).
-</td>
-</tr>
+    <tr>
+     <td colspan="2" style="text-align: center;"><em>LC_MONETARY Category Constants</em></td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="2" rowspan="1" align="center">
-<em class="emphasis">
-LC_MONETARY Category Constants
-</em>
-</td>
-</tr>
+    <tr>
+     <td>INT_CURR_SYMBOL</td>
+     <td>International currency symbol.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-INT_CURR_SYMBOL
-</td>
-<td colspan="1" rowspan="1" align="left">
-International currency symbol.
-</td>
-</tr>
+    <tr>
+     <td>CURRENCY_SYMBOL</td>
+     <td>Local currency symbol.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-CURRENCY_SYMBOL
-</td>
-<td colspan="1" rowspan="1" align="left">
-Local currency symbol.
-</td>
-</tr>
+    <tr>
+     <td>CRNCYSTR</td>
+     <td>Same value as CURRENCY_SYMBOL.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-CRNCYSTR
-</td>
-<td colspan="1" rowspan="1" align="left">
-Same value as CURRENCY_SYMBOL.
-</td>
-</tr>
+    <tr>
+     <td>MON_DECIMAL_POINT</td>
+     <td>Decimal point character.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-MON_DECIMAL_POINT
-</td>
-<td colspan="1" rowspan="1" align="left">
-Decimal point character.
-</td>
-</tr>
+    <tr>
+     <td>MON_THOUSANDS_SEP</td>
+     <td>Thousands separator (groups of three digits).</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-MON_THOUSANDS_SEP
-</td>
-<td colspan="1" rowspan="1" align="left">
-Thousands separator (groups of three digits).
-</td>
-</tr>
+    <tr>
+     <td>MON_GROUPING</td>
+     <td>Like &#039;grouping&#039; element.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-MON_GROUPING
-</td>
-<td colspan="1" rowspan="1" align="left">
-Like &#039;grouping&#039; element.
-</td>
-</tr>
+    <tr>
+     <td>POSITIVE_SIGN</td>
+     <td>Sign for positive values.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-POSITIVE_SIGN
-</td>
-<td colspan="1" rowspan="1" align="left">
-Sign for positive values.
-</td>
-</tr>
+    <tr>
+     <td>NEGATIVE_SIGN</td>
+     <td>Sign for negative values.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-NEGATIVE_SIGN
-</td>
-<td colspan="1" rowspan="1" align="left">
-Sign for negative values.
-</td>
-</tr>
+    <tr>
+     <td>INT_FRAC_DIGITS</td>
+     <td>International fractional digits.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-INT_FRAC_DIGITS
-</td>
-<td colspan="1" rowspan="1" align="left">
-International fractional digits.
-</td>
-</tr>
+    <tr>
+     <td>FRAC_DIGITS</td>
+     <td>Local fractional digits.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-FRAC_DIGITS
-</td>
-<td colspan="1" rowspan="1" align="left">
-Local fractional digits.
-</td>
-</tr>
+    <tr>
+     <td>P_CS_PRECEDES</td>
+     <td>Returns 1 if CURRENCY_SYMBOL precedes a positive value.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-P_CS_PRECEDES
-</td>
-<td colspan="1" rowspan="1" align="left">
-Returns 1 if CURRENCY_SYMBOL precedes a positive value.
-</td>
-</tr>
+    <tr>
+     <td>P_SEP_BY_SPACE</td>
+     <td>Returns 1 if a space separates CURRENCY_SYMBOL from a positive value.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-P_SEP_BY_SPACE
-</td>
-<td colspan="1" rowspan="1" align="left">
-Returns 1 if a space separates CURRENCY_SYMBOL from a positive value.
-</td>
-</tr>
+    <tr>
+     <td>N_CS_PRECEDES</td>
+     <td>Returns 1 if CURRENCY_SYMBOL precedes a negative value.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-N_CS_PRECEDES
-</td>
-<td colspan="1" rowspan="1" align="left">
-Returns 1 if CURRENCY_SYMBOL precedes a negative value.
-</td>
-</tr>
+    <tr>
+     <td>N_SEP_BY_SPACE</td>
+     <td>Returns 1 if a space separates CURRENCY_SYMBOL from a negative value.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-N_SEP_BY_SPACE
-</td>
-<td colspan="1" rowspan="1" align="left">
-Returns 1 if a space separates CURRENCY_SYMBOL from a negative value.
-</td>
-</tr>
-
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-P_SIGN_POSN
-</td>
-<td colspan="1" rowspan="2" align="left" valign="middle">
-<ul class="itemizedlist">
-<li class="listitem">
-<p class="simpara">
-
+    <tr>
+     <td>P_SIGN_POSN</td>
+     <td rowspan="2" style="vertical-align: middle;">
+      <ul class="itemizedlist">
+       <li class="listitem">
+        <span class="simpara">
           Returns 0 if parentheses surround the quantity and currency_symbol.
-
-</p>
-</li>
-<li class="listitem">
-<p class="simpara">
-
+        </span>
+       </li>
+       <li class="listitem">
+        <span class="simpara">
          Returns 1 if the sign string precedes the quantity and currency_symbol.
-
-</p>
-</li>
-<li class="listitem">
-<p class="simpara">
-
+        </span>
+       </li>
+       <li class="listitem">
+        <span class="simpara">
          Returns 2 if the sign string follows the quantity and currency_symbol.
-
-</p>
-</li>
-<li class="listitem">
-<p class="simpara">
-
+        </span>
+       </li>
+       <li class="listitem">
+        <span class="simpara">
          Returns 3 if the sign string immediately precedes the currency_symbol.
-
-</p>
-</li>
-<li class="listitem">
-<p class="simpara">
-
+        </span>
+       </li>
+       <li class="listitem">
+        <span class="simpara">
          Returns 4 if the sign string immediately follows the currency_symbol.
+        </span>
+       </li>
+      </ul>
+     </td>
+    </tr>
 
-</p>
-</li>
-</ul>
-</td>
-</tr>
+    <tr>
+     <td>N_SIGN_POSN</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-N_SIGN_POSN
-</td>
-</tr>
+    <tr>
+     <td colspan="2" style="text-align: center;"><em>LC_NUMERIC Category Constants</em></td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="2" rowspan="1" align="center">
-<em class="emphasis">
-LC_NUMERIC Category Constants
-</em>
-</td>
-</tr>
+    <tr>
+     <td>DECIMAL_POINT</td>
+     <td>Decimal point character.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-DECIMAL_POINT
-</td>
-<td colspan="1" rowspan="1" align="left">
-Decimal point character.
-</td>
-</tr>
+    <tr>
+     <td>RADIXCHAR</td>
+     <td>Same value as DECIMAL_POINT.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-RADIXCHAR
-</td>
-<td colspan="1" rowspan="1" align="left">
-Same value as DECIMAL_POINT.
-</td>
-</tr>
+    <tr>
+     <td>THOUSANDS_SEP</td>
+     <td>Separator character for thousands (groups of three digits).</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-THOUSANDS_SEP
-</td>
-<td colspan="1" rowspan="1" align="left">
-Separator character for thousands (groups of three digits).
-</td>
-</tr>
+    <tr>
+     <td>THOUSEP</td>
+     <td>Same value as THOUSANDS_SEP.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-THOUSEP
-</td>
-<td colspan="1" rowspan="1" align="left">
-Same value as THOUSANDS_SEP.
-</td>
-</tr>
+    <tr>
+     <td>GROUPING</td>
+     <td></td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-GROUPING
-</td>
-<td colspan="1" rowspan="1" align="left">
-</td>
-</tr>
+    <tr>
+     <td colspan="2" style="text-align: center;"><em>LC_MESSAGES Category Constants</em></td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="2" rowspan="1" align="center">
-<em class="emphasis">
-LC_MESSAGES Category Constants
-</em>
-</td>
-</tr>
+    <tr>
+     <td>YESEXPR</td>
+     <td>Regex string for matching &#039;yes&#039; input.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-YESEXPR
-</td>
-<td colspan="1" rowspan="1" align="left">
-Regex string for matching &#039;yes&#039; input.
-</td>
-</tr>
+    <tr>
+     <td>NOEXPR</td>
+     <td>Regex string for matching &#039;no&#039; input.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-NOEXPR
-</td>
-<td colspan="1" rowspan="1" align="left">
-Regex string for matching &#039;no&#039; input.
-</td>
-</tr>
+    <tr>
+     <td>YESSTR</td>
+     <td>Output string for &#039;yes&#039;.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-YESSTR
-</td>
-<td colspan="1" rowspan="1" align="left">
-Output string for &#039;yes&#039;.
-</td>
-</tr>
+    <tr>
+     <td>NOSTR</td>
+     <td>Output string for &#039;no&#039;.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-NOSTR
-</td>
-<td colspan="1" rowspan="1" align="left">
-Output string for &#039;no&#039;.
-</td>
-</tr>
+    <tr>
+     <td colspan="2" style="text-align: center;"><em>LC_CTYPE Category Constants</em></td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="2" rowspan="1" align="center">
-<em class="emphasis">
-LC_CTYPE Category Constants
-</em>
-</td>
-</tr>
+    <tr>
+     <td>CODESET</td>
+     <td>Return a string with the name of the character encoding.</td>
+    </tr>
 
-<tr valign="middle">
-<td colspan="1" rowspan="1" align="left">
-CODESET
-</td>
-<td colspan="1" rowspan="1" align="left">
-Return a string with the name of the character encoding.
-</td>
-</tr>
-
-</tbody>
-</colgroup>
-
-</table>
+   </tbody>
+  
+ </table>
 
 </div>
-

--- a/tests/xhtml/TestChunkedXHTML.php
+++ b/tests/xhtml/TestChunkedXHTML.php
@@ -1,7 +1,7 @@
 <?php
 namespace phpdotnet\phd;
 
-class TestChunkedXHTML extends Package_PHP_ChunkedXHTML {
+class TestChunkedXHTML extends Package_Generic_ChunkedXHTML {
     public function update($event, $val = null) {
         switch($event) {
         case Render::CHUNK:


### PR DESCRIPTION
This PR fixes existing tests with the following changes:

 - refactor existing `setup.php` to use existing autoloader and initialize basic configuration options
 - add test format from `php` to `xhtml` tests
 - use existing `TestRender` for all tests (as opposed to custom renderer in each one)
 - fix minor format specific issues with dynamic properties and uninitialized arrays
 - update all tests of which the underlying formatting has changed in Phd