### PR TITLE
Refactor Index

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -112,50 +112,6 @@ class Index extends Format
     public function appendData($data) {
     }
 
-    /**
-     * Checks if indexing is needed.
-     *
-     * This is determined the following way:
-     * 0. If no index file exists, indexing is required.
-     * 1. If the config option --no-index is supplied, nothing is indexed
-     * 2. If the config option --force-index is supplied, indexing is required
-     * 3. If no option is given, the file modification time of the index and
-     *    the manual docbook file are compared. If the index is older than
-     *    the docbook file, indexing will be done.
-     *
-     * @return boolean True if indexing is required.
-     */
-    final static public function requireIndexing()
-    {
-        $indexfile = Config::output_dir() . 'index.sqlite';
-        if (!file_exists($indexfile)) {
-            return true;
-        }
-
-        if (Config::no_index()) {
-            return false;
-        }
-
-        if (Config::force_index()) {
-            return true;
-        }
-
-        $db            = new \SQLite3($indexfile);
-        $indexingCount = $db->query('SELECT COUNT(time) FROM indexing')
-            ->fetchArray(SQLITE3_NUM);
-        if ($indexingCount[0] == 0) {
-            return true;
-        }
-
-        $indexing = $db->query('SELECT time FROM indexing')
-            ->fetchArray(SQLITE3_ASSOC);
-        $xmlLastModification = filemtime(Config::xml_file());
-        if ($indexing['time'] > $xmlLastModification) {
-            return false;
-        }
-        return true;
-    }
-
     public function update($event, $value = null)
     {
         switch($event) {

--- a/phpdotnet/phd/IndexRepository.php
+++ b/phpdotnet/phd/IndexRepository.php
@@ -1,0 +1,119 @@
+<?php
+namespace phpdotnet\phd;
+
+class IndexRepository
+{
+    public function __construct(
+        private \SQLite3 $db
+    ) {}
+
+    public function init(): void {
+        $create = <<<SQL
+CREATE TABLE ids (
+docbook_id TEXT,
+filename TEXT,
+parent_id TEXT,
+sdesc TEXT,
+ldesc TEXT,
+element TEXT,
+previous TEXT,
+next TEXT,
+chunk INTEGER
+);
+CREATE TABLE changelogs (
+membership TEXT, -- How the extension in distributed (pecl, core, bundled with/out external dependencies..)
+docbook_id TEXT,
+parent_id TEXT,
+version TEXT,
+description TEXT
+);
+CREATE TABLE indexing (
+time INTEGER PRIMARY KEY
+);
+SQL;
+        $this->db->exec('DROP TABLE IF EXISTS ids');
+        $this->db->exec('DROP TABLE IF EXISTS indexing');
+        $this->db->exec('DROP TABLE IF EXISTS changelogs');
+        $this->db->exec('PRAGMA default_synchronous=OFF');
+        $this->db->exec('PRAGMA count_changes=OFF');
+        $this->db->exec('PRAGMA cache_size=100000');
+        $this->db->exec($create);
+    }
+
+    public function saveIndexingTime(int $time): void {
+        $this->db->exec("BEGIN TRANSACTION; INSERT INTO indexing (time) VALUES ('" . $time . "'); COMMIT");
+    }
+
+    public function commit(
+        array $commitList,
+        array $postReplacementIndexes,
+        array $postReplacementValues,
+        array $changelog,
+    ): bool {
+        if (!$commitList) {
+            return false;
+        }
+
+        foreach ($postReplacementValues as $key => $postReplacementValue) {
+            $postReplacementValues[$key] = $this->db->escapeString($postReplacementValue);
+        }
+
+        foreach ($commitList as $key => $commit) {
+            $commitList[$key] = sprintf(
+                "INSERT INTO ids (docbook_id, filename, parent_id, sdesc, ldesc, element, previous, next, chunk) VALUES('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %d);\n",
+                $this->db->escapeString($commit["docbook_id"]),
+                $this->db->escapeString($commit["filename"]),
+                $this->db->escapeString($commit["parent_id"]),
+                $this->db->escapeString($commit["sdesc"]),
+                $this->db->escapeString($commit["ldesc"]),
+                $this->db->escapeString($commit["element"]),
+                $this->db->escapeString($commit["previous"]),
+                $this->db->escapeString($commit["next"]),
+                $this->db->escapeString($commit["chunk"])
+            );
+        }
+
+        $search = $this->db->escapeString("POST-REPLACEMENT");
+        $none = $this->db->escapeString("");
+
+        foreach($postReplacementIndexes as $a) {
+            if (isset($postReplacementValues[$a["docbook_id"]])) {
+                $replacement = $postReplacementValues[$a["docbook_id"]];
+                $commitList[$a["idx"]] = str_replace($search, $replacement, $commitList[$a["idx"]]);
+            } else {
+                // If there are still post replacement, then they don't have
+                // any 'next' page
+                $commitList[$a["idx"]] = str_replace($search, $none, $commitList[$a["idx"]]);
+            }
+        }
+
+        $this->db->exec('BEGIN TRANSACTION; '.implode("", $commitList).' COMMIT');
+        $this->saveChangelogs($changelog);
+        return true;
+    }
+
+    private function saveChangelogs(array $changelog): void {
+        $log = "";
+        foreach($changelog as $id => $arr) {
+            foreach($arr as $entry) {
+                $log .= sprintf(
+                    "INSERT INTO changelogs (membership, docbook_id, parent_id, version, description) VALUES('%s', '%s', '%s', '%s', '%s');\n",
+                    $this->db->escapeString($entry[0] ?? ''),
+                    $this->db->escapeString($id),
+                    $this->db->escapeString($entry[1]),
+                    $this->db->escapeString($entry[2]),
+                    $this->db->escapeString($entry[3])
+                );
+            }
+        }
+        $this->db->exec('BEGIN TRANSACTION; ' . $log. ' COMMIT');
+    }
+
+    public function lastErrorCode(): int {
+        return $this->db->lastErrorCode();
+    }
+
+    public function lastErrorMsg(): string {
+        return $this->db->lastErrorMsg();
+    }
+}

--- a/phpdotnet/phd/TestRender.php
+++ b/phpdotnet/phd/TestRender.php
@@ -10,7 +10,7 @@ class TestRender extends Render {
     ) {}
 
     public function run() {
-        if ($this->index && $this->index::requireIndexing()) {
+        if ($this->index && requireIndexing($this->config)) {
             if (!file_exists($this->config->output_dir())) {
                 mkdir($this->config->output_dir(), 0755);
             }

--- a/render.php
+++ b/render.php
@@ -95,8 +95,14 @@ if (Config::process_xincludes()) {
     $readerOpts |= LIBXML_XINCLUDE;
 }
 
+if (file_exists(Config::output_dir() . 'index.sqlite')) {
+    $db = new \SQLite3(Config::output_dir() . 'index.sqlite');
+} else {
+    $db = null;
+}
+
 // Indexing
-if (Index::requireIndexing()) {
+if (requireIndexing(new Config, $db)) {
     v("Indexing...", VERBOSE_INDEXING);
     // Create indexer
     $format = new Index;

--- a/render.php
+++ b/render.php
@@ -104,12 +104,22 @@ if (file_exists(Config::output_dir() . 'index.sqlite')) {
 // Indexing
 if (requireIndexing(new Config, $db)) {
     v("Indexing...", VERBOSE_INDEXING);
+    if (Config::memoryindex()) {
+        $db = new \SQLite3(":memory:");
+    } else {
+        $db = $db ?? new \SQLite3(Config::output_dir() . 'index.sqlite');
+    }
     // Create indexer
-    $format = new Index;
+    $indexRepository = new IndexRepository($db);
+    $format = new Index($indexRepository);
     $render->attach($format);
 
     $reader->open(Config::xml_file(), NULL, $readerOpts);
     $render->execute($reader);
+
+    if (Config::memoryindex()) {
+        Config::set_indexcache($db);
+    }
 
     $render->detach($format);
 

--- a/tests/index/bug_GH-98.phpt
+++ b/tests/index/bug_GH-98.phpt
@@ -13,10 +13,7 @@ Config::init([
     "xml_file" => $xml_file,
 ]);
 
-$indexRepository = new IndexRepository(new \SQLite3(
-    Config::output_dir() . 'index.sqlite',
-    \SQLITE3_OPEN_READWRITE | \SQLITE3_OPEN_CREATE
-));
+$indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 
 $index = new TestIndex($indexRepository);
@@ -33,8 +30,6 @@ var_dump(in_array("another.non-chunked.element.id", $indexes));
 var_dump(in_array("chunked.element.id", $indexes));
 var_dump(in_array("another.chunked.element.id", $indexes));
 var_dump(in_array("bug-GH-98", $indexes));
-
-unlink(Config::output_dir() . 'index.sqlite');
 ?>
 --EXPECT--
 Indexes stored:

--- a/tests/index/bug_GH-98.phpt
+++ b/tests/index/bug_GH-98.phpt
@@ -13,7 +13,13 @@ Config::init([
     "xml_file" => $xml_file,
 ]);
 
-$index = new TestIndex;
+$indexRepository = new IndexRepository(new \SQLite3(
+    Config::output_dir() . 'index.sqlite',
+    \SQLITE3_OPEN_READWRITE | \SQLITE3_OPEN_CREATE
+));
+$indexRepository->init();
+
+$index = new TestIndex($indexRepository);
 $render = new TestRender(new Reader, new Config, null, $index);
 
 $render->run();
@@ -27,6 +33,8 @@ var_dump(in_array("another.non-chunked.element.id", $indexes));
 var_dump(in_array("chunked.element.id", $indexes));
 var_dump(in_array("another.chunked.element.id", $indexes));
 var_dump(in_array("bug-GH-98", $indexes));
+
+unlink(Config::output_dir() . 'index.sqlite');
 ?>
 --EXPECT--
 Indexes stored:

--- a/tests/index/data/indexing_001.xml
+++ b/tests/index/data/indexing_001.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="index" xml:lang="en">
+ <title>PHP Manual</title>
+
+ <info xmlns="http://docbook.org/ns/docbook" xml:id="bookinfo">
+  <authorgroup xmlns="http://docbook.org/ns/docbook" xml:id="authors">
+   <author>
+    <personname>
+     <firstname>A</firstname><surname>B</surname>
+    </personname>
+   </author>
+  </authorgroup>
+
+  <copyright>
+   <year>1997-<?dbtimestamp format="Y"?></year>
+   <holder>the PHP Documentation Group</holder>
+  </copyright>
+
+  <legalnotice xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="copyright">
+   <info><title>Copyright</title></info>
+   <simpara>
+    If you are interested in redistribution or republishing of this document
+    in whole or in part, either modified or unmodified, and you have questions,
+    please contact the Copyright holders at
+    <link xlink:href="mailto:doc-license@lists.php.net">doc-license@lists.php.net</link>.
+    Note that this address is mapped to a publicly archived mailing list.
+   </simpara>
+  </legalnotice>
+ </info>
+
+ <book xml:id="manual">
+  <title>PHP Manual</title>
+
+  <preface xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="preface">
+   <info>
+    <title>Preface</title>
+    <abstract>
+     <simpara>
+      <acronym>PHP</acronym>, which stands for "<literal>PHP: Hypertext
+      Preprocessor</literal>" is a widely-used Open Source general-purpose
+      scripting language
+     </simpara>
+    </abstract>
+   </info>
+
+   <section xmlns="http://docbook.org/ns/docbook" annotations="chunk:false" xml:id="contributors">
+    <info><title>Authors and Contributors</title></info>
+
+    <section>
+     <info><title>Authors and Editors</title></info>
+     <para>
+      The following contributors should be
+      recognized for the impact they have made and/or continue to make by adding
+      content to the manual:
+     </para>
+    </section>
+   </section>
+  </preface>
+ </book>
+
+ <book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="mongodb.setup">
+  <title xmlns="http://docbook.org/ns/docbook">Installing/Configuring</title>
+  <article xml:id="mongodb.requirements">
+   <title xmlns="http://docbook.org/ns/docbook">Requirements</title>
+   <para>
+    As of version 1.16.0, the driver requires PHP 7.2 or higher. Previous
+    versions of the driver allow compatibility with older PHP versions.
+   </para>
+  </article>
+ </book>
+
+ <book xml:id="chapterInBook">
+  <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="introduction">
+   <info><title>Introduction</title></info>
+
+   <section xml:id="intro-whatis">
+    <info><title>What is PHP?</title></info>
+    <para>
+     <acronym>PHP</acronym> (recursive acronym for <literal>PHP: Hypertext
+     Preprocessor</literal>) is a widely-used open source general-purpose
+     scripting language that is especially suited for web
+     development and can be embedded into HTML.
+    </para>
+   </section>
+  </chapter>
+ </book>
+
+ <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="apcu.constants">
+  <title xmlns="http://docbook.org/ns/docbook">Predefined Constants</title>
+  <simpara xmlns="http://docbook.org/ns/docbook">
+   The constants below are defined by this extension, and
+   will only be available when the extension has either
+   been compiled into PHP or dynamically loaded at runtime.
+  </simpara>
+ </appendix>
+
+ <part xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="reserved.interfaces">
+  <title>Predefined Interfaces and Classes</title>
+  <partintro>
+   <para>
+    See also the <link linkend="spl.interfaces">SPL Interfaces</link> and <link linkend="reserved.classes">reserved classes</link>.
+   </para>
+  </partintro>
+ </part>
+
+ <phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.traversable">
+  <title>The <interfacename>Traversable</interfacename> interface</title>
+  <titleabbrev>Traversable</titleabbrev>
+  <partintro>
+   <section role="changelog">
+    <title xmlns="http://docbook.org/ns/docbook">Changelog</title>
+    <para>
+     Changes
+    </para>
+   </section>
+  </partintro>
+ </phpdoc:classref>
+
+</set>

--- a/tests/index/indexing_001.phpt
+++ b/tests/index/indexing_001.phpt
@@ -13,10 +13,7 @@ Config::init([
     "xml_file" => $xml_file,
 ]);
 
-$indexRepository = new IndexRepository(new \SQLite3(
-    Config::output_dir() . 'index.sqlite',
-    \SQLITE3_OPEN_READWRITE | \SQLITE3_OPEN_CREATE
-));
+$indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 
 $index = new TestIndex($indexRepository);
@@ -29,8 +26,6 @@ $indexes = array_keys($index->getNfo());
 echo "Indexes stored:\n";
 
 var_dump($indexes);
-
-unlink(Config::output_dir() . 'index.sqlite');
 ?>
 --EXPECT--
 Indexes stored:

--- a/tests/index/indexing_001.phpt
+++ b/tests/index/indexing_001.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Indexing 001 - Basic indexing
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../setup.php";
+
+$xml_file = __DIR__ . "/data/indexing_001.xml";
+
+Config::init([
+    "force_index"    => true,
+    "xml_file" => $xml_file,
+]);
+
+$indexRepository = new IndexRepository(new \SQLite3(
+    Config::output_dir() . 'index.sqlite',
+    \SQLITE3_OPEN_READWRITE | \SQLITE3_OPEN_CREATE
+));
+$indexRepository->init();
+
+$index = new TestIndex($indexRepository);
+$render = new TestRender(new Reader, new Config, null, $index);
+
+$render->run();
+
+$indexes = array_keys($index->getNfo());
+
+echo "Indexes stored:\n";
+
+var_dump($indexes);
+
+unlink(Config::output_dir() . 'index.sqlite');
+?>
+--EXPECT--
+Indexes stored:
+array(15) {
+  [0]=>
+  string(5) "index"
+  [1]=>
+  string(8) "bookinfo"
+  [2]=>
+  string(7) "authors"
+  [3]=>
+  string(9) "copyright"
+  [4]=>
+  string(6) "manual"
+  [5]=>
+  string(7) "preface"
+  [6]=>
+  string(12) "contributors"
+  [7]=>
+  string(13) "mongodb.setup"
+  [8]=>
+  string(20) "mongodb.requirements"
+  [9]=>
+  string(13) "chapterInBook"
+  [10]=>
+  string(12) "introduction"
+  [11]=>
+  string(12) "intro-whatis"
+  [12]=>
+  string(14) "apcu.constants"
+  [13]=>
+  string(19) "reserved.interfaces"
+  [14]=>
+  string(17) "class.traversable"
+}


### PR DESCRIPTION
This PR is a minimal refactoring of `Index` to move its dependencies out of the class and inject them through the constructor.

The changes are:
 - move `requireIndexing()` method out of `Index` into a global function that receives all its dependencies through parameters
 - add a new `IndexRepository` class that handles all database access for `Index`, refactor `Index` to receive an object of this class as a constructor dependency and to pass raw data to it (i.e. data not containing SQL statements)
 - add basic indexing test
 - fix existing test that uses indexing to use `IndexRepository`