### PR TITLE
Use parent class's IndexRepository in Index

### DIFF
--- a/phpdotnet/phd/Format.php
+++ b/phpdotnet/phd/Format.php
@@ -24,7 +24,7 @@ abstract class Format extends ObjectStorage
     private $elementmap = array();
     private $textmap = array();
     private $formatname = "UNKNOWN";
-    private IndexRepository $indexRepository;
+    protected IndexRepository $indexRepository;
 
     protected $title;
     protected $fp = array();

--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -83,7 +83,6 @@ class Index extends Format
         'phpdoc'            => 'PI_PHPDOCHandler',
     );
 
-    private IndexRepository $indexRepository;
     private $currentchunk;
     private $ids       = array();
     private $currentid;


### PR DESCRIPTION
Make `Format`'s `IndexRepository` `protected` and use it from `Index` which now inherits this property from `Format`. Drop `Index`'s own `IndexRepository` property.