### PR TITLE
Refactor Options Parser and default Options Handler

### DIFF
--- a/phpdotnet/phd/Autoloader.php
+++ b/phpdotnet/phd/Autoloader.php
@@ -1,7 +1,7 @@
 <?php
 namespace phpdotnet\phd;
 
-require __DIR__ . DIRECTORY_SEPARATOR . 'Config.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'Config.php';
 
 class Autoloader
 {

--- a/phpdotnet/phd/Options/Handler.php
+++ b/phpdotnet/phd/Options/Handler.php
@@ -23,9 +23,9 @@ class Options_Handler implements Options_Interface
             'outputfilename:' => 'F:',     // The output filename (only useful for bightml/bigpdf)
             'partial:'     => 'p:',        // The ID to render (optionally ignoring its children)
             'skip:'        => 's:',        // The ID to skip (optionally skipping its children too)
-            'verbose:'     => 'v::',       // Adjust the verbosity level
+            'verbose::'    => 'v::',       // Adjust the verbosity level
             'list'         => 'l',         // List supported packages/formats
-            'lang::'       => 'L:',        // Language hint (used by the CHM)
+            'lang:'        => 'L:',        // Language hint (used by the CHM)
             'color:'       => 'c:',        // Use color output if possible
             'highlighter:' => 'g:',        // Class used as source code highlighter
             'version'      => 'V',         // Print out version information
@@ -37,7 +37,7 @@ class Options_Handler implements Options_Interface
             'saveconfig::' => 'S::',       // Save the generated config ?
             'quit'         => 'Q',         // Do not run the render. Use with -S to just save the config.
             'memoryindex'  => 'M',         // Use sqlite in memory rather then file
-            'packagedir'   => 'k:',        // Include path for external packages
+            'packagedir:'  => 'k:',        // Include path for external packages
         ];
     }
 

--- a/phpdotnet/phd/Options/Parser.php
+++ b/phpdotnet/phd/Options/Parser.php
@@ -106,7 +106,6 @@ class Options_Parser
             $handler = $this->handlerForOption($k);
 
             if (!is_callable($handler)) {
-                var_dump($k, $v);
                 trigger_error("Hmh, something weird has happend, I don't know this option", E_USER_ERROR);
             }
 

--- a/phpdotnet/phd/Options/Parser.php
+++ b/phpdotnet/phd/Options/Parser.php
@@ -5,7 +5,7 @@ class Options_Parser
 {
 
     private Options_Interface $defaultHandler;
-    /** @var array<Options_Interface> */
+	/** @var array<Options_Interface> */
     private array $packageHandlers = [];
 
     public function __construct(
@@ -90,7 +90,10 @@ class Options_Parser
         }
     }
 
-    public function getopt() {
+    /**
+     * @return array<string, mixed>
+     */
+    public function getopt(): array {
         $this->validateOptions();
 
         $args = getopt($this->getShortOptions(), $this->getLongOptions());
@@ -98,14 +101,20 @@ class Options_Parser
             trigger_error("Something happend with getopt(), please report a bug", E_USER_ERROR);
         }
 
+        $parsedOptions = [];
         foreach ($args as $k => $v) {
             $handler = $this->handlerForOption($k);
-            if (is_callable($handler)) {
-                call_user_func($handler, $k, $v);
-            } else {
+
+            if (!is_callable($handler)) {
                 var_dump($k, $v);
                 trigger_error("Hmh, something weird has happend, I don't know this option", E_USER_ERROR);
             }
+
+            $retVal = call_user_func($handler, $k, $v);
+            if (is_array($retVal)) {
+                $parsedOptions = array_merge($parsedOptions, $retVal);
+            }
         }
+        return $parsedOptions;
     }
 }

--- a/render.php
+++ b/render.php
@@ -4,10 +4,12 @@ namespace phpdotnet\phd;
 
 // @php_dir@ gets replaced by pear with the install dir. use __DIR__ when
 // running from SVN
-define("__INSTALLDIR__", '@php_dir@' == '@'.'php_dir@' ? __DIR__ : '@php_dir@');
+if (!defined("__INSTALLDIR__")) {
+    define("__INSTALLDIR__", '@php_dir@' == '@'.'php_dir@' ? __DIR__ : '@php_dir@');
+}
 
-require __INSTALLDIR__ . '/phpdotnet/phd/Autoloader.php';
-require __INSTALLDIR__ . '/phpdotnet/phd/functions.php';
+require_once __INSTALLDIR__ . '/phpdotnet/phd/Autoloader.php';
+require_once __INSTALLDIR__ . '/phpdotnet/phd/functions.php';
 
 spl_autoload_register(array(__NAMESPACE__ . "\\Autoloader", "autoload"));
 

--- a/render.php
+++ b/render.php
@@ -28,8 +28,13 @@ foreach (Config::getSupportedPackages() as $package) {
         $packageHandlers[strtolower($package)] = $handler;
     }
 }
-$optionsParser = new Options_Parser(new Options_Handler, ...$packageHandlers);
-$optionsParser->getopt();
+$optionsParser = new Options_Parser(
+    new Options_Handler(new Config, new Package_Generic_Factory),
+    ...$packageHandlers
+);
+$commandLineOptions = $optionsParser->getopt();
+
+Config::init($commandLineOptions);
 
 /* If no docbook file was passed, die */
 if (!is_dir(Config::xml_root()) || !is_file(Config::xml_file())) {

--- a/tests/options/default_handler_001.phpt
+++ b/tests/options/default_handler_001.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Default options handler 001 - List packages - short option
+--ARGS--
+-l
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--EXPECT--
+Supported packages:
+	Generic
+		xhtml
+		bigxhtml
+		manpage
+	IDE
+		xml
+		funclist
+		json
+		php
+		phpstub
+		sqlite
+	PEAR
+		xhtml
+		bigxhtml
+		php
+		chm
+		tocfeed
+	PHP
+		xhtml
+		bigxhtml
+		php
+		howto
+		manpage
+		pdf
+		bigpdf
+		kdevelop
+		chm
+		tocfeed
+		epub
+		enhancedchm

--- a/tests/options/default_handler_002.phpt
+++ b/tests/options/default_handler_002.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Default options handler 002 - List packages - long option
+--ARGS--
+--list
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--EXPECT--
+Supported packages:
+	Generic
+		xhtml
+		bigxhtml
+		manpage
+	IDE
+		xml
+		funclist
+		json
+		php
+		phpstub
+		sqlite
+	PEAR
+		xhtml
+		bigxhtml
+		php
+		chm
+		tocfeed
+	PHP
+		xhtml
+		bigxhtml
+		php
+		howto
+		manpage
+		pdf
+		bigpdf
+		kdevelop
+		chm
+		tocfeed
+		epub
+		enhancedchm

--- a/tests/options/default_handler_003.phpt
+++ b/tests/options/default_handler_003.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Default options handler 003 - Show help - short option
+--ARGS--
+-h
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--EXPECTF--
+PhD version: %s
+Copyright(c) %d-%d The PHP Documentation Group
+
+  -v
+  --verbose <int>            Adjusts the verbosity level
+  -f <formatname>
+  --format <formatname>      The build format to use
+  -P <packagename>
+  --package <packagename>    The package to use
+  -I
+  --noindex                  Do not index before rendering but load from cache
+                             (default: %s)
+  -M
+  --memoryindex              Do not save indexing into a file, store it in memory.
+                             (default: %s)
+  -r
+  --forceindex               Force re-indexing under all circumstances
+                             (default: %s)
+  -t
+  --notoc                    Do not rewrite TOC before rendering but load from
+                             cache (default: %s)
+  -d <filename>
+  --docbook <filename>       The Docbook file to render from
+  -x
+  --xinclude                 Process XML Inclusions (XInclude)
+                             (default: %s)
+  -p <id[=bool]>
+  --partial <id[=bool]>      The ID to render, optionally skipping its children
+                             chunks (default to %s; render children)
+  -s <id[=bool]>
+  --skip <id[=bool]>         The ID to skip, optionally skipping its children
+                             chunks (default to %s; skip children)
+  -l
+  --list                     Print out the supported packages and formats
+  -o <directory>
+  --output <directory>       The output directory (default: .)
+  -F filename
+  --outputfilename filename  Filename to use when writing standalone formats
+                             (default: <packagename>-<formatname>.<formatext>)
+  -L <language>
+  --lang <language>          The language of the source file (used by the CHM
+                             theme). (default: %s)
+  -c <bool>
+  --color <bool>             Enable color output when output is to a terminal
+                             (default: %s)
+  -C <filename>
+  --css <filename>           Link for an external CSS file.
+  -g <classname>
+  --highlighter <classname>  Use custom source code highlighting php class
+  -V
+  --version                  Print the PhD version information
+  -h
+  --help                     This help
+  -e <extension>
+  --ext <extension>          The alternative filename extension to use,
+                             including the dot. Use 'false' for no extension.
+  -S <bool>
+  --saveconfig <bool>        Save the generated config (default: %s).
+
+  -Q
+  --quit                     Don't run the build. Use with --saveconfig to
+                             just save the config.
+  -k
+  --packagedir               Use an external package directory.
+
+
+Most options can be passed multiple times for greater effect.

--- a/tests/options/default_handler_004.phpt
+++ b/tests/options/default_handler_004.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Default options handler 004 - Show help - long option
+--ARGS--
+--help
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--EXPECTF--
+PhD version: %s
+Copyright(c) %d-%d The PHP Documentation Group
+
+  -v
+  --verbose <int>            Adjusts the verbosity level
+  -f <formatname>
+  --format <formatname>      The build format to use
+  -P <packagename>
+  --package <packagename>    The package to use
+  -I
+  --noindex                  Do not index before rendering but load from cache
+                             (default: %s)
+  -M
+  --memoryindex              Do not save indexing into a file, store it in memory.
+                             (default: %s)
+  -r
+  --forceindex               Force re-indexing under all circumstances
+                             (default: %s)
+  -t
+  --notoc                    Do not rewrite TOC before rendering but load from
+                             cache (default: %s)
+  -d <filename>
+  --docbook <filename>       The Docbook file to render from
+  -x
+  --xinclude                 Process XML Inclusions (XInclude)
+                             (default: %s)
+  -p <id[=bool]>
+  --partial <id[=bool]>      The ID to render, optionally skipping its children
+                             chunks (default to %s; render children)
+  -s <id[=bool]>
+  --skip <id[=bool]>         The ID to skip, optionally skipping its children
+                             chunks (default to %s; skip children)
+  -l
+  --list                     Print out the supported packages and formats
+  -o <directory>
+  --output <directory>       The output directory (default: .)
+  -F filename
+  --outputfilename filename  Filename to use when writing standalone formats
+                             (default: <packagename>-<formatname>.<formatext>)
+  -L <language>
+  --lang <language>          The language of the source file (used by the CHM
+                             theme). (default: %s)
+  -c <bool>
+  --color <bool>             Enable color output when output is to a terminal
+                             (default: %s)
+  -C <filename>
+  --css <filename>           Link for an external CSS file.
+  -g <classname>
+  --highlighter <classname>  Use custom source code highlighting php class
+  -V
+  --version                  Print the PhD version information
+  -h
+  --help                     This help
+  -e <extension>
+  --ext <extension>          The alternative filename extension to use,
+                             including the dot. Use 'false' for no extension.
+  -S <bool>
+  --saveconfig <bool>        Save the generated config (default: %s).
+
+  -Q
+  --quit                     Don't run the build. Use with --saveconfig to
+                             just save the config.
+  -k
+  --packagedir               Use an external package directory.
+
+
+Most options can be passed multiple times for greater effect.

--- a/tests/options/default_handler_005.phpt
+++ b/tests/options/default_handler_005.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Default options handler 005 - Show version - short option
+--ARGS--
+-V
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--EXPECTF--
+%sPhD Version: %s
+	%sGeneric%s: %s
+	%sIDE%s: %s
+	%sPEAR%s: %s
+	%sPHP%s: %s
+%sPHP Version: %s
+%sCopyright(c) %d-%d The PHP Documentation Group%s

--- a/tests/options/default_handler_006.phpt
+++ b/tests/options/default_handler_006.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Default options handler 006 - Show version - long option
+--ARGS--
+--version
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--EXPECTF--
+%sPhD Version: %s
+	%sGeneric%s: %s
+	%sIDE%s: %s
+	%sPEAR%s: %s
+	%sPHP%s: %s
+%sPHP Version: %s
+%sCopyright(c) %d-%d The PHP Documentation Group%s

--- a/tests/options/default_handler_007.phpt
+++ b/tests/options/default_handler_007.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Default options handler 007 - Save config (short option) and quit (short option)
+--ARGS--
+--docbook tests/options/default_handler_007.phpt -S -Q
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . "/../../phd.config.php");
+?>
+--EXPECTF--
+%s[%d:%d:%d - Heads up              ]%s Writing the config file

--- a/tests/options/default_handler_008.phpt
+++ b/tests/options/default_handler_008.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Default options handler 008 - Save config (long option) and quit (long option)
+--ARGS--
+--docbook tests/options/default_handler_008.phpt --saveconfig --quit
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../render.php";
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . "/../../phd.config.php");
+?>
+--EXPECTF--
+%s[%d:%d:%d - Heads up              ]%s Writing the config file

--- a/tests/options/default_handler_009.phpt
+++ b/tests/options/default_handler_009.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Default options handler 009 - Long options returned as array
+--ARGS--
+--format="xhtml" --noindex --forceindex --notoc --docbook="tests/options/default_handler_009.phpt" --output="tests/options/" --outputfilename="tests/options/default_handler_009.xml" --partial="bookId" --skip="idToSkip" --verbose=E_ALL --lang="en" --color=1 --highlighter="highlighter" --package="PHP" --css="some.css" --xinclude --ext=".html" --memoryindex --packagedir="tests/options/"
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../setup.php";
+
+$optionsParser = new Options_Parser(
+    new Options_Handler(new Config, new Package_Generic_Factory)
+);
+$commandLineOptions = $optionsParser->getopt();
+
+var_dump($commandLineOptions);
+?>
+--EXPECTF--
+array(20) {
+  ["output_format"]=>
+  array(1) {
+    [0]=>
+    string(5) "xhtml"
+  }
+  ["no_index"]=>
+  bool(true)
+  ["force_index"]=>
+  bool(true)
+  ["no_toc"]=>
+  bool(true)
+  ["xml_root"]=>
+  string(13) "tests/options"
+  ["xml_file"]=>
+  string(38) "tests/options/default_handler_009.phpt"
+  ["output_dir"]=>
+  string(14) "tests/options/"
+  ["output_filename"]=>
+  string(23) "default_handler_009.xml"
+  ["render_ids"]=>
+  array(1) {
+    ["bookId"]=>
+    bool(true)
+  }
+  ["skip_ids"]=>
+  array(1) {
+    ["idToSkip"]=>
+    bool(true)
+  }
+  ["verbose"]=>
+  int(%d)
+  ["language"]=>
+  string(2) "en"
+  ["color_output"]=>
+  bool(true)
+  ["highlighter"]=>
+  string(11) "highlighter"
+  ["package"]=>
+  array(1) {
+    [0]=>
+    string(3) "PHP"
+  }
+  ["css"]=>
+  array(1) {
+    [0]=>
+    string(8) "some.css"
+  }
+  ["process_xincludes"]=>
+  bool(true)
+  ["ext"]=>
+  string(5) ".html"
+  ["memoryindex"]=>
+  bool(true)
+  ["package_dirs"]=>
+  array(2) {
+    [0]=>
+    string(%d) "%s"
+    [1]=>
+    string(%d) "%s"
+  }
+}

--- a/tests/options/default_handler_010.phpt
+++ b/tests/options/default_handler_010.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Default options handler 010 - Short options returned as array
+--ARGS--
+-f xhtml -I -r -t -d "tests/options/default_handler_009.phpt" -o "tests/options/" -F "tests/options/default_handler_009.xml" -p bookId -s idToSkip -v="E_ALL" -L en -c 1 -g highlighter -P PHP -C "some.css" -x -e ".html" -M -k="tests/options/"
+--SKIPIF--
+<?php
+if (file_exists(__DIR__ . "/../../phd.config.php")) {
+    die("Skipped: existing phd.config.php file will overwrite command line options.");
+}
+?>
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../setup.php";
+
+$optionsParser = new Options_Parser(
+    new Options_Handler(new Config, new Package_Generic_Factory)
+);
+$commandLineOptions = $optionsParser->getopt();
+
+var_dump($commandLineOptions);
+?>
+--EXPECTF--
+array(20) {
+  ["output_format"]=>
+  array(1) {
+    [0]=>
+    string(5) "xhtml"
+  }
+  ["no_index"]=>
+  bool(true)
+  ["force_index"]=>
+  bool(true)
+  ["no_toc"]=>
+  bool(true)
+  ["xml_root"]=>
+  string(13) "tests/options"
+  ["xml_file"]=>
+  string(38) "tests/options/default_handler_009.phpt"
+  ["output_dir"]=>
+  string(14) "tests/options/"
+  ["output_filename"]=>
+  string(23) "default_handler_009.xml"
+  ["render_ids"]=>
+  array(1) {
+    ["bookId"]=>
+    bool(true)
+  }
+  ["skip_ids"]=>
+  array(1) {
+    ["idToSkip"]=>
+    bool(true)
+  }
+  ["verbose"]=>
+  int(%d)
+  ["language"]=>
+  string(2) "en"
+  ["color_output"]=>
+  bool(true)
+  ["highlighter"]=>
+  string(11) "highlighter"
+  ["package"]=>
+  array(1) {
+    [0]=>
+    string(3) "PHP"
+  }
+  ["css"]=>
+  array(1) {
+    [0]=>
+    string(8) "some.css"
+  }
+  ["process_xincludes"]=>
+  bool(true)
+  ["ext"]=>
+  string(5) ".html"
+  ["memoryindex"]=>
+  bool(true)
+  ["package_dirs"]=>
+  array(2) {
+    [0]=>
+    string(%d) "%s"
+    [1]=>
+    string(%d) "%s"
+  }
+}

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -1,17 +1,16 @@
 <?php
 namespace phpdotnet\phd;
 
-define("__PHDDIR__", __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR);
-define("__INSTALLDIR__", "@php_dir@" == "@"."php_dir@" ? dirname(dirname(__DIR__)) : "@php_dir@");
+define("__INSTALLDIR__", "@php_dir@" == "@"."php_dir@" ? dirname(__DIR__) : "@php_dir@");
 
-require_once __PHDDIR__ . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "Autoloader.php";
+require_once __INSTALLDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "Autoloader.php";
 spl_autoload_register(["phpdotnet\\phd\\Autoloader", "autoload"]);
 
-require_once __PHDDIR__ . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "functions.php";
+require_once __INSTALLDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "functions.php";
 
 Config::init([
-    "lang_dir"  => __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR
+    "lang_dir"  => __INSTALLDIR__ . DIRECTORY_SEPARATOR
                     . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR
                     . "data" . DIRECTORY_SEPARATOR . "langs" . DIRECTORY_SEPARATOR,
-    "package_dirs" => [__PHDDIR__, __INSTALLDIR__],
+    "package_dirs" => [__INSTALLDIR__],
 ]);


### PR DESCRIPTION
This PR includes the followings:
 - remove all direct setting of `Config` from the default `Options_Handler` and return an array of parsed options instead. Add return type declarations to each method returning an array
 - inject dependencies through `Options_Handler`'s constructor in `render.php`
 - refactor a few files to allow them to be used from tests
 - add tests for the default `Options_Handler` and `Options_Parser`
 - fix inconsistent short and long option required/optional flags in `Options_Handler`
