### PR TITLE
DocBook 5.2 class and exception markup migration

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -35,7 +35,7 @@ class Index extends Format
     'phpdoc:varentry'       => 'format_chunk',
     'preface'               => 'format_chunk',
     'refentry'              => 'format_refentry',
-    'reference'             => 'format_container_chunk',
+    'reference'             => 'format_reference',
     'sect1'                 => 'format_chunk',
     'section'               => array(
         /* DEFAULT */          false,
@@ -446,4 +446,14 @@ class Index extends Format
         $this->currentMembership = $membership;
     }
 
+    public function format_reference($open, $name, $attrs, $props) {
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+            $name = match ($attrs[Reader::XMLNS_DOCBOOK]['role']) {
+                "class" => "phpdoc:classref",
+                "exception" => "phpdoc:exceptionref",
+                default => $name,
+            };
+        }
+        return $this->format_container_chunk($open, $name, $attrs, $props);
+    }
 }

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1626,7 +1626,21 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
     public function format_screen($open, $name, $attrs) {
         if ($open) {
+            if ($this->getRole() !== "examples"
+                && $this->getRole() !== "description"
+                && $this->getRole() !== "notes"
+                && $this->getRole() !== "returnvalues"
+                && $this->getRole() !== "parameters") {
+                $this->pushRole('');
+            }
             return '<div class="example-contents ' .$name. '">';
+        }
+        if ($this->getRole() !== "examples"
+            && $this->getRole() !== "description"
+            && $this->getRole() !== "notes"
+            && $this->getRole() !== "returnvalues"
+            && $this->getRole() !== "parameters") {
+            $this->popRole();
         }
         return '</div>';
     }

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -152,6 +152,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             /* DEFAULT */          'format_suppressed_text',
             'phpdoc:classref'   => 'format_grep_classname_text',
             'phpdoc:exceptionref'  => 'format_grep_classname_text',
+            'reference'            => 'format_reference_titleabbrev_text',
             'refentry' => 'format_grep_classname_text',
         ),
          'varname'               => array(
@@ -1065,9 +1066,22 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
             if ($attrs[Reader::XMLNS_DOCBOOK]['role'] === "class"
                 || $attrs[Reader::XMLNS_DOCBOOK]['role'] === "exception") {
+                if ($open) {
+                    $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]['role']);
+                } else {
+                    $this->popRole();
+                }
                 return $this->format_class_chunk($open, $name, $attrs, $props);
             }
         }
         return $this->format_container_chunk($open, $name, $attrs, $props);
+    }
+
+    public function format_reference_titleabbrev_text($value, $tag) {
+        if ($this->getRole() === "class"
+            || $this->getRole() === "exception") {
+            return $this->format_grep_classname_text($value, $tag);
+        }
+        return $this->format_suppressed_text($value, $tag);
     }
 }

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -25,7 +25,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         'phpdoc:exceptionref'   => 'format_class_chunk',
         'phpdoc:varentry'       => 'format_varentry_chunk',
         'refentry'              => 'format_refentry',
-        'reference'             => 'format_container_chunk',
+        'reference'             => 'format_reference',
         'refpurpose'            => 'format_refpurpose',
         'refsynopsisdiv'        => 'format_refsynopsisdiv',
         'set'                   => 'format_root_chunk',
@@ -1061,6 +1061,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         return $this->format_container_chunk($open, "reference", $attrs, $props);
     }
 
+    public function format_reference($open, $name, $attrs, $props) {
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
+            if ($attrs[Reader::XMLNS_DOCBOOK]['role'] === "class"
+                || $attrs[Reader::XMLNS_DOCBOOK]['role'] === "exception") {
+                return $this->format_class_chunk($open, $name, $attrs, $props);
+            }
+        }
+        return $this->format_container_chunk($open, $name, $attrs, $props);
+    }
 }
-
-

--- a/tests/package/php/class_rendering_001.phpt
+++ b/tests/package/php/class_rendering_001.phpt
@@ -1,0 +1,129 @@
+--TEST--
+Class rendering 001 - phpdoc:classref rendering
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/class_rendering_001.xml";
+
+Config::init(["xml_file" => $xml_file]);
+
+$format = new TestPHPChunkedXHTML;
+$render = new TestRender(new Reader, new Config, $format);
+
+$render->run();
+?>
+--EXPECTF--
+Filename: classname.construct.html
+Content:
+<div id="classname.construct" class="refentry">
+     <div class="refnamediv">
+      <h1 class="refname">ClassName::__construct</h1>
+      <p class="verinfo">(No version information available, might only be in Git)</p><p class="refpurpose"><span class="refname">ClassName::__construct</span> &mdash; <span class="dc-title">Returns new ClassName object</span></p>
+
+     </div>
+
+     <div class="refsect1 description" id="refsect1-classname.construct-description">
+      Description
+      <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$firstParameter</code><span class="initializer"> = &quot;now&quot;</span></span>)</div>
+
+      <p class="para rdfs-comment">
+       Returns new a ClassName object.
+      </p>
+     </div>
+
+
+     <div class="refsect1 parameters" id="refsect1-classname.construct-parameters">
+      <h3 class="title">Parameters</h3>
+      <dl>
+       
+        <dt><code class="parameter">firstParameter</code></dt>
+        <dd>
+         <p class="para">
+          The description of the parameter.
+         </p>
+        </dd>
+       
+      </dl>
+     </div>
+
+
+     <div class="refsect1 returnvalues" id="refsect1-classname.construct-returnvalues">
+      <h3 class="title">Return Values</h3>
+      <p class="para">
+       Return values of the method.
+      </p>
+     </div>
+
+
+     <div class="refsect1 errors" id="refsect1-classname.construct-errors">
+      <h3 class="title">Errors/Exceptions</h3>
+      <p class="para">
+       Exceptions thrown and/or errors raised by the method.
+      </p>
+     </div>
+
+
+    </div>
+Filename: class.classname.html
+Content:
+<div id="class.classname" class="reference">
+
+ <h1 class="title">The ClassName class</h1>
+ 
+
+ <div class="partintro"><p class="verinfo">(No version information available, might only be in Git)</p>
+
+  <div class="section" id="classname.intro">
+   <h2 class="title">Introduction</h2>
+   <p class="para">
+    Introductory paragraph about the class.
+   </p>
+  </div>
+
+  <div class="section" id="classname.synopsis">
+   <h2 class="title">Class synopsis</h2>
+
+   <div class="classsynopsis"><div class="classsynopsisinfo">
+    
+     <span class="modifier">class</span> <strong class="classname"><strong class="classname">ClassName</strong></strong>
+    
+
+    
+     <span class="modifier">implements</span>
+      <strong class="interfacename">InterfaceName</strong> {</div>
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Constants */</div>
+    <div class="fieldsynopsis">
+     <span class="modifier">public</span>
+     <span class="modifier">const</span>
+     <span class="type"><a href="language.types.string.html" class="type string">string</a></span>
+      <var class="fieldsynopsis_varname"><a href=".html#classname.constants.first-constant"><var class="varname">FIRST_CONSTANT</var></a></var><span class="initializer"> = &quot;Initial value&quot;</span>;</div>
+
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
+
+    
+   }</div>
+
+  </div>
+
+  <div class="section" id="classname.constants.types">
+   <h2 class="title">Predefined Constants</h2>
+   <dl>
+    
+     <dt id="classname.constants.first-constant"><strong><code>ClassName::FIRST_CONSTANT</code></strong></dt>
+     <dd>
+      <span class="simpara">
+       The description of the class constant.
+      </span>
+     </dd>
+    
+   </dl>
+  </div>
+
+ </div>
+
+</div>

--- a/tests/package/php/class_rendering_002.phpt
+++ b/tests/package/php/class_rendering_002.phpt
@@ -1,0 +1,129 @@
+--TEST--
+Class rendering 002 - reference element with role="class" rendering
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/class_rendering_002.xml";
+
+Config::init(["xml_file" => $xml_file]);
+
+$format = new TestPHPChunkedXHTML;
+$render = new TestRender(new Reader, new Config, $format);
+
+$render->run();
+?>
+--EXPECTF--
+Filename: classname.construct.html
+Content:
+<div id="classname.construct" class="refentry">
+     <div class="refnamediv">
+      <h1 class="refname">ClassName::__construct</h1>
+      <p class="verinfo">(No version information available, might only be in Git)</p><p class="refpurpose"><span class="refname">ClassName::__construct</span> &mdash; <span class="dc-title">Returns new ClassName object</span></p>
+
+     </div>
+
+     <div class="refsect1 description" id="refsect1-classname.construct-description">
+      Description
+      <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$firstParameter</code><span class="initializer"> = &quot;now&quot;</span></span>)</div>
+
+      <p class="para rdfs-comment">
+       Returns new a ClassName object.
+      </p>
+     </div>
+
+
+     <div class="refsect1 parameters" id="refsect1-classname.construct-parameters">
+      <h3 class="title">Parameters</h3>
+      <dl>
+       
+        <dt><code class="parameter">firstParameter</code></dt>
+        <dd>
+         <p class="para">
+          The description of the parameter.
+         </p>
+        </dd>
+       
+      </dl>
+     </div>
+
+
+     <div class="refsect1 returnvalues" id="refsect1-classname.construct-returnvalues">
+      <h3 class="title">Return Values</h3>
+      <p class="para">
+       Return values of the method.
+      </p>
+     </div>
+
+
+     <div class="refsect1 errors" id="refsect1-classname.construct-errors">
+      <h3 class="title">Errors/Exceptions</h3>
+      <p class="para">
+       Exceptions thrown and/or errors raised by the method.
+      </p>
+     </div>
+
+
+    </div>
+Filename: class.classname.html
+Content:
+<div id="class.classname" class="reference">
+
+ <h1 class="title">The ClassName class</h1>
+ 
+
+ <div class="partintro"><p class="verinfo">(No version information available, might only be in Git)</p>
+
+  <div class="section" id="classname.intro">
+   <h2 class="title">Introduction</h2>
+   <p class="para">
+    Introductory paragraph about the class.
+   </p>
+  </div>
+
+  <div class="section" id="classname.synopsis">
+   <h2 class="title">Class synopsis</h2>
+
+   <div class="classsynopsis"><div class="classsynopsisinfo">
+    
+     <span class="modifier">class</span> <strong class="classname"><strong class="classname">ClassName</strong></strong>
+    
+
+    
+     <span class="modifier">implements</span>
+      <strong class="interfacename">InterfaceName</strong> {</div>
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Constants */</div>
+    <div class="fieldsynopsis">
+     <span class="modifier">public</span>
+     <span class="modifier">const</span>
+     <span class="type"><a href="language.types.string.html" class="type string">string</a></span>
+      <var class="fieldsynopsis_varname"><a href=".html#classname.constants.first-constant"><var class="varname">FIRST_CONSTANT</var></a></var><span class="initializer"> = &quot;Initial value&quot;</span>;</div>
+
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
+
+    
+   }</div>
+
+  </div>
+
+  <div class="section" id="classname.constants.types">
+   <h2 class="title">Predefined Constants</h2>
+   <dl>
+    
+     <dt id="classname.constants.first-constant"><strong><code>ClassName::FIRST_CONSTANT</code></strong></dt>
+     <dd>
+      <span class="simpara">
+       The description of the class constant.
+      </span>
+     </dd>
+    
+   </dl>
+  </div>
+
+ </div>
+
+</div>

--- a/tests/package/php/class_rendering_003.phpt
+++ b/tests/package/php/class_rendering_003.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Class rendering 003 - compare output of phpdoc:classref and reference element with role="class" rendering
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_filePhpdoc = __DIR__ . "/data/class_rendering_001.xml";
+
+Config::init(["xml_file" => $xml_filePhpdoc]);
+
+$formatPhpdoc = new TestPHPChunkedXHTML;
+$renderPhpdoc = new TestRender(new Reader, new Config, $formatPhpdoc);
+
+ob_start();
+$renderPhpdoc->run();
+$phpdocOutput = ob_get_clean();
+
+
+$xml_fileReferenceWithRole = __DIR__ . "/data/class_rendering_002.xml";
+
+Config::init(["xml_file" => $xml_fileReferenceWithRole]);
+
+$formatReferenceWithRole = new TestPHPChunkedXHTML;
+$renderReferenceWithRole = new TestRender(new Reader, new Config, $formatReferenceWithRole);
+
+ob_start();
+$renderReferenceWithRole->run();
+$referenceWithRoleOutput = ob_get_clean();
+
+var_dump($phpdocOutput === $referenceWithRoleOutput);
+?>
+--EXPECT--
+bool(true)

--- a/tests/package/php/data/class_rendering_001.xml
+++ b/tests/package/php/data/class_rendering_001.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.classname" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" >
+
+ <title>The ClassName class</title>
+ <titleabbrev>ClassName</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="classname.intro">
+   <title>Introduction</title>
+   <para>
+    Introductory paragraph about the class.
+   </para>
+  </section>
+
+  <section xml:id="classname.synopsis">
+   <title>Class synopsis</title>
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>ClassName</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>InterfaceName</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="classname.constants.first-constant">ClassName::FIRST_CONSTANT</varname>
+     <initializer>"Initial value"</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+
+    <refentry xml:id="classname.construct" xmlns="http://docbook.org/ns/docbook">
+     <refnamediv>
+      <refname>ClassName::__construct</refname>
+      <refpurpose>Returns new ClassName object</refpurpose>
+     </refnamediv>
+
+     <refsect1 role="description">
+      Description
+      <constructorsynopsis>
+       <modifier>public</modifier> <methodname>ClassName::__construct</methodname>
+       <methodparam choice="opt"><type>string</type><parameter>firstParameter</parameter><initializer>"now"</initializer></methodparam>
+      </constructorsynopsis>
+      <para>
+       Returns new a ClassName object.
+      </para>
+     </refsect1>
+
+     <refsect1 role="parameters">
+      <title>Parameters</title>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>firstParameter</parameter></term>
+        <listitem>
+         <para>
+          The description of the parameter.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </refsect1>
+
+     <refsect1 role="returnvalues">
+      <title>Return Values</title>
+      <para>
+       Return values of the method.
+      </para>
+     </refsect1>
+
+     <refsect1 role="errors">
+      <title>Errors/Exceptions</title>
+      <para>
+       Exceptions thrown and/or errors raised by the method.
+      </para>
+     </refsect1>
+
+    </refentry>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="classname.constants.types">
+   <title>Predefined Constants</title>
+   <variablelist>
+    <varlistentry xml:id="classname.constants.first-constant">
+     <term><constant>ClassName::FIRST_CONSTANT</constant></term>
+     <listitem>
+      <simpara>
+       The description of the class constant.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>

--- a/tests/package/php/data/class_rendering_002.xml
+++ b/tests/package/php/data/class_rendering_002.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<reference xml:id="class.classname" role="class" xmlns="http://docbook.org/ns/docbook" >
+
+ <title>The ClassName class</title>
+ <titleabbrev>ClassName</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="classname.intro">
+   <title>Introduction</title>
+   <para>
+    Introductory paragraph about the class.
+   </para>
+  </section>
+
+  <section xml:id="classname.synopsis">
+   <title>Class synopsis</title>
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>ClassName</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>InterfaceName</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="classname.constants.first-constant">ClassName::FIRST_CONSTANT</varname>
+     <initializer>"Initial value"</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+
+    <refentry xml:id="classname.construct" xmlns="http://docbook.org/ns/docbook">
+     <refnamediv>
+      <refname>ClassName::__construct</refname>
+      <refpurpose>Returns new ClassName object</refpurpose>
+     </refnamediv>
+
+     <refsect1 role="description">
+      Description
+      <constructorsynopsis>
+       <modifier>public</modifier> <methodname>ClassName::__construct</methodname>
+       <methodparam choice="opt"><type>string</type><parameter>firstParameter</parameter><initializer>"now"</initializer></methodparam>
+      </constructorsynopsis>
+      <para>
+       Returns new a ClassName object.
+      </para>
+     </refsect1>
+
+     <refsect1 role="parameters">
+      <title>Parameters</title>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>firstParameter</parameter></term>
+        <listitem>
+         <para>
+          The description of the parameter.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </refsect1>
+
+     <refsect1 role="returnvalues">
+      <title>Return Values</title>
+      <para>
+       Return values of the method.
+      </para>
+     </refsect1>
+
+     <refsect1 role="errors">
+      <title>Errors/Exceptions</title>
+      <para>
+       Exceptions thrown and/or errors raised by the method.
+      </para>
+     </refsect1>
+
+    </refentry>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="classname.constants.types">
+   <title>Predefined Constants</title>
+   <variablelist>
+    <varlistentry xml:id="classname.constants.first-constant">
+     <term><constant>ClassName::FIRST_CONSTANT</constant></term>
+     <listitem>
+      <simpara>
+       The description of the class constant.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+</reference>

--- a/tests/package/php/data/exception_rendering_001.xml
+++ b/tests/package/php/data/exception_rendering_001.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:exceptionref xml:id="class.exceptionname" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+ <title>The ExceptionName Exception</title>
+ <titleabbrev>ExceptionName</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="exceptionname.intro">
+   Introduction
+   <para>
+    An ExceptionName exception.
+   </para>
+  </section>
+
+  <section xml:id="exceptionname.synopsis">
+   Class synopsis
+
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>ExceptionName</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>protected</modifier>
+     <type>int</type>
+     <varname linkend="exceptionname.props.propertyname">propertyName</varname>
+     <initializer>"Initial name"</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+     <refentry xml:id="exceptionname.construct" xmlns="http://docbook.org/ns/docbook">
+      <refnamediv>
+       <refname>ExceptionName::__construct</refname>
+       <refpurpose>Constructs the exception</refpurpose>
+      </refnamediv>
+
+      <refsect1 role="description">
+       Description
+       <constructorsynopsis role="ExceptionName">
+        <modifier>public</modifier> <methodname>ExceptionName::__construct</methodname>
+        <methodparam choice="opt"><type>string</type><parameter>propertyName</parameter><initializer>""</initializer></methodparam>
+       </constructorsynopsis>
+       <para>
+        Constructs the Exception.
+       </para>
+      </refsect1>
+
+      <refsect1 role="parameters">
+       Parameters
+       <para>
+       <variablelist>
+        <varlistentry>
+         <term><parameter>parameterName</parameter></term>
+         <listitem>
+          <para>
+           Description of the parameter
+          </para>
+         </listitem>
+        </varlistentry>
+       </variablelist>
+      </para>
+     </refsect1>
+    </refentry>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="exceptionname.props">
+   Properties
+   <variablelist>
+    <varlistentry xml:id="exceptionname.props.propertyname">
+     <term><varname>propertyName</varname></term>
+     <listitem>
+      <para>Description of the property</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>

--- a/tests/package/php/data/exception_rendering_002.xml
+++ b/tests/package/php/data/exception_rendering_002.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<reference xml:id="class.exceptionname" role="exception" xmlns="http://docbook.org/ns/docbook">
+ <title>The ExceptionName Exception</title>
+ <titleabbrev>ExceptionName</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="exceptionname.intro">
+   Introduction
+   <para>
+    An ExceptionName exception.
+   </para>
+  </section>
+
+  <section xml:id="exceptionname.synopsis">
+   Class synopsis
+
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>ExceptionName</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>protected</modifier>
+     <type>int</type>
+     <varname linkend="exceptionname.props.propertyname">propertyName</varname>
+     <initializer>"Initial name"</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+     <refentry xml:id="exceptionname.construct" xmlns="http://docbook.org/ns/docbook">
+      <refnamediv>
+       <refname>ExceptionName::__construct</refname>
+       <refpurpose>Constructs the exception</refpurpose>
+      </refnamediv>
+
+      <refsect1 role="description">
+       Description
+       <constructorsynopsis role="ExceptionName">
+        <modifier>public</modifier> <methodname>ExceptionName::__construct</methodname>
+        <methodparam choice="opt"><type>string</type><parameter>propertyName</parameter><initializer>""</initializer></methodparam>
+       </constructorsynopsis>
+       <para>
+        Constructs the Exception.
+       </para>
+      </refsect1>
+
+      <refsect1 role="parameters">
+       Parameters
+       <para>
+       <variablelist>
+        <varlistentry>
+         <term><parameter>parameterName</parameter></term>
+         <listitem>
+          <para>
+           Description of the parameter
+          </para>
+         </listitem>
+        </varlistentry>
+       </variablelist>
+      </para>
+     </refsect1>
+    </refentry>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="exceptionname.props">
+   Properties
+   <variablelist>
+    <varlistentry xml:id="exceptionname.props.propertyname">
+     <term><varname>propertyName</varname></term>
+     <listitem>
+      <para>Description of the property</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+</reference>

--- a/tests/package/php/exception_rendering_001.phpt
+++ b/tests/package/php/exception_rendering_001.phpt
@@ -1,0 +1,110 @@
+--TEST--
+Exception rendering 001 - phpdoc:exceptionref rendering
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/exception_rendering_001.xml";
+
+Config::init(["xml_file" => $xml_file]);
+
+$format = new TestPHPChunkedXHTML;
+$render = new TestRender(new Reader, new Config, $format);
+
+$render->run();
+?>
+--EXPECTF--
+Filename: exceptionname.construct.html
+Content:
+<div id="exceptionname.construct" class="refentry">
+      <div class="refnamediv">
+       <h1 class="refname">ExceptionName::__construct</h1>
+       <p class="verinfo">(No version information available, might only be in Git)</p><p class="refpurpose"><span class="refname">ExceptionName::__construct</span> &mdash; <span class="dc-title">Constructs the exception</span></p>
+
+      </div>
+
+      <div class="refsect1 description" id="refsect1-exceptionname.construct-description">
+       Description
+       <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ExceptionName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$propertyName</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
+
+       <p class="para rdfs-comment">
+        Constructs the Exception.
+       </p>
+      </div>
+
+
+      <div class="refsect1 parameters" id="refsect1-exceptionname.construct-parameters">
+       Parameters
+       <p class="para">
+       <dl>
+        
+         <dt><code class="parameter">parameterName</code></dt>
+         <dd>
+          <p class="para">
+           Description of the parameter
+          </p>
+         </dd>
+        
+       </dl>
+      </p>
+     </div>
+
+    </div>
+Filename: class.exceptionname.html
+Content:
+<div id="class.exceptionname" class="reference">
+ <h1 class="title">The ExceptionName Exception</h1>
+ 
+
+ <div class="partintro"><p class="verinfo">(No version information available, might only be in Git)</p>
+
+  <div class="section" id="exceptionname.intro">
+   Introduction
+   <p class="para">
+    An ExceptionName exception.
+   </p>
+  </div>
+
+  <div class="section" id="exceptionname.synopsis">
+   Class synopsis
+
+   <div class="classsynopsis"><div class="classsynopsisinfo">
+    
+     <span class="modifier">class</span> <strong class="classname"><strong class="exceptionname">ExceptionName</strong></strong>
+    
+
+    
+     <span class="modifier">extends</span>
+      <strong class="classname">Exception</strong>
+     {</div>
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Properties */</div>
+    <div class="fieldsynopsis">
+     <span class="modifier">protected</span>
+     <span class="type"><a href="language.types.integer.html" class="type int">int</a></span>
+      <var class="varname"><a href=".html#exceptionname.props.propertyname">$<var class="varname">propertyName</var></a></var><span class="initializer"> = &quot;Initial name&quot;</span>;</div>
+
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
+     
+   }</div>
+
+  </div>
+
+  <div class="section" id="exceptionname.props">
+   Properties
+   <dl>
+    
+     <dt id="exceptionname.props.propertyname"><var class="varname">propertyName</var></dt>
+     <dd>
+      <p class="para">Description of the property</p>
+     </dd>
+    
+   </dl>
+  </div>
+
+ </div>
+
+</div>

--- a/tests/package/php/exception_rendering_002.phpt
+++ b/tests/package/php/exception_rendering_002.phpt
@@ -1,0 +1,110 @@
+--TEST--
+Exception rendering 002 - reference element with role="exception" rendering
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/exception_rendering_002.xml";
+
+Config::init(["xml_file" => $xml_file]);
+
+$format = new TestPHPChunkedXHTML;
+$render = new TestRender(new Reader, new Config, $format);
+
+$render->run();
+?>
+--EXPECTF--
+Filename: exceptionname.construct.html
+Content:
+<div id="exceptionname.construct" class="refentry">
+      <div class="refnamediv">
+       <h1 class="refname">ExceptionName::__construct</h1>
+       <p class="verinfo">(No version information available, might only be in Git)</p><p class="refpurpose"><span class="refname">ExceptionName::__construct</span> &mdash; <span class="dc-title">Constructs the exception</span></p>
+
+      </div>
+
+      <div class="refsect1 description" id="refsect1-exceptionname.construct-description">
+       Description
+       <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ExceptionName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$propertyName</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
+
+       <p class="para rdfs-comment">
+        Constructs the Exception.
+       </p>
+      </div>
+
+
+      <div class="refsect1 parameters" id="refsect1-exceptionname.construct-parameters">
+       Parameters
+       <p class="para">
+       <dl>
+        
+         <dt><code class="parameter">parameterName</code></dt>
+         <dd>
+          <p class="para">
+           Description of the parameter
+          </p>
+         </dd>
+        
+       </dl>
+      </p>
+     </div>
+
+    </div>
+Filename: class.exceptionname.html
+Content:
+<div id="class.exceptionname" class="reference">
+ <h1 class="title">The ExceptionName Exception</h1>
+ 
+
+ <div class="partintro"><p class="verinfo">(No version information available, might only be in Git)</p>
+
+  <div class="section" id="exceptionname.intro">
+   Introduction
+   <p class="para">
+    An ExceptionName exception.
+   </p>
+  </div>
+
+  <div class="section" id="exceptionname.synopsis">
+   Class synopsis
+
+   <div class="classsynopsis"><div class="classsynopsisinfo">
+    
+     <span class="modifier">class</span> <strong class="classname"><strong class="exceptionname">ExceptionName</strong></strong>
+    
+
+    
+     <span class="modifier">extends</span>
+      <strong class="classname">Exception</strong>
+     {</div>
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Properties */</div>
+    <div class="fieldsynopsis">
+     <span class="modifier">protected</span>
+     <span class="type"><a href="language.types.integer.html" class="type int">int</a></span>
+      <var class="varname"><a href=".html#exceptionname.props.propertyname">$<var class="varname">propertyName</var></a></var><span class="initializer"> = &quot;Initial name&quot;</span>;</div>
+
+
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
+     
+   }</div>
+
+  </div>
+
+  <div class="section" id="exceptionname.props">
+   Properties
+   <dl>
+    
+     <dt id="exceptionname.props.propertyname"><var class="varname">propertyName</var></dt>
+     <dd>
+      <p class="para">Description of the property</p>
+     </dd>
+    
+   </dl>
+  </div>
+
+ </div>
+
+</div>

--- a/tests/package/php/exception_rendering_003.phpt
+++ b/tests/package/php/exception_rendering_003.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Exception rendering 003 - compare output of phpdoc:exceptionref and reference element with role="exception" rendering
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_filePhpdoc = __DIR__ . "/data/exception_rendering_001.xml";
+
+Config::init(["xml_file" => $xml_filePhpdoc]);
+
+$formatPhpdoc = new TestPHPChunkedXHTML;
+$renderPhpdoc = new TestRender(new Reader, new Config, $formatPhpdoc);
+
+ob_start();
+$renderPhpdoc->run();
+$phpdocOutput = ob_get_clean();
+
+
+$xml_fileReferenceWithRole = __DIR__ . "/data/exception_rendering_002.xml";
+
+Config::init(["xml_file" => $xml_fileReferenceWithRole]);
+
+$formatReferenceWithRole = new TestPHPChunkedXHTML;
+$renderReferenceWithRole = new TestRender(new Reader, new Config, $formatReferenceWithRole);
+
+ob_start();
+$renderReferenceWithRole->run();
+$referenceWithRoleOutput = ob_get_clean();
+
+var_dump($phpdocOutput === $referenceWithRoleOutput);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
This PR adds support for the new markup for classes and exceptions. Rendering `doc-en` with the old markup with and without these changes, and the new markup with these changes showed zero diffs.