### PR TITLE
Added IndexRepository.php entry for pear install command

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -130,6 +130,7 @@
           <file name="functions.php" role="php"/>
           <file name="Highlighter.php" role="php"/>
           <file name="Index.php" role="php"/>
+          <file name="IndexRepository.php" role="php"/>
           <file name="MediaManager.php" role="php"/>
           <file name="ObjectStorage.php" role="php"/>
           <file name="PIHandler.php" role="php"/>


### PR DESCRIPTION
I cannot run phd of the latest HEAD.
This is because `IndexRepository.php` is added in https://github.com/php/phd/commit/26bf0c610a61160a3e4cc91e88ed68e0f179e28f.

```
$ phd -f xhtml -L ja -P PHP -d doc-base/.manual.xml
[12:29:14 - Indexing              ] Indexing...
[12:29:14 - E_USER_ERROR          ] /home/mumumu/.phpenv/versions/8.3.6/lib/php/phpdotnet/phd/Autoloader.php:26
        Cannot find file for phpdotnet\phd\IndexRepository: /home/mumumu/.phpenv/versions/8.3.6/lib/php/phpdotnet/phd/IndexRepository.php
```

When refactoring to organize files, please also pay attention to the entries in package.xml. 