### PR TITLE
Override hardcoded stylesheets in PHP XHTML formats

### DIFF
--- a/phpdotnet/phd/Package/PHP/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/PHP/ChunkedXHTML.php
@@ -8,11 +8,6 @@ class Package_PHP_ChunkedXHTML extends Package_PHP_Web {
         parent::__construct();
         $this->registerFormatName("PHP-Chunked-XHTML");
         $this->setExt(Config::ext() === null ? ".html" : Config::ext());
-
-        Config::setCss(array(
-            'http://www.php.net/styles/theme-base.css',
-            'http://www.php.net/styles/theme-medium.css',
-        ));
     }
 
     public function __destruct() {

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -190,6 +190,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         $this->mytextmap = array_merge(parent::getDefaultTextMap(), static::getDefaultTextMap());
         $this->dchunk = array_merge(parent::getDefaultChunkInfo(), static::getDefaultChunkInfo());
         $this->registerPIHandlers($this->pihandlers);
+
+        if (Config::css() === []) {
+            Config::setCss(array(
+                "http://www.php.net/styles/theme-base.css",
+                "http://www.php.net/styles/theme-medium.css",
+            ));
+        }
     }
 
     public function getDefaultElementMap() {


### PR DESCRIPTION
Let the `--css` option override the default stylesheets for all PHP XHTML-based formats. Closes #70.

Phd's `--css` option allows to pass stylesheets to the rendered formats. However, in the constructor of the `PHP_ChunkedXHTML` format two stylesheets from `php.net` are added to every rendering in this format. 
This PR changes this behaviour so that the hardcoded stylesheets are only added if there are no stylesheets passed in from the command line and it applies this to all of the XHTML-based format in the PHP package. 
The default behavior (ie. without the `--css` option) does not change for the `PHP_ChunkedXHTML` format.