### PR TITLE
Remove ReaderKeeper from Index

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -57,10 +57,10 @@ class Index extends Format
     ),
     'set'                   => 'format_container_chunk',
     'setindex'              => 'format_chunk',
-    'title'                 => 'format_ldesc',
-    'refpurpose'            => 'format_ldesc',
-    'refname'               => 'format_sdesc',
-    'titleabbrev'           => 'format_sdesc',
+    'title'                 => 'format_long_desc',
+    'refpurpose'            => 'format_long_desc',
+    'refname'               => 'format_short_desc',
+    'titleabbrev'           => 'format_short_desc',
     'example'               => 'format_example',
     'refsect1'              => 'format_refsect1',
     'tbody'                 => array(
@@ -83,10 +83,10 @@ class Index extends Format
         'phpdoc'            => 'PI_PHPDOCHandler',
     );
 
-    private bool $inLdesc = false;
-    private bool $inSdesc = false;
-    private string $currentLdesc = "";
-    private string $currentSdesc = "";
+    private bool $inLongDesc = false;
+    private bool $inShortDesc = false;
+    private string $currentLongDesc = "";
+    private string $currentShortDesc = "";
     private $currentchunk;
     private $ids       = array();
     private $currentid;
@@ -112,11 +112,11 @@ class Index extends Format
     public function transformFromMap($open, $tag, $name, $attrs, $props) {
     }
     public function TEXT($value) {
-        if ($this->inLdesc) {
-            $this->currentLdesc .= $value;
+        if ($this->inLongDesc) {
+            $this->currentLongDesc .= $value;
         }
-        if ($this->inSdesc) {
-            $this->currentSdesc .= $value;
+        if ($this->inShortDesc) {
+            $this->currentShortDesc .= $value;
         }
         if ($this->inChangelog) {
             $this->currentChangeLogString .= $value;
@@ -127,11 +127,11 @@ class Index extends Format
     public function createLink($for, &$desc = null, $type = Format::SDESC) {
     }
     public function appendData($data) {
-        if ($this->inLdesc && is_string($data) && trim($data) === "") {
-            $this->currentLdesc .= $data;
+        if ($this->inLongDesc && is_string($data) && trim($data) === "") {
+            $this->currentLongDesc .= $data;
         }
-        if ($this->inSdesc && is_string($data) && trim($data) === "") {
-            $this->currentSdesc .= $data;
+        if ($this->inShortDesc && is_string($data) && trim($data) === "") {
+            $this->currentShortDesc .= $data;
         }
         if ($this->inChangelog && is_string($data) && trim($data) === "") {
             $this->currentChangeLogString .= $data;
@@ -344,25 +344,25 @@ class Index extends Format
         return false;
     }
 
-    public function format_ldesc($open, $name, $attrs, $props) {
+    public function format_long_desc($open, $name, $attrs, $props) {
         if ($open) {
-            $this->inLdesc = true;
-            $this->currentLdesc = "";
+            $this->inLongDesc = true;
+            $this->currentLongDesc = "";
             return;
         }
-        $this->inLdesc = false;
+        $this->inLongDesc = false;
         if (empty($this->nfo[$this->currentid]["ldesc"])) {
-            $this->nfo[$this->currentid]["ldesc"] = htmlentities(trim($this->currentLdesc), ENT_COMPAT, "UTF-8");
+            $this->nfo[$this->currentid]["ldesc"] = htmlentities(trim($this->currentLongDesc), ENT_COMPAT, "UTF-8");
         }
     }
-    public function format_sdesc($open, $name, $attrs, $props) {
+    public function format_short_desc($open, $name, $attrs, $props) {
         if ($open) {
-            $this->inSdesc = true;
-            $this->currentSdesc = "";
+            $this->inShortDesc = true;
+            $this->currentShortDesc = "";
             return;
         }
-        $this->inSdesc = false;
-        $s = htmlentities(trim($this->currentSdesc), ENT_COMPAT, "UTF-8");
+        $this->inShortDesc = false;
+        $s = htmlentities(trim($this->currentShortDesc), ENT_COMPAT, "UTF-8");
         if (empty($this->nfo[$this->currentid]["sdesc"])) {
             $this->nfo[$this->currentid]["sdesc"] = $s;
         } else {


### PR DESCRIPTION
`ReaderKeeper` is a global static object wrapper around an array that contains the active `Reader` and is used by three `Format`s to read the contents of certain tags as string, XML or return it as a DOM Node. 

This PR removes `ReaderKeeper` from the `Index` `Format` by delaying writing the long and short descriptions, and the changelog tables until after the appropriate tags are closed. This is done in a similar way to how method parameters are rendered, ie. by keeping everything inside the tag in temporary variables and processing them when the tag is closed.

There is no test for this PR but I've done a full render of `doc-en` with and without these changes and there are zero diffs for the ~12k files generated.