### PR TITLE
Add links to constants

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -437,9 +437,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         ),
         /* FIXME: This is one crazy stupid workaround for footnotes */
         'constant'              => array(
-            /* DEFAULT */          false,
+            /* DEFAULT */          'format_constant_text',
             'para'              => array(
-                /* DEFAULT */      false,
+                /* DEFAULT */      'format_constant_text',
                 'footnote'      => 'format_footnote_constant_text',
             ),
         ),
@@ -1612,6 +1612,25 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             return "<strong><code>";
         }
         return "</code></strong>";
+    }
+    public function format_constant_text($value, $tag) {
+        if (str_contains($value, '::')) {
+            // class constant
+            $normalizedLinkFormat = str_replace(
+                array("::", "\\", "_"),
+                array(".constants.", "-", "-"),
+                strtolower($value)
+            );
+        } else {
+            $normalizedLinkFormat = 'constant.' . str_replace('_', '-', strtolower($value));
+        }
+        $link = $this->createLink($normalizedLinkFormat);
+
+        if ($link === null) {
+            return $value;
+        }
+
+        return '<a href="' . $link . '">' . $value . '</a>';
     }
     public function admonition_title($title, $lang)
     {

--- a/tests/TestRender.php
+++ b/tests/TestRender.php
@@ -4,7 +4,12 @@ namespace phpdotnet\phd;
 class TestRender {
     protected $format;
 
-    public function __construct($formatclass, $opts, $extra = array()) {
+    public function __construct(
+        string $formatclass,
+        array $opts,
+        ?array $extra = [],
+        ?array $indices = []
+    ) {
         foreach ($opts as $k => $v) {
             $method = "set_$k";
             Config::$method($v);
@@ -14,6 +19,22 @@ class TestRender {
         }
         $classname = __NAMESPACE__ . "\\" . $formatclass;
         $this->format = new $classname();
+
+        foreach ($indices as $index) {
+            $this->format->SQLiteIndex(
+                null, // $context,
+                null, // $index,
+                $index["docbook_id"] ?? "", // $id,
+                $index["filename"] ?? "", // $filename,
+                $index["parent_id"] ?? "", // $parent,
+                $index["sdesc"] ?? "", // $sdesc,
+                $index["ldesc"] ?? "", // $ldesc,
+                $index["element"] ?? "", // $element,
+                $index["previous"] ?? "", // $previous,
+                $index["next"] ?? "", // $next,
+                $index["chunk"] ?? 0, // $chunk
+            );
+        }
     }
 
     public function run() {

--- a/tests/php/constant_links_001.phpt
+++ b/tests/php/constant_links_001.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Constant links 001
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../setup.php";
+require_once __DIR__ . "/TestChunkedXHTML.php";
+
+$formatclass = "TestChunkedXHTML";
+$xml_file = __DIR__ . "/data/constant_links.xml";
+
+$opts = array(
+    "index"             => true,
+    "xml_root"          => dirname($xml_file),
+    "xml_file"          => $xml_file,
+    "output_dir"        => __DIR__ . "/output/",
+);
+
+$extra = array(
+    "lang_dir" => __PHDDIR__ . "phpdotnet/phd/data/langs/",
+    "phpweb_version_filename" => dirname($xml_file) . '/version.xml',
+    "phpweb_acronym_filename" => dirname($xml_file) . '/acronyms.xml',
+);
+
+$indeces = [
+    [
+        "docbook_id" => "constant.definitely-exists",
+        "filename"   => "extensionname.constantspage",
+    ],
+    [
+        "docbook_id" => "vendor-namespace.constants.definitely-exists2",
+        "filename"   => "extensionname2.constantspage2",
+    ],
+];
+
+$render = new TestRender($formatclass, $opts, $extra, $indeces);
+
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
+}
+
+$render->run();
+?>
+--EXPECTF--
+Filename: constant_links.html
+Content:
+<div id="constant_links" class="chapter">
+
+ <div class="section">
+  <p class="para">%d. Existing constants</p>
+  <strong><code><a href="extensionname.constantspage.html#constant.definitely-exists">DEFINITELY_EXISTS</a></code></strong>
+  <p class="para">
+   <strong><code><a href="extensionname2.constantspage2.html#vendor-namespace.constants.definitely-exists2">Vendor\Namespace::DEFINITELY_EXISTS2</a></code></strong>
+  </p>
+ </div>
+
+ <div class="section">
+  <p class="para">%d. Nonexistent constants</p>
+  <strong><code>THIS_DOES_NOT_EXIST</code></strong>
+  <p class="para">
+   <strong><code>Vendor\Namespace::THIS_DOES_NOT_EXIST_EITHER</code></strong>
+  </p>
+ </div>
+
+</div>

--- a/tests/php/data/constant_links.xml
+++ b/tests/php/data/constant_links.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="constant_links">
+
+ <section>
+  <para>1. Existing constants</para>
+  <constant>DEFINITELY_EXISTS</constant>
+  <para>
+   <constant>Vendor\Namespace::DEFINITELY_EXISTS2</constant>
+  </para>
+ </section>
+
+ <section>
+  <para>2. Nonexistent constants</para>
+  <constant>THIS_DOES_NOT_EXIST</constant>
+  <para>
+   <constant>Vendor\Namespace::THIS_DOES_NOT_EXIST_EITHER</constant>
+  </para>
+ </section>
+
+</chapter>


### PR DESCRIPTION
Add links to constants with IDs in the following two standard formats (`xml:id` doesn't have to be on the `<constant>` element):

```xml
<constant xml:id="extension-namespace-or-classname.constants.name-of-constant">
 Extension\Namespace\Or\ClassName::NAME_OF_CONSTANT
</constant>

<constant xml:id="constant.name-of-constant">
 NAME_OF_CONSTANT
</constant>
```

Please note that there is a large number of constants not using one of these standard formats.