### PR TITLE
Implement simplelist attributes

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -143,7 +143,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         'methodparam'           => 'format_methodparam',
         'methodsynopsis'        => 'format_methodsynopsis',
         'methodname'            => 'format_methodname',
-        'member'                => 'li',
+        'member'                => 'format_member',
         'modifier'              => 'span',
         'note'                  => 'format_note',
         'orgname'               => 'span',
@@ -269,7 +269,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         'setindex'              => 'format_chunk',
         'shortaffil'            => 'format_suppressed_tags',
         'sidebar'               => 'format_note',
-        'simplelist'            => 'format_itemizedlist', /* FIXME: simplelists has few attributes that need to be implemented */
+        'simplelist'            => 'format_simplelist', /* FIXME: simplelists has few attributes that need to be implemented */
         'simplesect'            => 'div',
         'simpara'               => array(
             /* DEFAULT */          'p',
@@ -446,6 +446,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         'literal'               => 'format_literal_text',
         'email'                 => 'format_email_text',
         'titleabbrev'           => 'format_suppressed_text',
+        'member'                => 'format_member_text',
     );
 
     /** @var array */
@@ -500,6 +501,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         "chunk_id"                 => null,
         "varlistentry"             => array(
             "listitems"                     => array(),
+        ),
+        "simplelist"               => array(
+            "members"              => array(),
+            "type"                 => null,
+            "columns"              => null,
         ),
     );
 
@@ -2040,6 +2046,110 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</ul>';
     }
 
+    public function format_simplelist($open, $name, $attrs, $props) {
+        if ($open) {
+            $this->cchunk["simplelist"]["type"] = $attrs[Reader::XMLNS_DOCBOOK]["type"] ?? "";
+            $this->cchunk["simplelist"]["columns"] = $attrs[Reader::XMLNS_DOCBOOK]["columns"] ?? 1;
+
+            if ($this->cchunk["simplelist"]["columns"] < 1) {
+                $this->cchunk["simplelist"]["columns"] = 1;
+            }
+
+            if ($this->cchunk["simplelist"]["type"] === "inline") {
+                return '<span class="' . $name . '">';
+            } else if ($this->cchunk["simplelist"]["type"] === "vert" || $this->cchunk["simplelist"]["type"] === "horiz") {
+                return '<table class="' . $name . '">' . "\n" . str_repeat(" ", $props["depth"] + 1) . "<tbody>\n";
+            }
+
+            return '<ul class="' . $name . '">';
+        }
+
+        if ($this->cchunk["simplelist"]["type"] === "inline") {
+            $list = "";
+            foreach ($this->cchunk["simplelist"]["members"] as $member) {
+                $list .= $member . ", ";
+            }
+            $list = rtrim($list, ", ");
+
+            $this->cchunk["simplelist"] = $this->dchunk["simplelist"];
+            return $list . '</span>';
+
+        }
+
+        if ($this->cchunk["simplelist"]["type"] === "horiz") {
+
+            $table = "";
+            for ($i = 0; $i < count($this->cchunk["simplelist"]["members"]); $i++) {
+                if ($i % $this->cchunk["simplelist"]["columns"] === 0) {
+                    $table .= str_repeat(" ", $props["depth"] + 2) . "<tr>\n";
+                }
+
+                $table .= str_repeat(" ", $props["depth"] + 3) . "<td>" . $this->cchunk["simplelist"]["members"][$i] . "</td>\n";
+
+                if ($i % $this->cchunk["simplelist"]["columns"] === $this->cchunk["simplelist"]["columns"] - 1) {
+                    $table .= str_repeat(" ", $props["depth"] + 2) . "</tr>\n";
+                }
+            }
+            if ($i % $this->cchunk["simplelist"]["columns"] !== 0) {
+                $numOfMissingCells = $this->cchunk["simplelist"]["columns"] - ($i % $this->cchunk["simplelist"]["columns"]);
+                $oneRow = str_repeat(" ", $props["depth"] + 3) . "<td></td>\n";
+                $table .= str_repeat($oneRow, $numOfMissingCells);
+                $table .= str_repeat(" ", $props["depth"] + 2) . "</tr>\n";
+            }
+
+            $this->cchunk["simplelist"] = $this->dchunk["simplelist"];
+
+            return $table . str_repeat(" ", $props["depth"] + 1) . "</tbody>\n" . str_repeat(" ", $props["depth"]) . "</table>";
+
+        }
+
+        if ($this->cchunk["simplelist"]["type"] === "vert") {
+
+            $table = "";
+            $numOfRows = ceil(count($this->cchunk["simplelist"]["members"]) / $this->cchunk["simplelist"]["columns"]);
+            for ($row = 0; $row < $numOfRows; $row++) {
+                $table .= str_repeat(" ", $props["depth"] + 2) . "<tr>\n";
+                for ($col = 0; $col < $this->cchunk["simplelist"]["columns"]; $col++) {
+                    $memberIndex = ($numOfRows * $col) + $row;
+                    $table .= str_repeat(" ", $props["depth"] + 3) . "<td>";
+                    if ($memberIndex < count($this->cchunk["simplelist"]["members"])) {
+                        $table .= $this->cchunk["simplelist"]["members"][$memberIndex];
+                    }
+                    $table .= "</td>\n";
+                }
+                $table .= str_repeat(" ", $props["depth"] + 2) . "</tr>\n";
+            }
+            $this->cchunk["simplelist"] = $this->dchunk["simplelist"];
+
+            return $table . str_repeat(" ", $props["depth"] + 1) . "</tbody>\n" . str_repeat(" ", $props["depth"]) . "</table>";
+        }
+
+        $this->cchunk["simplelist"] = $this->dchunk["simplelist"];
+        return '</ul>';
+    }
+
+    public function format_member($open, $name, $attrs, $props) {
+        if ($this->cchunk["simplelist"]["type"] === "inline"
+            || $this->cchunk["simplelist"]["type"] === "vert"
+            || $this->cchunk["simplelist"]["type"] === "horiz") {
+            return '';
+        }
+        if ($open) {
+            return '<li>';
+        }
+        return '</li>';
+    }
+
+    public function format_member_text($value, $tag) {
+        if ($this->cchunk["simplelist"]["type"] === "inline"
+            || $this->cchunk["simplelist"]["type"] === "vert"
+            || $this->cchunk["simplelist"]["type"] === "horiz") {
+            $this->cchunk["simplelist"]["members"][] = $value;
+            return '';
+        }
+        return $value;
+    }
+
     public function format_orderedlist($open, $name, $attrs, $props) {
         if ($open) {
             $numeration = "1";
@@ -2115,6 +2225,15 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             return false;
         }
 
+        if (
+            $elementStack[$currentDepth - 1] === "simplelist"
+            && ($this->cchunk["simplelist"]["type"] === "inline"
+                || $this->cchunk["simplelist"]["type"] === "vert"
+                || $this->cchunk["simplelist"]["type"] === "horiz")
+            ) {
+            return false;
+        }
+
         /* The following if is to skip unnecessary whitespaces in the implements list */
         if (
             ($elementStack[$currentDepth - 1] === 'classsynopsisinfo' && $elementStack[$currentDepth] === 'oointerface') ||
@@ -2127,5 +2246,3 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
 
 }
-
-

--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -216,6 +216,3 @@ class Render extends ObjectStorage
     } /* }}} */
 
 }
-
-
-

--- a/tests/php/type_rendering_001.phpt
+++ b/tests/php/type_rendering_001.phpt
@@ -38,8 +38,7 @@ Content:
 
  <div class="section">
   <p class="para">1. Function/method with no return type</p>
-  <div class="methodsynopsis dc-description">
-   <span class="methodname"><strong>function_name</strong></span>()</div>
+  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>()</div>
 
  </div>
 

--- a/tests/php/type_rendering_002.phpt
+++ b/tests/php/type_rendering_002.phpt
@@ -38,8 +38,7 @@ Content:
 
  <div class="section">
   <p class="para">1. Function/method with no parameters</p>
-  <div class="methodsynopsis dc-description">
-   <span class="methodname"><strong>function_name</strong></span>()</div>
+  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>()</div>
 
  </div>
 

--- a/tests/php/type_rendering_003.phpt
+++ b/tests/php/type_rendering_003.phpt
@@ -38,8 +38,7 @@ Content:
 
  <div class="section">
   <p class="para">1. Constructor with no parameters, no return type</p>
-  <div class="constructorsynopsis dc-description">
-   <span class="modifier">final</span> <span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>()</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>()</div>
 
  </div>
 

--- a/tests/xhtml/data/simplelist.xml
+++ b/tests/xhtml/data/simplelist.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="simpelist" xmlns="http://docbook.org/ns/docbook">
+
+ <section>
+  <para>1. Simplelist with no type</para>
+  <simplelist>
+   <member>First</member>
+   <member>Second</member>
+   <member>Third</member>
+   <member>Fourth</member>
+   <member>Fifth</member>
+   <member>Sixth</member>
+   <member>Seventh</member>
+  </simplelist>
+ </section>
+
+ <section>
+  <para>2. Simplelist with "inline" type</para>
+  <simplelist type="inline">
+   <member>First</member>
+   <member>Second</member>
+   <member>Third</member>
+   <member>Fourth</member>
+   <member>Fifth</member>
+   <member>Sixth</member>
+   <member>Seventh</member>
+  </simplelist>
+ </section>
+
+ <section>
+  <para>3. Simplelist with "vert" type, 3 columns</para>
+  <simplelist type="vert" columns="3">
+   <member>First</member>
+   <member>Second</member>
+   <member>Third</member>
+   <member>Fourth</member>
+   <member>Fifth</member>
+   <member>Sixth</member>
+   <member>Seventh</member>
+  </simplelist>
+ </section>
+
+ <section>
+  <para>4. Simplelist with "horiz" type, 4 columns</para>
+  <simplelist type="horiz" columns="4">
+   <member>First</member>
+   <member>Second</member>
+   <member>Third</member>
+   <member>Fourth</member>
+   <member>Fifth</member>
+   <member>Sixth</member>
+   <member>Seventh</member>
+  </simplelist>
+ </section>
+
+</chapter>

--- a/tests/xhtml/simplelist_001.phpt
+++ b/tests/xhtml/simplelist_001.phpt
@@ -1,0 +1,100 @@
+--TEST--
+Simplelist rendering 001 - Types and columns
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../setup.php";
+require_once __DIR__ . "/TestChunkedXHTML.php";
+
+$formatclass = "TestChunkedXHTML";
+$xml_file = __DIR__ . "/data/simplelist.xml";
+
+$opts = array(
+    "index"             => true,
+    "xml_root"          => dirname($xml_file),
+    "xml_file"          => $xml_file,
+    "output_dir"        => __DIR__ . "/output/",
+);
+
+$extra = array(
+    "lang_dir" => __PHDDIR__ . "phpdotnet/phd/data/langs/",
+    "phpweb_version_filename" => dirname($xml_file) . '/version.xml',
+    "phpweb_acronym_filename" => dirname($xml_file) . '/acronyms.xml',
+);
+
+$render = new TestRender($formatclass, $opts, $extra);
+
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
+}
+
+$render->run();
+?>
+--EXPECTF--
+Filename: simpelist.html
+Content:
+<div id="simpelist" class="chapter">
+
+ <div class="section">
+  <p class="para">1. Simplelist with no type</p>
+  <ul class="simplelist">
+   <li>First</li>
+   <li>Second</li>
+   <li>Third</li>
+   <li>Fourth</li>
+   <li>Fifth</li>
+   <li>Sixth</li>
+   <li>Seventh</li>
+  </ul>
+ </div>
+
+ <div class="section">
+  <p class="para">2. Simplelist with &quot;inline&quot; type</p>
+  <span class="simplelist">First, Second, Third, Fourth, Fifth, Sixth, Seventh</span>
+ </div>
+
+ <div class="section">
+  <p class="para">3. Simplelist with &quot;vert&quot; type, 3 columns</p>
+  <table class="simplelist">
+   <tbody>
+    <tr>
+     <td>First</td>
+     <td>Fourth</td>
+     <td>Seventh</td>
+    </tr>
+    <tr>
+     <td>Second</td>
+     <td>Fifth</td>
+     <td></td>
+    </tr>
+    <tr>
+     <td>Third</td>
+     <td>Sixth</td>
+     <td></td>
+    </tr>
+   </tbody>
+  </table>
+ </div>
+
+ <div class="section">
+  <p class="para">4. Simplelist with &quot;horiz&quot; type, 4 columns</p>
+  <table class="simplelist">
+   <tbody>
+    <tr>
+     <td>First</td>
+     <td>Second</td>
+     <td>Third</td>
+     <td>Fourth</td>
+    </tr>
+    <tr>
+     <td>Fifth</td>
+     <td>Sixth</td>
+     <td>Seventh</td>
+     <td></td>
+    </tr>
+   </tbody>
+  </table>
+ </div>
+
+</div>

--- a/tests/xhtml/whitespace_formatting_001.phpt
+++ b/tests/xhtml/whitespace_formatting_001.phpt
@@ -44,13 +44,13 @@ Content:
 
  <div class="section">
   <p class="para">2. Constructor with whitespace between name, parameters and return types</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>(<span class="methodparam"><span class="type"><span class="type">iterable</span><span class="type">resource</span><span class="type">callable</span><span class="type">null</span></span> <code class="parameter">$option</code></span><span class="type"><span class="type void">void</span></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>(<span class="methodparam"><span class="type"><span class="type">iterable</span><span class="type">resource</span><span class="type">callable</span><span class="type">null</span></span> <code class="parameter">$option</code></span><span class="type"><a href="language.types.void.html" class="type void">void</a></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">3. Destructor with whitespace between name, parameters and return types</p>
-  <div class="destructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>(<span class="methodparam"><span class="type"><span class="type">iterable</span><span class="type">resource</span><span class="type">callable</span><span class="type">null</span></span> <code class="parameter">$option</code></span><span class="type"><span class="type void">void</span></span>)</div>
+  <div class="destructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>(<span class="methodparam"><span class="type"><span class="type">iterable</span><span class="type">resource</span><span class="type">callable</span><span class="type">null</span></span> <code class="parameter">$option</code></span><span class="type"><a href="language.types.void.html" class="type void">void</a></span>)</div>
 
  </div>
 


### PR DESCRIPTION
Implement `type` and `columns` attributes of `<simplelist>`. Preserve backward compatibility by still using `<ul>` and `<li>` elements if no `type` is specified, ie. by not defaulting to `vert` as described [here](https://tdg.docbook.org/tdg/4.5/simplelist). See the included test for examples.

Closes #83, supersedes #84 and depends on #95 for proper formatting of whitespace.

Works on the same principle as parameter and return type rendering, ie. storing values, discarding output and processing when the appropriate section is closed.
The main method for processing `<simplelist>` is rather big and ugly so I'd appreciate all feedback on how to improve it.
