### PR TITLE
Remove html_entity_decode() when getting refentry names from the database

### DIFF
--- a/phpdotnet/phd/IndexRepository.php
+++ b/phpdotnet/phd/IndexRepository.php
@@ -189,7 +189,7 @@ SQL;
 
 
     private function SQLiteRefname($context, $index, $id, $sdesc): void {
-        $ref = strtolower(html_entity_decode($sdesc, ENT_QUOTES, 'UTF-8'));
+        $ref = strtolower($sdesc);
         $this->refs[$ref] = $id;
     }
 


### PR DESCRIPTION
`refentry` names are taken from xml IDs and stored in the database during indexing. These are then retrieved and used for linking to functions and methods. Do not use `html_entity_decode()` on these names as these IDs should not have entities in them to begin with. This change aligns this function with the function/method linking functions that only do `strtolower()` as well.

There is no test for this PR but I've ran the a full render of `doc-en` with and without this change and there were zero diffs for the ~12k generated files.