### PR TITLE
Add handler for caption tag

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -26,6 +26,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             'part'              => 'format_chunk',
         ),
         'book'                  => 'format_container_chunk_top',
+        'caption'               => 'format_caption',
         'chapter'               => 'format_container_chunk_top',
         'citetitle'             => 'em',
         'cmdsynopsis'           => 'format_cmdsynopsis',
@@ -2280,4 +2281,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $whitespace;
     }
 
+    public function format_caption($open, $name, $attrs, $props) {
+        return $open ? '<div class="caption">' : '</div>';
+    }
 }

--- a/tests/package/generic/caption_001.phpt
+++ b/tests/package/generic/caption_001.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Whitespace formatting 001
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/caption_001.xml";
+
+Config::init(["xml_file" => $xml_file]);
+
+$format = new TestGenericChunkedXHTML;
+$format->postConstruct();
+$render = new TestRender(new Reader, new Config, $format);
+
+$render->run();
+?>
+--EXPECT--
+Filename: caption_001.html
+Content:
+<div id="caption_001" class="chapter">
+
+ <div class="section">
+  <div class="mediaobject">
+   <div class="imageobject">
+   </div>
+   <div class="caption">
+    <p class="para">
+     Insightful caption
+    </p>
+   </div>
+  </div>
+ </div>
+
+</div>

--- a/tests/package/generic/data/caption_001.xml
+++ b/tests/package/generic/data/caption_001.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="caption_001" xmlns="http://docbook.org/ns/docbook">
+
+ <section>
+  <mediaobject>
+   <imageobject>
+   </imageobject>
+   <caption>
+    <para>
+     Insightful caption
+    </para>
+   </caption>
+  </mediaobject>
+ </section>
+
+</chapter>


### PR DESCRIPTION
Add handler for caption tag. The first of these tags has just been added to `doc-en` a few days ago.