### PR TITLE
Fix GH-3353 incorrect function tag linking

### DIFF
--- a/phpdotnet/phd/IndexRepository.php
+++ b/phpdotnet/phd/IndexRepository.php
@@ -189,13 +189,7 @@ SQL;
 
 
     private function SQLiteRefname($context, $index, $id, $sdesc): void {
-        $ref = strtolower(
-                str_replace(
-                    ["_", "::", "->"],
-                    ["-", "-", "-"],
-                    html_entity_decode($sdesc, ENT_QUOTES, 'UTF-8')
-                )
-            );
+        $ref = strtolower(html_entity_decode($sdesc, ENT_QUOTES, 'UTF-8'));
         $this->refs[$ref] = $id;
     }
 

--- a/phpdotnet/phd/Package/Generic/PDF.php
+++ b/phpdotnet/phd/Package/Generic/PDF.php
@@ -586,7 +586,7 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
             $display_value = $value;
         }
 
-        $ref = strtolower(str_replace(array("_", "::", "->"), array("-", "-", "-"), $value));
+        $ref = strtolower($value);
         if (($linkend = $this->getRefnameLink($ref)) !== null) {
             $this->pdfDoc->setFont(PdfWriter::FONT_NORMAL, 12, array(0, 0, 1)); // blue
             $linkAreas = $this->pdfDoc->add(PdfWriter::LINK_ANNOTATION, $display_value.($tag == "function" ? "()" : ""));

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -837,7 +837,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         if (isset($non_functions[$value])) {
             $filename = "function." . str_replace("_", "-", $value);
         } else {
-            $ref = strtolower(str_replace(array("_", "::", "->"), array("-", "-", "-"), $value));
+            $ref = strtolower($value);
             $filename = $this->getRefnameLink($ref);
         }
         if ($filename !== null) {

--- a/tests/bug_doc-en_GH-3353.phpt
+++ b/tests/bug_doc-en_GH-3353.phpt
@@ -1,0 +1,101 @@
+--TEST--
+Bug doc-en GH-3353 - incorrect method/function linking when a method's name and a function's name are normalized to the same string
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/setup.php";
+
+$xml_file = __DIR__ . "/data/bug_doc-en_GH-3353.xml";
+
+Config::init([
+    "force_index"    => true,
+    "xml_file" => $xml_file,
+]);
+
+$render = new Render();
+
+$indexRepository = new IndexRepository(new \SQLite3(":memory:"));
+$indexRepository->init();
+Config::set_indexcache($indexRepository);
+
+
+// Indexing
+$index = new TestIndex($indexRepository);
+$render->attach($index);
+
+$reader = new Reader;
+$reader->open(Config::xml_file(), null, LIBXML_PARSEHUGE | LIBXML_XINCLUDE);
+$render->execute($reader);
+
+$render->detach($index);
+
+
+// Rendering
+$format = new TestPHPChunkedXHTML;
+$render->attach($format);
+
+$reader = new Reader;
+$reader->open(Config::xml_file(), null, LIBXML_PARSEHUGE | LIBXML_XINCLUDE);
+
+$render->execute($reader);
+?>
+--EXPECT--
+Filename: method.and.function.html
+Content:
+<div id="method.and.function" class="refentry">
+  <div class="refnamediv">
+   <h1 class="refname">ClassName::methodName</h1>
+   <h1 class="refname">classname_methodname</h1>
+   <p class="verinfo">(No version information available, might only be in Git)</p><p class="refpurpose"><span class="refname">ClassName::methodName</span> -- <span class="refname">classname_methodname</span> &mdash; <span class="dc-title">1. This is the first method/function description</span></p>
+
+  </div>
+  <div class="refsect1 description" id="method.and.function-description">
+   <p class="para">
+    Link to <span class="function"><a href="method.only.html" class="function">ClassName::methodName()</a></span>
+    and to <span class="function"><a href="function.only.html" class="function">classname_methodname()</a></span>
+   </p>
+  </div>
+
+ </div>
+Filename: method.only.html
+Content:
+<div id="method.only" class="refentry">
+  <div class="refnamediv">
+   <h1 class="refname">ClassName::methodName</h1>
+   <p class="verinfo">(No version information available, might only be in Git)</p><p class="refpurpose"><span class="refname">ClassName::methodName</span> &mdash; <span class="dc-title">2. This is the second (method) description</span></p>
+
+  </div>
+  <div class="refsect1 description" id="method.only-description">
+   <p class="para">
+    Link to <span class="function"><strong>ClassName::methodName()</strong></span>
+    and to <span class="function"><a href="function.only.html" class="function">classname_methodname()</a></span>
+   </p>
+  </div>
+
+ </div>
+Filename: function.only.html
+Content:
+<div id="function.only" class="refentry">
+  <div class="refnamediv">
+   <h1 class="refname">classname_methodname</h1>
+   <p class="verinfo">(No version information available, might only be in Git)</p><p class="refpurpose"><span class="refname">classname_methodname</span> &mdash; <span class="dc-title">3. This is the third (function) description</span></p>
+
+  </div>
+  <div class="refsect1 description" id="function.only-description">
+   <p class="para">
+    Link to <span class="function"><a href="method.only.html" class="function">ClassName::methodName()</a></span>
+    and to <span class="function"><strong>classname_methodname()</strong></span>
+   </p>
+  </div>
+
+ </div>
+Filename: function.only.html
+Content:
+<div id="bug_doc-en_GH-3353" class="refentry">
+ 
+
+ 
+
+ 
+</div>

--- a/tests/bug_doc-en_GH-3353.phpt
+++ b/tests/bug_doc-en_GH-3353.phpt
@@ -52,8 +52,10 @@ Content:
   </div>
   <div class="refsect1 description" id="method.and.function-description">
    <p class="para">
-    Link to <span class="function"><a href="method.only.html" class="function">ClassName::methodName()</a></span>
-    and to <span class="function"><a href="function.only.html" class="function">classname_methodname()</a></span>
+    Link to <span class="function"><a href="method.only.html" class="function">ClassName::methodName()</a></span> with a function tag
+    and to <span class="function"><a href="function.only.html" class="function">classname_methodname()</a></span> with a function tag
+    and to <span class="methodname"><a href="method.only.html" class="methodname">ClassName::methodName()</a></span> with a methodname tag
+    and to <span class="methodname"><a href="function.only.html" class="methodname">classname_methodname()</a></span> with a methodname tag
    </p>
   </div>
 
@@ -68,8 +70,10 @@ Content:
   </div>
   <div class="refsect1 description" id="method.only-description">
    <p class="para">
-    Link to <span class="function"><strong>ClassName::methodName()</strong></span>
-    and to <span class="function"><a href="function.only.html" class="function">classname_methodname()</a></span>
+    Link to <span class="function"><strong>ClassName::methodName()</strong></span> with a function tag
+    and to <span class="function"><a href="function.only.html" class="function">classname_methodname()</a></span> with a function tag
+    and to <span class="methodname"><strong>ClassName::methodName()</strong></span> with a methodname tag
+    and to <span class="methodname"><a href="function.only.html" class="methodname">classname_methodname()</a></span> with a methodname tag
    </p>
   </div>
 
@@ -84,8 +88,10 @@ Content:
   </div>
   <div class="refsect1 description" id="function.only-description">
    <p class="para">
-    Link to <span class="function"><a href="method.only.html" class="function">ClassName::methodName()</a></span>
-    and to <span class="function"><strong>classname_methodname()</strong></span>
+    Link to <span class="function"><a href="method.only.html" class="function">ClassName::methodName()</a></span> with a function tag
+    and to <span class="function"><strong>classname_methodname()</strong></span> with a function tag
+    and to <span class="methodname"><a href="method.only.html" class="methodname">ClassName::methodName()</a></span> with a methodname tag
+    and to <span class="methodname"><strong>classname_methodname()</strong></span> with a methodname tag
    </p>
   </div>
 

--- a/tests/data/bug_doc-en_GH-3353.xml
+++ b/tests/data/bug_doc-en_GH-3353.xml
@@ -1,0 +1,41 @@
+<refentry xml:id="bug_doc-en_GH-3353">
+ <refentry xml:id="method.and.function">
+  <refnamediv>
+   <refname>ClassName::methodName</refname>
+   <refname>classname_methodname</refname>
+   <refpurpose>1. This is the first method/function description</refpurpose>
+  </refnamediv>
+  <refsect1 role="description" xml:id="method.and.function-description">
+   <para>
+    Link to <function>ClassName::methodName</function>
+    and to <function>classname_methodname</function>
+   </para>
+  </refsect1>
+ </refentry>
+
+ <refentry xml:id="method.only">
+  <refnamediv>
+   <refname>ClassName::methodName</refname>
+   <refpurpose>2. This is the second (method) description</refpurpose>
+  </refnamediv>
+  <refsect1 role="description" xml:id="method.only-description">
+   <para>
+    Link to <function>ClassName::methodName</function>
+    and to <function>classname_methodname</function>
+   </para>
+  </refsect1>
+ </refentry>
+
+ <refentry xml:id="function.only">
+  <refnamediv>
+   <refname>classname_methodname</refname>
+   <refpurpose>3. This is the third (function) description</refpurpose>
+  </refnamediv>
+  <refsect1 role="description" xml:id="function.only-description">
+   <para>
+    Link to <function>ClassName::methodName</function>
+    and to <function>classname_methodname</function>
+   </para>
+  </refsect1>
+ </refentry>
+</refentry>

--- a/tests/data/bug_doc-en_GH-3353.xml
+++ b/tests/data/bug_doc-en_GH-3353.xml
@@ -7,8 +7,10 @@
   </refnamediv>
   <refsect1 role="description" xml:id="method.and.function-description">
    <para>
-    Link to <function>ClassName::methodName</function>
-    and to <function>classname_methodname</function>
+    Link to <function>ClassName::methodName</function> with a function tag
+    and to <function>classname_methodname</function> with a function tag
+    and to <methodname>ClassName::methodName</methodname> with a methodname tag
+    and to <methodname>classname_methodname</methodname> with a methodname tag
    </para>
   </refsect1>
  </refentry>
@@ -20,8 +22,10 @@
   </refnamediv>
   <refsect1 role="description" xml:id="method.only-description">
    <para>
-    Link to <function>ClassName::methodName</function>
-    and to <function>classname_methodname</function>
+    Link to <function>ClassName::methodName</function> with a function tag
+    and to <function>classname_methodname</function> with a function tag
+    and to <methodname>ClassName::methodName</methodname> with a methodname tag
+    and to <methodname>classname_methodname</methodname> with a methodname tag
    </para>
   </refsect1>
  </refentry>
@@ -33,8 +37,10 @@
   </refnamediv>
   <refsect1 role="description" xml:id="function.only-description">
    <para>
-    Link to <function>ClassName::methodName</function>
-    and to <function>classname_methodname</function>
+    Link to <function>ClassName::methodName</function> with a function tag
+    and to <function>classname_methodname</function> with a function tag
+    and to <methodname>ClassName::methodName</methodname> with a methodname tag
+    and to <methodname>classname_methodname</methodname> with a methodname tag
    </para>
   </refsect1>
  </refentry>


### PR DESCRIPTION
Closes https://github.com/php/doc-en/issues/3353.

When the list of `refentry`s (functions and methods) is retrieved from the indexing database the characters `_`, `::` and `->` in their names were replaced by `-` before storing them in the array `$ref` in `Format.php`. As this array is used to generate the links to and the index list of functions/methods, functions and methods with the same name after replacing the before mentioned characters (e.g. `finfo_buffer()`/`finfo::buffer()`, `finfo_file()`/`finfo::file()`, etc.) were overwriting each other's reference entries in memory (in the `$ref` array).

Fix this by not replacing the above listed characters.