### PR TITLE
Render elements in simplelist members correctly

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -2166,6 +2166,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($this->cchunk["simplelist"]["type"] === "inline"
             || $this->cchunk["simplelist"]["type"] === "vert"
             || $this->cchunk["simplelist"]["type"] === "horiz") {
+            $this->appendToBuffer = $open;
+            if (! $open) {
+                $this->cchunk["simplelist"]["members"][] = $this->buffer;
+            }
+            $this->buffer = '';
             return '';
         }
         if ($open) {
@@ -2175,12 +2180,6 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
 
     public function format_member_text($value, $tag) {
-        if ($this->cchunk["simplelist"]["type"] === "inline"
-            || $this->cchunk["simplelist"]["type"] === "vert"
-            || $this->cchunk["simplelist"]["type"] === "horiz") {
-            $this->cchunk["simplelist"]["members"][] = $value;
-            return '';
-        }
         return $value;
     }
 

--- a/tests/package/generic/data/simplelist.xml
+++ b/tests/package/generic/data/simplelist.xml
@@ -53,4 +53,30 @@
   </simplelist>
  </section>
 
+ <section>
+  <para>5. Simplelist with no type and various elements inside members</para>
+  <simplelist>
+   <member>1 <literal>First</literal></member>
+   <member>2 <constant>Second</constant></member>
+   <member>3 <code>Third</code></member>
+   <member>4 <literal>Fourth</literal></member>
+   <member>5 <constant>Fifth</constant></member>
+   <member>6 <code>Sixth</code></member>
+   <member>7 <literal>Seventh</literal></member>
+  </simplelist>
+ </section>
+
+ <section>
+  <para>6. Simplelist with "inline" type and various elements inside members</para>
+  <simplelist type="inline">
+   <member>1 <literal>First</literal></member>
+   <member>2 <constant>Second</constant></member>
+   <member>3 <code>Third</code></member>
+   <member>4 <literal>Fourth</literal></member>
+   <member>5 <constant>Fifth</constant></member>
+   <member>6 <code>Sixth</code></member>
+   <member>7 <literal>Seventh</literal></member>
+  </simplelist>
+ </section>
+
 </chapter>

--- a/tests/package/generic/simplelist_001.phpt
+++ b/tests/package/generic/simplelist_001.phpt
@@ -81,4 +81,22 @@ Content:
   </table>
  </div>
 
+ <div class="section">
+  <p class="para">5. Simplelist with no type and various elements inside members</p>
+  <ul class="simplelist">
+   <li>1 <code class="literal">First</code></li>
+   <li>2 <strong><code>Second</code></strong></li>
+   <li>3 <code class="code">Third</code></li>
+   <li>4 <code class="literal">Fourth</code></li>
+   <li>5 <strong><code>Fifth</code></strong></li>
+   <li>6 <code class="code">Sixth</code></li>
+   <li>7 <code class="literal">Seventh</code></li>
+  </ul>
+ </div>
+
+ <div class="section">
+  <p class="para">6. Simplelist with &quot;inline&quot; type and various elements inside members</p>
+  <span class="simplelist">1 <code class="literal">First</code>, 2 <strong><code>Second</code></strong>, 3 <code class="code">Third</code>, 4 <code class="literal">Fourth</code>, 5 <strong><code>Fifth</code></strong>, 6 <code class="code">Sixth</code>, 7 <code class="literal">Seventh</code></span>
+ </div>
+
 </div>


### PR DESCRIPTION
Render elements in `<simplelist>` `<member>`s correctly by buffering all output in a `<member>` element.