### PR TITLE
Bump smoke test version to 8.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-          version: ['7.1', '7.2', '7.4', '8.1']
+          version: ['8.0', '8.1', '8.2', '8.3']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PhD


### PR DESCRIPTION
Change the PHP versions for the smoke tests to 8.0 and above. As PHP 8.0+ features are already in use in the codebase (e.g: `match`, `str_contains()`, etc.) this should not be an issue.