### PR TITLE
Add file modification history to PHP doc pages

### DIFF
--- a/phpdotnet/phd/Config.php
+++ b/phpdotnet/phd/Config.php
@@ -20,6 +20,7 @@ class Config
         'no_toc'            => false,
         'xml_root'          => '.',
         'xml_file'          => './.manual.xml',
+        'history_file'      => './fileModHistory.php',
         'lang_dir'          => './',
         'language'          => 'en',
         'fallback_language' => 'en',

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -5,6 +5,9 @@ class Package_PHP_Web extends Package_PHP_XHTML {
 
     protected $sources = array();
 
+    /** $var array<string, array<string, mixed>> */
+    protected array $history = [];
+
     public function __construct() {
         parent::__construct();
         $this->registerFormatName("PHP-Web");
@@ -78,6 +81,7 @@ class Package_PHP_Web extends Package_PHP_XHTML {
             $this->loadSourcesInfo();
             $this->setOutputDir(Config::output_dir() . strtolower($this->getFormatName()) . '/');
             $this->postConstruct();
+            $this->loadHistoryInfo();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
                     v("Output directory is a file?", E_USER_ERROR);
@@ -182,6 +186,7 @@ $PARENTS = ' . var_export($parents, true) . ';';
             "alternatives" => $this->cchunk["alternatives"],
             "source" => $this->sourceInfo($id),
         );
+        $setup["history"] = $this->history[$setup["source"]["path"]] ?? [];
         if ($this->getChildren($id)) {
             $lang = Config::language();
             $setup["extra_header_links"] = array(
@@ -203,6 +208,8 @@ $setup["toc"] = $TOC;
 $setup["toc_deprecated"] = $TOC_DEPRECATED;
 $setup["parents"] = $PARENTS;
 manual_setup($setup);
+
+contributors($setup);
 
 ?>
 ';
@@ -268,6 +275,15 @@ manual_setup($setup);
         }
         return isset($this->sources[$id]) ? $this->sources[$id] : null;
     }
+
+    public function loadHistoryInfo() {
+        if (!is_file(Config::phpweb_history_filename())) {
+            $this->history = [];
+            return;
+        }
+
+        $history = include Config::phpweb_history_filename();
+
+        $this->history = (is_array($history)) ? $history : [];
+    }
 }
-
-

--- a/render.php
+++ b/render.php
@@ -60,6 +60,7 @@ if (!$conf) {
         "phpweb_version_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'version.xml',
         "phpweb_acronym_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'entities' . DIRECTORY_SEPARATOR . 'acronyms.xml',
         "phpweb_sources_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'sources.xml',
+        "phpweb_history_filename" => Config::xml_root() . DIRECTORY_SEPARATOR . 'fileModHistory.php',
     ));
 }
 


### PR DESCRIPTION
Load file modification history from file and add it to PHP documentation pages. This data will be used to add last commit date/time and author, as well as a list of all contributors to the each page.

Needs https://github.com/php/doc-base/pull/120 for it to work.