### PR TITLE
Trim leading and trailing underscores in constant IDs

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1612,13 +1612,17 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     public function format_constant_text($value, $tag) {
         if (str_contains($value, '::')) {
             // class constant
-            $normalizedLinkFormat = str_replace(
-                array("::", "\\", "_"),
-                array(".constants.", "-", "-"),
-                strtolower($value)
+            list($extensionAndClass, $constant) = explode(
+                "::",
+                str_replace(
+                    array("\\", "_"),
+                    array("-", "-"),
+                    strtolower($value)
+                )
             );
+            $normalizedLinkFormat = $extensionAndClass . ".constants." . trim($constant, "-");
         } else {
-            $normalizedLinkFormat = 'constant.' . str_replace('_', '-', strtolower($value));
+            $normalizedLinkFormat = 'constant.' . str_replace('_', '-', strtolower(trim($value, "_")));
         }
         $link = $this->createLink($normalizedLinkFormat);
 

--- a/tests/package/php/constant_links_001.phpt
+++ b/tests/package/php/constant_links_001.phpt
@@ -19,6 +19,14 @@ $indices = [
         "docbook_id" => "vendor-namespace.constants.definitely-exists2",
         "filename"   => "extensionname2.constantspage2",
     ],
+    [
+        "docbook_id" => "constant.leading-and-trailing-undescores",
+        "filename"   => "extensionname3.constantspage3",
+    ],
+    [
+        "docbook_id" => "extension-class.constants.leading-and-trailing-undescores2",
+        "filename"   => "extensionname4.constantspage4",
+    ],
 ];
 
 $format = new TestPHPChunkedXHTML;
@@ -61,6 +69,14 @@ Content:
   <strong><code>THIS_DOES_NOT_EXIST</code></strong>
   <p class="para">
    <strong><code>Vendor\Namespace::THIS_DOES_NOT_EXIST_EITHER</code></strong>
+  </p>
+ </div>
+
+ <div class="section">
+  <p class="para">%d. Constant with leading and trailing underscores in ID</p>
+  <strong><code><a href="extensionname3.constantspage3.html#constant.leading-and-trailing-undescores">__LEADING_AND_TRAILING_UNDESCORES__</a></code></strong>
+  <p class="para">
+   <strong><code><a href="extensionname4.constantspage4.html#extension-class.constants.leading-and-trailing-undescores2">Extension\Class::__LEADING_AND_TRAILING_UNDESCORES2__</a></code></strong>
   </p>
  </div>
 

--- a/tests/package/php/data/constant_links.xml
+++ b/tests/package/php/data/constant_links.xml
@@ -17,4 +17,12 @@
   </para>
  </section>
 
+ <section>
+  <para>3. Constant with leading and trailing underscores in ID</para>
+  <constant>__LEADING_AND_TRAILING_UNDESCORES__</constant>
+  <para>
+   <constant>Extension\Class::__LEADING_AND_TRAILING_UNDESCORES2__</constant>
+  </para>
+ </section>
+
 </chapter>


### PR DESCRIPTION
Trim leading and trailing underscores in constant IDs. 
Add test cases.

Used for magic constants, FFI's `__BIGGEST_ALIGNMENT__` and the global `__COMPILER_HALT_OFFSET__` constants.