### PR TITLE
Add title color to h1 title elements

### DIFF
--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -1019,7 +1019,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
 
     public function format_container_chunk_title($open, $name, $attrs, $props) {
         if ($open) {
-            return $props["empty"] ? '' : '<h1>';
+            return $props["empty"] ? '' : '<h1 class="title">';
         }
         $ret = "";
         if (isset($this->cchunk["container_chunk"]) && $this->cchunk["container_chunk"]) {

--- a/tests/package/php/faq001.phpt
+++ b/tests/package/php/faq001.phpt
@@ -19,7 +19,7 @@ $render->run();
 Filename: faq.001.html
 Content:
 <div id="faq.001" class="chapter">
-  <h1>FAQ Test 001</h1>
+  <h1 class="title">FAQ Test 001</h1>
 
   
 


### PR DESCRIPTION
Add title color to h1 title elements such as the titles of sections under Appendices in the manual (e.g the title of https://www.php.net/manual/en/history.php).