### PR TITLE
Pass setup to page footer

### DIFF
--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -209,7 +209,7 @@ manual_setup($setup);
     }
 
     public function footer($id) {
-        return "<?php manual_footer(); ?>";
+        return '<?php manual_footer($setup); ?>';
     }
 
     protected function writeJsonIndex() {


### PR DESCRIPTION
Pass the various setup variables to the footer so that the contribution links can be moved there in `web-php`.