### PR TITLE
Remove superfluous database initialization

### DIFF
--- a/render.php
+++ b/render.php
@@ -122,7 +122,6 @@ Config::set_indexcache($indexRepository);
 // Indexing
 if (requireIndexing(new Config)) {
     v("Indexing...", VERBOSE_INDEXING);
-    Config::indexcache()->init();
     // Create indexer
     $format = new Index(Config::indexcache());
     $render->attach($format);


### PR DESCRIPTION
Remove superfluous database initialization as database is already initialized during the initialization of Indexing.