### PR TITLE
Enable nested roles

### DIFF
--- a/phpdotnet/phd/Format/Abstract/XHTML.php
+++ b/phpdotnet/phd/Format/Abstract/XHTML.php
@@ -2,7 +2,7 @@
 namespace phpdotnet\phd;
 
 abstract class Format_Abstract_XHTML extends Format {
-    public $role = false;
+    public $role = [];
 
     /* XHTMLPhDFormat */
     protected $openPara = 0;
@@ -39,14 +39,14 @@ abstract class Format_Abstract_XHTML extends Format {
     }
 
     public function CDATA($str) {
-        switch($this->role) {
+        switch(end($this->role)) {
         case '':
             return '<div class="cdata"><pre>'
                 . htmlspecialchars($str, ENT_QUOTES, "UTF-8")
                 . '</pre></div>';
         default:
-            return '<div class="' . $this->role . 'code">'
-                . $this->highlight(trim($str), $this->role, 'xhtml')
+            return '<div class="' . end($this->role) . 'code">'
+                . $this->highlight(trim($str), end($this->role), 'xhtml')
                 . '</div>';
         }
     }

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -705,10 +705,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if(!isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $attrs[Reader::XMLNS_DOCBOOK]["role"] = "unknown";
             }
-            $this->role = $role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
+            $this->role[] = $role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
             return '<strong class="' .$name.' ' .$role. '">';
         }
-        $this->role = null;
+        array_pop($this->role);
         return "</strong>";
     }
 
@@ -716,18 +716,18 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                $this->role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
+                $this->role[] = $attrs[Reader::XMLNS_DOCBOOK]["role"];
             } else {
-                $this->role = false;
+                $this->role[] = null;
             }
             return '<code class="literal">';
         }
-        $this->role = false;
+        array_pop($this->role);
         return '</code>';
     }
 
     public function format_literal_text($value, $tag) {
-        switch ($this->role) {
+        switch (end($this->role)) {
             case 'infdec':
                 $value = (float)$value;
                 $p = strpos($value, '.');
@@ -930,7 +930,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if(!isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $attrs[Reader::XMLNS_DOCBOOK]["role"] = "unknown-" . ++$role;
             }
-            $this->role = $role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
+            $this->role[] = $role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
 
             if (isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $id = $attrs[Reader::XMLNS_XML]["id"];
@@ -941,7 +941,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
             return '<div class="' .$name.' ' .$role. '" id="' . $id . '">';
         }
-        $this->role = null;
+        array_pop($this->role);
         return "</div>\n";
     }
 
@@ -1495,24 +1495,29 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     public function format_variablelist($open, $name, $attrs, $props) {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                $this->role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
+                $this->role[] = $attrs[Reader::XMLNS_DOCBOOK]["role"];
             }
             $classStr = $headerStr = $idStr = '';
             if (isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $idStr = ' id="' . $attrs[Reader::XMLNS_XML]["id"] . '"';
             }
-            if ($this->role === 'constant_list') {
+            if (end($this->role) === 'constant_list') {
                 $tagName = 'table';
                 $classStr = ' class="doctable table"';
-                $headerStr = "\n<tr>\n<th>" . $this->autogen('Constants', $props['lang']) . "</th>\n<th>" . $this->autogen('Description', $props['lang']) . "</th>\n</tr>";
+                $headerStr = "\n" . $this->indent($props["depth"] + 1) . "<tr>\n"
+                    . $this->indent($props["depth"] + 2) . "<th>"
+                    . $this->autogen('Constants', $props['lang']) . "</th>\n"
+                    . $this->indent($props["depth"] + 2) . "<th>"
+                    . $this->autogen('Description', $props['lang']) . "</th>\n"
+                    . $this->indent($props["depth"] + 1) . "</tr>";
             } else {
                 $tagName = 'dl';
             }
             return '<' . $tagName . $idStr . $classStr . '>' . $headerStr;
         }
-        $tagName = ($this->role === 'constant_list') ? 'table' : 'dl';
-        $this->role = false;
-        return "</" . $tagName . ">\n";
+        $tagName = (end($this->role) === 'constant_list') ? 'table' : 'dl';
+        array_pop($this->role);
+        return "</" . $tagName . ">";
     }
     public function format_varlistentry($open, $name, $attrs) {
         if ($open) {
@@ -1521,29 +1526,29 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             } else {
                 unset($this->cchunk['varlistentry']['id']);
             }
-            return ($this->role === 'constant_list') ? '<tr>' : '';
+            return (end($this->role) === 'constant_list') ? '<tr>' : '';
         }
-        return ($this->role === 'constant_list') ? '</tr>' : '';
+        return (end($this->role) === 'constant_list') ? '</tr>' : '';
     }
     public function format_varlistentry_term($open, $name, $attrs, $props) {
-        $tagName = ($this->role === 'constant_list') ? 'td' : 'dt';
+        $tagName = (end($this->role) === 'constant_list') ? 'td' : 'dt';
         if ($open) {
             if (isset($this->cchunk['varlistentry']['id'])) {
                 $id = $this->cchunk['varlistentry']['id'];
                 unset($this->cchunk['varlistentry']['id']);
                 return '<' . $tagName . ' id="' . $id . '">';
             } else {
-                return "<" . $tagName . ">\n";
+                return "<" . $tagName . ">";
             }
         }
-        return "</" . $tagName . ">\n";
+        return "</" . $tagName . ">";
     }
     public function format_varlistentry_listitem($open, $name, $attrs) {
-        $tagName = ($this->role === 'constant_list') ? 'td' : 'dd';
+        $tagName = (end($this->role) === 'constant_list') ? 'td' : 'dd';
         if ($open) {
-            return "<" . $tagName . ">\n";
+            return "<" . $tagName . ">";
         }
-        return "</" . $tagName . ">\n";
+        return "</" . $tagName . ">";
     }
     public function format_term($open, $name, $attrs, $props) {
         if ($open) {
@@ -1587,14 +1592,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     public function format_programlisting($open, $name, $attrs) {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                $this->role = $attrs[Reader::XMLNS_DOCBOOK]["role"];
+                $this->role[] = $attrs[Reader::XMLNS_DOCBOOK]["role"];
             } else {
-                $this->role = false;
+                $this->role[] = null;
             }
 
             return '<div class="example-contents">';
         }
-        $this->role = false;
+        array_pop($this->role);
         return "</div>\n";
     }
     public function format_programlisting_text($value, $tag) {
@@ -1685,9 +1690,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
     public function format_variablelist_title($open, $name, $attrs, $props) {
         if ($open) {
-            return ($this->role === 'constant_list') ? "<caption><strong>" : "<strong>";
+            return (end($this->role) === 'constant_list') ? "<caption><strong>" : "<strong>";
         }
-        return ($this->role === 'constant_list') ? "</strong></caption>" : "</strong>";
+        return (end($this->role) === 'constant_list') ? "</strong></caption>" : "</strong>";
     }
 
     public function format_mediaobject($open, $name, $attrs) {

--- a/phpdotnet/phd/Package/PEAR/XHTML.php
+++ b/phpdotnet/phd/Package/PEAR/XHTML.php
@@ -684,15 +684,15 @@ abstract class Package_PEAR_XHTML extends Package_Generic_XHTML {
         if ($open) {
             $this->trim = true;
             if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
-                $this->role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
+                $this->role[] = $attrs[Reader::XMLNS_DOCBOOK]['role'];
             } else {
-                $this->role = '';
+                $this->role[] = '';
             }
 
-            return '<div class="'. ($this->role ? $this->role . 'code' : 'programlisting')
+            return '<div class="'. (end($this->role) ? end($this->role) . 'code' : 'programlisting')
                    . '">';
         }
-        $this->role = false;
+        array_pop($this->role);
         $this->trim = false;
 
         return '</div>';
@@ -710,7 +710,7 @@ abstract class Package_PEAR_XHTML extends Package_Generic_XHTML {
     */
     public function format_programlisting_text($value, $tag)
     {
-        switch($this->role) {
+        switch(end($this->role)) {
         case 'php':
             if (strrpos($value, '<?php') || strrpos($value, '?>')) {
                 return $this->highlight(trim($value), 'php', 'xhtml');
@@ -719,7 +719,7 @@ abstract class Package_PEAR_XHTML extends Package_Generic_XHTML {
             }
             break;
         default:
-            return $this->highlight(trim($value), $this->role, 'xhtml');
+            return $this->highlight(trim($value), end($this->role), 'xhtml');
         }
     }
 
@@ -760,26 +760,26 @@ abstract class Package_PEAR_XHTML extends Package_Generic_XHTML {
         if ($this->trim) {
             $str = rtrim($str);
         }
-        if (!$this->role) {
+        if (!end($this->role)) {
             return str_replace(
                 array("\n", ' '), array('<br/>', '&nbsp;'),
                 htmlspecialchars($str, ENT_QUOTES, 'UTF-8')
             );
         }
 
-        switch ($this->role) {
+        switch (end($this->role)) {
         case 'php':
             if (strrpos($str, '<?php') || strrpos($str, '?>')) {
-                $str = $this->highlight(trim($str), $this->role, 'xhtml');
+                $str = $this->highlight(trim($str), end($this->role), 'xhtml');
             } else {
-                $str = $this->highlight("<?php\n" . trim($str) . "\n?>", $this->role, 'xhtml');
+                $str = $this->highlight("<?php\n" . trim($str) . "\n?>", end($this->role), 'xhtml');
             }
             break;
         case '':
             $str = htmlspecialchars($str, ENT_QUOTES, 'UTF-8');
             break;
         default:
-            $str = $this->highlight($str, $this->role, 'xhtml');
+            $str = $this->highlight($str, end($this->role), 'xhtml');
             break;
         }
 

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -843,7 +843,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         if ($filename !== null) {
             if ($this->CURRENT_ID !== $filename) {
                 $rel = $desc = "";
-                if ($this->role == "seealso") {
+                if (end($this->role) == "seealso") {
                     $rel  = ' rel="rdfs-seeAlso"';
                     $desc = " - " . Format::getLongDescription($filename);
                 }

--- a/tests/php/data/variablelist_rendering_001.xml
+++ b/tests/php/data/variablelist_rendering_001.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="variablelist-rendering">
+
+ <section>
+  <para>1. Variablelist with no role</para>
+  <variablelist>
+   <varlistentry xml:id="constant.variablelist-test-constant">
+    <term><constant>VARIABLELIST_TEST_CONSTANT</constant></term>
+    <listitem>
+     <simpara>
+      Description of constant
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </section>
+
+ <section>
+  <para>2. Variablelist with role="constant_list"</para>
+  <variablelist role="constant_list">
+   <varlistentry xml:id="constant.variablelist-test-constant-in-constant-list">
+    <term><constant>VARIABLELIST_TEST_CONSTANT_IN_CONSTANT_LIST</constant></term>
+    <listitem>
+     <simpara>
+      <literal>literal</literal> will add its own "role"
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.variablelist-test-constant-in-constant-list2">
+    <term><constant>VARIABLELIST_TEST_CONSTANT_IN_CONSTANT_LIST2</constant></term>
+    <listitem>
+     <simpara>
+      Role should have not been overwritten by literal
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </section>
+
+</chapter>

--- a/tests/php/variablelist_rendering_001.phpt
+++ b/tests/php/variablelist_rendering_001.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Variablelist rendering 001
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../setup.php";
+require_once __DIR__ . "/TestChunkedXHTML.php";
+
+$formatclass = "TestChunkedXHTML";
+$xml_file = __DIR__ . "/data/variablelist_rendering_001.xml";
+
+$opts = array(
+    "index"             => true,
+    "xml_root"          => dirname($xml_file),
+    "xml_file"          => $xml_file,
+    "output_dir"        => __DIR__ . "/output/",
+);
+
+$extra = array(
+    "lang_dir" => __PHDDIR__ . "phpdotnet/phd/data/langs/",
+    "phpweb_version_filename" => dirname($xml_file) . '/version.xml',
+    "phpweb_acronym_filename" => dirname($xml_file) . '/acronyms.xml',
+);
+
+$render = new TestRender($formatclass, $opts, $extra);
+
+if (Index::requireIndexing() && !file_exists($opts["output_dir"])) {
+    mkdir($opts["output_dir"], 0755);
+}
+
+$render->run();
+?>
+--EXPECTF--
+Filename: variablelist-rendering.html
+Content:
+<div id="variablelist-rendering" class="chapter">
+
+ <div class="section">
+  <p class="para">%d. Variablelist with no role</p>
+  <dl>
+   
+    <dt id="constant.variablelist-test-constant"><strong><code>VARIABLELIST_TEST_CONSTANT</code></strong></dt>
+    <dd>
+     <span class="simpara">
+      Description of constant
+     </span>
+    </dd>
+   
+  </dl>
+ </div>
+
+ <div class="section">
+  <p class="para">%d. Variablelist with role=&quot;constant_list&quot;</p>
+  <table class="doctable table">
+   <tr>
+    <th>Constants</th>
+    <th>Description</th>
+   </tr>
+   <tr>
+    <td id="constant.variablelist-test-constant-in-constant-list"><strong><code>VARIABLELIST_TEST_CONSTANT_IN_CONSTANT_LIST</code></strong></td>
+    <td>
+     <span class="simpara">
+      <code class="literal">literal</code> will add its own &quot;role&quot;
+     </span>
+    </td>
+   </tr>
+   <tr>
+    <td id="constant.variablelist-test-constant-in-constant-list2"><strong><code>VARIABLELIST_TEST_CONSTANT_IN_CONSTANT_LIST2</code></strong></td>
+    <td>
+     <span class="simpara">
+      Role should have not been overwritten by literal
+     </span>
+    </td>
+   </tr>
+  </table>
+ </div>
+
+</div>


### PR DESCRIPTION
Refactor `role` to be and array instead of a string to allow nesting of roles. Use the `indent` method to format constant list tables. Add tests for regular, table formatted and nested role containing `<variablelist>`s.

This PR fixes the shortcoming of the previous `role="constant_list"` PR and enables nested roles in `<variablelist>`s which allows to format constant lists in the documentation as tables without these being thrown off by elements that are rendered by adding roles to them (e.g. `<literal>`).