### PR TITLE
Fix GH 65

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -274,6 +274,8 @@ class Index extends Format
                 'class', 'enum' => $this->format_container_chunk($open, 'phpdoc:classref', $attrs, $props),
                 'exception' => $this->format_container_chunk($open, 'phpdoc:exceptionref', $attrs, $props),
                 'variable' => $this->format_chunk($open, 'phpdoc:varentry', $attrs, $props),
+                'stream_wrapper' => $this->format_chunk($open, 'stream_wrapper', $attrs, $props),
+                'stream_context_option' => $this->format_chunk($open, 'stream_context_option', $attrs, $props),
                 default => $this->format_chunk($open, $name, $attrs, $props),
             };
         }


### PR DESCRIPTION
Remove spurious entries some language documentations have in the function/method listing. The spurious entries were the stream wrapper and context options which were listed in refentry elements. PhD assumes that refentry elements are always functions/methods. Fix this by giving stream wrappers and context options a role attribute with an appropriate value and handling these roles/values during indexing in PhD.

Closes #65 