### PR TITLE
Fix doc-en GH-3428

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -103,6 +103,7 @@ class Index extends Format
     private $commit     = array();
     private $POST_REPLACEMENT_INDEXES = array();
     private $POST_REPLACEMENT_VALUES  = array();
+    private int $exampleCounter = 0;
 
     public function __construct(IndexRepository $indexRepository) {
         $this->indexRepository = $indexRepository;
@@ -377,16 +378,14 @@ class Index extends Format
     }
 
     public function format_example($open, $name, $attrs, $props) {
-        static $n = 0;
-
         if ($open) {
-            ++$n;
+            ++$this->exampleCounter;
 
             if(isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $id = $attrs[Reader::XMLNS_XML]["id"];
             }
             else {
-                $id = "example-" . $n;
+                $id = "example-" . $this->exampleCounter;
             }
 
             $this->storeInfo($name, $id, $this->currentchunk, false);

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -521,6 +521,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     protected $isSectionChunk = array();
     protected $params = array();
 
+    protected int $exampleCounter = 0;
+
     public function __construct() {
         parent::__construct();
         $this->registerPIHandlers($this->pihandlers);
@@ -1711,13 +1713,12 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</strong><br />';
     }
     public function format_example($open, $name, $attrs, $props) {
-        static $n = 0;
         if ($open) {
-            ++$n;
+            ++$this->exampleCounter;
             if (isset($props["id"])) {
                 return '<div class="' . $name . '" id="' . $props["id"] . '">';
             }
-            return '<div class="' . $name . '" id="' . $this->getGeneratedExampleId($n-1) . '">';
+            return '<div class="' . $name . '" id="' . $this->getGeneratedExampleId($this->exampleCounter - 1) . '">';
         }
         return '</div>';
     }

--- a/phpdotnet/phd/TestRender.php
+++ b/phpdotnet/phd/TestRender.php
@@ -22,6 +22,9 @@ class TestRender extends Render {
 
         if ($this->format !== null) {
             $this->attach($this->format);
+        }
+
+        if (count($this) > 0) {
             $this->reader->open($this->config->xml_file());
             $this->execute($this->reader);
         }

--- a/tests/bug_doc-en_GH-3428.phpt
+++ b/tests/bug_doc-en_GH-3428.phpt
@@ -1,0 +1,159 @@
+--TEST--
+Example numbering 001 - indexing and rendering examples with and without an xml:id
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/setup.php";
+
+$xml_file = __DIR__ . "/data/example_numbering_001.xml";
+
+Config::init([
+    "force_index"    => true,
+    "xml_file" => $xml_file,
+]);
+
+$indexRepository = new IndexRepository(new \SQLite3(":memory:"));
+$indexRepository->init();
+Config::set_indexcache($indexRepository);
+
+$index = new TestIndex($indexRepository);
+
+$render = new TestRender(new Reader, new Config, null, $index);
+
+$render->run();
+
+$indexes = array_keys($index->getNfo());
+
+echo "Indexes stored:\n";
+
+var_dump($indexes);
+
+$render = new TestRender(new Reader, new Config);
+
+$format1 = new TestGenericChunkedXHTML;
+$format2 = new TestGenericChunkedXHTML;
+$format3 = new TestGenericChunkedXHTML;
+
+$render->attach($format1);
+$render->attach($format2);
+$render->attach($format3);
+
+$render->run();
+
+?>
+--EXPECT--
+Indexes stored:
+array(6) {
+  [0]=>
+  string(17) "example-numbering"
+  [1]=>
+  string(9) "example-1"
+  [2]=>
+  string(9) "example-2"
+  [3]=>
+  string(16) "third-example-id"
+  [4]=>
+  string(9) "example-4"
+  [5]=>
+  string(9) "example-5"
+}
+Filename: example-numbering.html
+Content:
+<div id="example-numbering" class="chapter">
+ <div class="section">
+  <div class="example" id="example-1">
+    <p><strong>Example #1 - 1. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-2">
+    <p><strong>Example #2 - 2. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="third-example-id">
+    <p><strong>Example #3 - 3. example with an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-4">
+    <p><strong>Example #4 - 4. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-5">
+    <p><strong>Example #5 - 5. example without an xml:id</strong></p>
+  </div>
+ </div>
+</div>
+Filename: example-numbering.html
+Content:
+<div id="example-numbering" class="chapter">
+ <div class="section">
+  <div class="example" id="example-1">
+    <p><strong>Example #1 - 1. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-2">
+    <p><strong>Example #2 - 2. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="third-example-id">
+    <p><strong>Example #3 - 3. example with an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-4">
+    <p><strong>Example #4 - 4. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-5">
+    <p><strong>Example #5 - 5. example without an xml:id</strong></p>
+  </div>
+ </div>
+</div>
+Filename: example-numbering.html
+Content:
+<div id="example-numbering" class="chapter">
+ <div class="section">
+  <div class="example" id="example-1">
+    <p><strong>Example #1 - 1. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-2">
+    <p><strong>Example #2 - 2. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="third-example-id">
+    <p><strong>Example #3 - 3. example with an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-4">
+    <p><strong>Example #4 - 4. example without an xml:id</strong></p>
+  </div>
+ </div>
+
+ <div class="section">
+  <div class="example" id="example-5">
+    <p><strong>Example #5 - 5. example without an xml:id</strong></p>
+  </div>
+ </div>
+</div>

--- a/tests/data/bug_doc-en_GH-3428.xml
+++ b/tests/data/bug_doc-en_GH-3428.xml
@@ -1,0 +1,31 @@
+<chapter xml:id="example-numbering">
+ <section>
+  <example>
+    <title>- 1. example without an xml:id</title>
+  </example>
+ </section>
+
+ <section>
+  <example>
+    <title>- 2. example without an xml:id</title>
+  </example>
+ </section>
+
+ <section>
+  <example xml:id="third-example-id">
+    <title>- 3. example with an xml:id</title>
+  </example>
+ </section>
+
+ <section>
+  <example>
+    <title>- 4. example without an xml:id</title>
+  </example>
+ </section>
+
+ <section>
+  <example>
+    <title>- 5. example without an xml:id</title>
+  </example>
+ </section>
+</chapter>


### PR DESCRIPTION
Replace static example element counter with class properties in `Index` and `generic XHTML`. Add tests.
Refactor `TestRender` so that it can render multiple formats.

Closes [doc-en #3428](https://github.com/php/doc-en/issues/3428).