### PR TITLE
Add non-parameter attribute rendering

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -145,7 +145,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         'methodsynopsis'        => 'format_methodsynopsis',
         'methodname'            => 'format_methodname',
         'member'                => 'format_member',
-        'modifier'              => 'format_modifier',
+        'modifier'              => array(
+            /* DEFAULT */          'format_modifier',
+            'methodparam'       => 'format_methodparam_modifier',
+        ),
         'note'                  => 'format_note',
         'orgname'               => 'span',
         'othercredit'           => 'format_div',
@@ -395,6 +398,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             'fieldsynopsis'    => 'format_fieldsynopsis_modifier_text',
             'methodparam'      => 'format_modifier_text',
             'methodsynopsis'   => 'format_modifier_text',
+            'constructorsynopsis' => 'format_modifier_text',
+            'ooclass'          => 'format_modifier_text',
+            'ooexception'      => 'format_modifier_text',
+            'oointerface'      => 'format_modifier_text',
         ),
         /** Those are used to retrieve the class/interface name to be able to remove it from method names */
         'classname' => [
@@ -1220,6 +1227,23 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
 
     public function format_modifier($open, $name, $attrs, $props) {
+        if ($open) {
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+                $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
+                return '<span class="' . $this->getRole() . '">';
+            }
+            return '<span class="modifier">';
+        }
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+            if ($attrs[Reader::XMLNS_DOCBOOK]["role"] === "attribute") {
+                return '</span><br>';
+            }
+            $this->popRole();
+        }
+        return '</span>';
+    }
+
+    public function format_methodparam_modifier($open, $name, $attrs, $props) {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);

--- a/tests/package/generic/attribute_formatting_001.phpt
+++ b/tests/package/generic/attribute_formatting_001.phpt
@@ -48,13 +48,13 @@ Content:
 
  <div class="section">
   <p class="para">3. Function parameter with unknown attribute</p>
-  <div class="methodsynopsis dc-description"><span class="type">bool</span> <span class="methodname">password_verify</span><span class="attribute">#[\UnknownAttribute]</span>(<span class="methodparam"><span class="type">string</span> <code class="parameter">$password</code></span>, <span class="methodparam"><span class="type">string</span> <code class="parameter">$hash</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="type">bool</span> <span class="methodname">password_verify</span>(<span class="methodparam"><span class="attribute">#[\UnknownAttribute]</span><span class="type">string</span> <code class="parameter">$password</code></span>, <span class="methodparam"><span class="type">string</span> <code class="parameter">$hash</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">4. Function parameter with known attribute</p>
-  <div class="methodsynopsis dc-description"><span class="type">bool</span> <span class="methodname">password_verify</span><span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span>(<span class="methodparam"><span class="type">string</span> <code class="parameter">$password</code></span>, <span class="methodparam"><span class="type">string</span> <code class="parameter">$hash</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="type">bool</span> <span class="methodname">password_verify</span>(<span class="methodparam"><span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><span class="type">string</span> <code class="parameter">$password</code></span>, <span class="methodparam"><span class="type">string</span> <code class="parameter">$hash</code></span>)</div>
 
  </div>
 </div>

--- a/tests/package/generic/attribute_formatting_002.phpt
+++ b/tests/package/generic/attribute_formatting_002.phpt
@@ -1,0 +1,170 @@
+--TEST--
+Attribute formatting 002 - Class and method attributes
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/attribute_formatting_002.xml";
+
+Config::init(["xml_file" => $xml_file]);
+
+$format = new TestGenericChunkedXHTML;
+
+$format->SQLiteIndex(
+    null, // $context,
+    null, // $index,
+    "class.knownattribute", // $id,
+    "file.knownattribute.is.in", // $filename,
+    "", // $parent,
+    "", // $sdesc,
+    "", // $ldesc,
+    "", // $element,
+    "", // $previous,
+    "", // $next,
+    0, // $chunk
+);
+$format->SQLiteIndex(
+    null, // $context,
+    null, // $index,
+    "class.anotherknownattribute", // $id,
+    "file.anotherknownattribute.is.in", // $filename,
+    "", // $parent,
+    "", // $sdesc,
+    "", // $ldesc,
+    "", // $element,
+    "", // $previous,
+    "", // $next,
+    0, // $chunk
+);
+
+$render = new TestRender(new Reader, new Config, $format);
+
+$render->run();
+?>
+--EXPECT--
+Filename: attribute-formatting-002.html
+Content:
+<div id="attribute-formatting-002" class="chapter">
+ <div class="section">
+  <p class="para">1. Class with unknown attributes</p>
+  <div class="classsynopsis"><div class="classsynopsisinfo">
+   
+    <span class="attribute">#[\UnknownAttribute]</span><br>
+    <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+    <span class="modifier">class</span> <strong class="classname">DateTime</strong>
+    {</div>
+  }</div>
+ </div>
+
+ <div class="section">
+  <p class="para">2. Class with known attributes</p>
+  <div class="classsynopsis"><div class="classsynopsisinfo">
+   
+    <span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+    <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+    <span class="modifier">class</span> <strong class="classname">DateTime</strong>
+    {</div>
+  }</div>
+ </div>
+
+ <div class="section">
+  <p class="para">3. Method with unknown attributes</p>
+  <div class="methodsynopsis dc-description">
+   <span class="attribute">#[\UnknownAttribute]</span><br>
+   <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+   <span class="modifier">public</span>  <span class="methodname">ClassName::methodName</span>()</div>
+
+ </div>
+
+ <div class="section">
+  <p class="para">4. Method with known attributes</p>
+  <div class="methodsynopsis dc-description"><span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+   <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+   <span class="modifier">public</span>  <span class="methodname">ClassName::methodName</span>()</div>
+
+ </div>
+
+ <div class="section">
+  <p class="para">5. Constructor with unknown attributes</p>
+  <div class="constructorsynopsis dc-description"><span class="attribute">#[\UnknownAttribute]</span><br>
+   <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+   <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>()</div>
+
+ </div>
+
+ <div class="section">
+  <p class="para">6. Constructor with known attributes</p>
+  <div class="constructorsynopsis dc-description"><span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+   <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+   <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>()</div>
+
+ </div>
+
+ <div class="section">
+  <p class="para">7. Class, constructor and methods with unknown attributes</p>
+  <div class="classsynopsis"><div class="classsynopsisinfo">
+   
+    <span class="attribute">#[\UnknownAttribute]</span><br>
+    <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+    <span class="modifier">class</span> <strong class="classname">DateTime</strong>
+    {</div>
+   <div class="constructorsynopsis dc-description">
+    <span class="attribute">#[\UnknownAttribute]</span><br>
+    <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+    <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>()</div>
+
+   <div class="methodsynopsis dc-description"><span class="attribute">#[\UnknownAttribute]</span><br>
+    <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+    <span class="modifier">public</span>  <span class="methodname">ClassName::methodName1</span>()</div>
+
+   <div class="methodsynopsis dc-description"><span class="attribute">#[\UnknownAttribute]</span><br>
+    <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+    <span class="modifier">public</span>  <span class="methodname">ClassName::methodName2</span>()</div>
+
+  }</div>
+ </div>
+
+ <div class="section">
+  <p class="para">8. Class, constructor and methods with known attributes</p>
+  <div class="classsynopsis"><div class="classsynopsisinfo">
+   
+    <span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+    <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+    <span class="modifier">class</span> <strong class="classname">DateTime</strong>
+    {</div>
+   <div class="constructorsynopsis dc-description">
+    <span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+    <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+    <span class="modifier">public</span>  <span class="methodname">ClassName::__construct</span>()</div>
+
+   <div class="methodsynopsis dc-description"><span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+    <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+    <span class="modifier">public</span>  <span class="methodname">ClassName::methodName1</span>()</div>
+
+   <div class="methodsynopsis dc-description"><span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+    <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+    <span class="modifier">public</span>  <span class="methodname">ClassName::methodName2</span>()</div>
+
+  }</div>
+ </div>
+
+ <div class="section">
+  <p class="para">9. Function with unknown attributes</p>
+  <div class="methodsynopsis dc-description">
+   <span class="attribute">#[\UnknownAttribute]</span><br>
+   <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+   <span class="type">void</span> <span class="methodname">function_name</span>)</div>
+
+ </div>
+
+ <div class="section">
+  <p class="para">10. Function with known attributes</p>
+  <div class="methodsynopsis dc-description"><span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+   <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+   <span class="type">void</span> <span class="methodname">function_name</span>)</div>
+
+ </div>
+
+</div>

--- a/tests/package/generic/data/attribute_formatting_001.xml
+++ b/tests/package/generic/data/attribute_formatting_001.xml
@@ -19,7 +19,7 @@
   <para>3. Function parameter with unknown attribute</para>
   <methodsynopsis>
    <type>bool</type><methodname>password_verify</methodname>
-   <modifier role="attribute">#[\UnknownAttribute]</modifier><methodparam><type>string</type><parameter>password</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\UnknownAttribute]</modifier><type>string</type><parameter>password</parameter></methodparam>
    <methodparam><type>string</type><parameter>hash</parameter></methodparam>
   </methodsynopsis>
  </section>
@@ -28,7 +28,7 @@
   <para>4. Function parameter with known attribute</para>
   <methodsynopsis>
    <type>bool</type><methodname>password_verify</methodname>
-   <modifier role="attribute">#[\KnownAttribute]</modifier><methodparam><type>string</type><parameter>password</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\KnownAttribute]</modifier><type>string</type><parameter>password</parameter></methodparam>
    <methodparam><type>string</type><parameter>hash</parameter></methodparam>
   </methodsynopsis>
  </section>

--- a/tests/package/generic/data/attribute_formatting_002.xml
+++ b/tests/package/generic/data/attribute_formatting_002.xml
@@ -1,0 +1,140 @@
+<chapter xml:id="attribute-formatting-002">
+ <section>
+  <para>1. Class with unknown attributes</para>
+  <classsynopsis class="class">
+   <ooclass>
+    <modifier role="attribute">#[\UnknownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+    <classname>DateTime</classname>
+   </ooclass>
+  </classsynopsis>
+ </section>
+
+ <section>
+  <para>2. Class with known attributes</para>
+  <classsynopsis class="class">
+   <ooclass>
+    <modifier role="attribute">#[\KnownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+    <classname>DateTime</classname>
+   </ooclass>
+  </classsynopsis>
+ </section>
+
+ <section>
+  <para>3. Method with unknown attributes</para>
+  <methodsynopsis>
+   <modifier role="attribute">#[\UnknownAttribute]</modifier>
+   <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+   <modifier>public</modifier> <methodname>ClassName::methodName</methodname>
+   <void/>
+ </methodsynopsis>
+ </section>
+
+ <section>
+  <para>4. Method with known attributes</para>
+  <methodsynopsis>
+   <modifier role="attribute">#[\KnownAttribute]</modifier>
+   <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+   <modifier>public</modifier> <methodname>ClassName::methodName</methodname>
+   <void/>
+ </methodsynopsis>
+ </section>
+
+ <section>
+  <para>5. Constructor with unknown attributes</para>
+  <constructorsynopsis>
+   <modifier role="attribute">#[\UnknownAttribute]</modifier>
+   <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+   <modifier>public</modifier> <methodname>ClassName::__construct</methodname>
+   <void/>
+  </constructorsynopsis>
+ </section>
+
+ <section>
+  <para>6. Constructor with known attributes</para>
+  <constructorsynopsis>
+   <modifier role="attribute">#[\KnownAttribute]</modifier>
+   <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+   <modifier>public</modifier> <methodname>ClassName::__construct</methodname>
+   <void/>
+  </constructorsynopsis>
+ </section>
+
+ <section>
+  <para>7. Class, constructor and methods with unknown attributes</para>
+  <classsynopsis class="class">
+   <ooclass>
+    <modifier role="attribute">#[\UnknownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+    <classname>DateTime</classname>
+   </ooclass>
+   <constructorsynopsis>
+    <modifier role="attribute">#[\UnknownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+    <modifier>public</modifier> <methodname>ClassName::__construct</methodname>
+    <void/>
+   </constructorsynopsis>
+   <methodsynopsis>
+    <modifier role="attribute">#[\UnknownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+    <modifier>public</modifier> <methodname>ClassName::methodName1</methodname>
+    <void/>
+   </methodsynopsis>
+   <methodsynopsis>
+    <modifier role="attribute">#[\UnknownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+    <modifier>public</modifier> <methodname>ClassName::methodName2</methodname>
+    <void/>
+   </methodsynopsis>
+  </classsynopsis>
+ </section>
+
+ <section>
+  <para>8. Class, constructor and methods with known attributes</para>
+  <classsynopsis class="class">
+   <ooclass>
+    <modifier role="attribute">#[\KnownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+    <classname>DateTime</classname>
+   </ooclass>
+   <constructorsynopsis>
+    <modifier role="attribute">#[\KnownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+    <modifier>public</modifier> <methodname>ClassName::__construct</methodname>
+    <void/>
+   </constructorsynopsis>
+   <methodsynopsis>
+    <modifier role="attribute">#[\KnownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+    <modifier>public</modifier> <methodname>ClassName::methodName1</methodname>
+    <void/>
+   </methodsynopsis>
+   <methodsynopsis>
+    <modifier role="attribute">#[\KnownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+    <modifier>public</modifier> <methodname>ClassName::methodName2</methodname>
+    <void/>
+   </methodsynopsis>
+  </classsynopsis>
+ </section>
+
+ <section>
+  <para>9. Function with unknown attributes</para>
+  <methodsynopsis>
+   <modifier role="attribute">#[\UnknownAttribute]</modifier>
+   <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+   <type>void</type><methodname>function_name</methodname>
+  </methodsynopsis>
+ </section>
+
+ <section>
+  <para>10. Function with known attributes</para>
+  <methodsynopsis>
+   <modifier role="attribute">#[\KnownAttribute]</modifier>
+   <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+   <type>void</type><methodname>function_name</methodname>
+  </methodsynopsis>
+ </section>
+
+</chapter>


### PR DESCRIPTION
Enable rendering of attributes for classes, exceptions, interfaces, methods and functions. The implementation feels a little off but it seems to work as intended (see attached test `attribute_formatting_002.phpt`).

I've also found a mistake I've made in the test `attribute_formatting_001.phpt` where the parameter attribute was outside of the `<methodparam>` element. I've corrected this by moving the attribute inside the element.