### PR TITLE
Remove output directory creation from render.php

### DIFF
--- a/phpdotnet/phd/Options/Handler.php
+++ b/phpdotnet/phd/Options/Handler.php
@@ -210,8 +210,14 @@ class Options_Handler implements Options_Interface
         if (is_array($v)) {
             trigger_error("Only a single output location can be supplied", E_USER_ERROR);
         }
-        if (!is_dir($v)) {
-            mkdir($v, 0777, true);
+        if (!file_exists($v)) {
+            v("Creating output directory..", VERBOSE_MESSAGES);
+            if (!mkdir($v, 0777, true)) {
+                v("Can't create output directory : %s", $v, E_USER_ERROR);
+            }
+            v("Output directory created", VERBOSE_MESSAGES);
+        } elseif (!is_dir($v)) {
+            v("Output directory is a file?", E_USER_ERROR);
         }
         if (!is_dir($v) || !is_readable($v)) {
             trigger_error(sprintf("'%s' is not a valid directory", $v), E_USER_ERROR);

--- a/render.php
+++ b/render.php
@@ -43,12 +43,7 @@ if (!is_dir(Config::xml_root()) || !is_file(Config::xml_file())) {
     trigger_error("No Docbook file given. Specify it on the command line with --docbook.", E_USER_ERROR);
 }
 if (!file_exists(Config::output_dir())) {
-    v("Creating output directory..", VERBOSE_MESSAGES);
-    if (!mkdir(Config::output_dir(), 0777, True)) {
-        v("Can't create output directory : %s", Config::output_dir(), E_USER_ERROR);
-    }
-} elseif (!is_dir(Config::output_dir())) {
-    v("Output directory is not a file?", E_USER_ERROR);
+    v("Output directory doesn't exist", E_USER_ERROR);
 }
 
 // This needs to be moved. Preferably into the PHP package.


### PR DESCRIPTION
Remove output directory creation from render.php as this is already done in `Config` when setting the output directory. Move the appropriate checks and errors/warnings from `render.php` to `Config`.