### PR TITLE
Use the same indexing database throughout

### DIFF
--- a/phpdotnet/phd/Format.php
+++ b/phpdotnet/phd/Format.php
@@ -63,14 +63,8 @@ abstract class Format extends ObjectStorage
     protected $CURRENT_ID = "";
 
     public function __construct() {
-        $sqlite = Config::indexcache();
-        if (!$sqlite) {
-            if (file_exists(Config::output_dir() . "index.sqlite")) {
-                $sqlite = new \SQLite3(Config::output_dir() . 'index.sqlite');
-            }
-        }
-        if ($sqlite) {
-            $this->sqlite = $sqlite;
+        if (Config::indexcache()) {
+            $this->sqlite = Config::indexcache();
             $this->sortIDs();
         }
     }

--- a/phpdotnet/phd/functions.php
+++ b/phpdotnet/phd/functions.php
@@ -195,12 +195,9 @@ set_error_handler(__NAMESPACE__ . '\\errh');
  *
  * @return boolean True if indexing is required.
  */
-function requireIndexing(Config $config, ?\SQLite3 $db = null): bool {
-    if ($db === null) {
-        $indexfile = $config->output_dir() . 'index.sqlite';
-        if (!file_exists($indexfile)) {
-            return true;
-        }
+function requireIndexing(Config $config): bool {
+    if (! $config->indexcache()) {
+        return true;
     }
 
     if ($config->no_index()) {
@@ -211,9 +208,8 @@ function requireIndexing(Config $config, ?\SQLite3 $db = null): bool {
         return true;
     }
 
-    if ($db === null) {
-        $db = new \SQLite3($indexfile);
-    }
+    $db = $config->indexcache();
+
     $indexingCount = $db->query('SELECT COUNT(time) FROM indexing')
         ->fetchArray(SQLITE3_NUM);
     if ($indexingCount[0] == 0) {


### PR DESCRIPTION
Use the same indexing database in every part of PhD by always retrieving it from `indexcache` and always set `indexcache` before any indexing or rendering is done in `render.php`.