### PR TITLE
Refactor Config #1

### DIFF
--- a/tests/bug_doc-en_GH-3353.phpt
+++ b/tests/bug_doc-en_GH-3353.phpt
@@ -8,16 +8,14 @@ require_once __DIR__ . "/setup.php";
 
 $xml_file = __DIR__ . "/data/bug_doc-en_GH-3353.xml";
 
-Config::init([
-    "force_index"    => true,
-    "xml_file" => $xml_file,
-]);
+$config->setForce_index(true);
+$config->setXml_file($xml_file);
 
 $render = new Render();
 
 $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
-Config::set_indexcache($indexRepository);
+$config->set_indexcache($indexRepository);
 
 
 // Indexing
@@ -25,7 +23,7 @@ $index = new TestIndex($indexRepository);
 $render->attach($index);
 
 $reader = new Reader;
-$reader->open(Config::xml_file(), null, LIBXML_PARSEHUGE | LIBXML_XINCLUDE);
+$reader->open($config->xml_file(), null, LIBXML_PARSEHUGE | LIBXML_XINCLUDE);
 $render->execute($reader);
 
 $render->detach($index);
@@ -36,7 +34,7 @@ $format = new TestPHPChunkedXHTML;
 $render->attach($format);
 
 $reader = new Reader;
-$reader->open(Config::xml_file(), null, LIBXML_PARSEHUGE | LIBXML_XINCLUDE);
+$reader->open($config->xml_file(), null, LIBXML_PARSEHUGE | LIBXML_XINCLUDE);
 
 $render->execute($reader);
 ?>

--- a/tests/bug_doc-en_GH-3428.phpt
+++ b/tests/bug_doc-en_GH-3428.phpt
@@ -8,18 +8,16 @@ require_once __DIR__ . "/setup.php";
 
 $xml_file = __DIR__ . "/data/example_numbering_001.xml";
 
-Config::init([
-    "force_index"    => true,
-    "xml_file" => $xml_file,
-]);
+$config->setForce_index(true);
+$config->setXml_file($xml_file);
 
 $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
-Config::set_indexcache($indexRepository);
+$config->set_indexcache($indexRepository);
 
 $index = new TestIndex($indexRepository);
 
-$render = new TestRender(new Reader, new Config, null, $index);
+$render = new TestRender(new Reader, $config, null, $index);
 
 $render->run();
 
@@ -29,7 +27,7 @@ echo "Indexes stored:\n";
 
 var_dump($indexes);
 
-$render = new TestRender(new Reader, new Config);
+$render = new TestRender(new Reader, $config);
 
 $format1 = new TestGenericChunkedXHTML;
 $format2 = new TestGenericChunkedXHTML;

--- a/tests/example_numbering_001.phpt
+++ b/tests/example_numbering_001.phpt
@@ -8,18 +8,16 @@ require_once __DIR__ . "/setup.php";
 
 $xml_file = __DIR__ . "/data/example_numbering_001.xml";
 
-Config::init([
-    "force_index"    => true,
-    "xml_file" => $xml_file,
-]);
+$config->setForce_index(true);
+$config->setXml_file($xml_file);
 
 $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
-Config::set_indexcache($indexRepository);
+$config->set_indexcache($indexRepository);
 
 $index = new TestIndex($indexRepository);
 
-$render = new TestRender(new Reader, new Config, null, $index);
+$render = new TestRender(new Reader, $config, null, $index);
 
 $render->run();
 
@@ -31,7 +29,7 @@ var_dump($indexes);
 
 $format = new TestGenericChunkedXHTML;
 
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 

--- a/tests/index/bug_GH-98.phpt
+++ b/tests/index/bug_GH-98.phpt
@@ -8,16 +8,14 @@ require_once __DIR__ . "/../setup.php";
 
 $xml_file = __DIR__ . "/data/bug_GH-98.xml";
 
-Config::init([
-    "force_index"    => true,
-    "xml_file" => $xml_file,
-]);
+$config->setForce_index(true);
+$config->setXml_file($xml_file);
 
 $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 
 $index = new TestIndex($indexRepository);
-$render = new TestRender(new Reader, new Config, null, $index);
+$render = new TestRender(new Reader, $config, null, $index);
 
 $render->run();
 

--- a/tests/index/indexing_001.phpt
+++ b/tests/index/indexing_001.phpt
@@ -8,16 +8,14 @@ require_once __DIR__ . "/../setup.php";
 
 $xml_file = __DIR__ . "/data/indexing_001.xml";
 
-Config::init([
-    "force_index"    => true,
-    "xml_file" => $xml_file,
-]);
+$config->setForce_index(true);
+$config->setXml_file($xml_file);
 
 $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 
 $index = new TestIndex($indexRepository);
-$render = new TestRender(new Reader, new Config, null, $index);
+$render = new TestRender(new Reader, $config, null, $index);
 
 $render->run();
 

--- a/tests/options/default_handler_009.phpt
+++ b/tests/options/default_handler_009.phpt
@@ -15,7 +15,7 @@ namespace phpdotnet\phd;
 require_once __DIR__ . "/../setup.php";
 
 $optionsParser = new Options_Parser(
-    new Options_Handler(new Config, new Package_Generic_Factory)
+    new Options_Handler($config, new Package_Generic_Factory)
 );
 $commandLineOptions = $optionsParser->getopt();
 

--- a/tests/options/default_handler_010.phpt
+++ b/tests/options/default_handler_010.phpt
@@ -15,7 +15,7 @@ namespace phpdotnet\phd;
 require_once __DIR__ . "/../setup.php";
 
 $optionsParser = new Options_Parser(
-    new Options_Handler(new Config, new Package_Generic_Factory)
+    new Options_Handler($config, new Package_Generic_Factory)
 );
 $commandLineOptions = $optionsParser->getopt();
 

--- a/tests/package/generic/001.phpt
+++ b/tests/package/generic/001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/001-1.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/generic/002.phpt
+++ b/tests/package/generic/002.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/002.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/generic/003.phpt
+++ b/tests/package/generic/003.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/003.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/generic/attribute_formatting_001.phpt
+++ b/tests/package/generic/attribute_formatting_001.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/attribute_formatting_001.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
 
@@ -26,7 +26,7 @@ $format->SQLiteIndex(
     0, // $chunk
 );
 
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/generic/attribute_formatting_002.phpt
+++ b/tests/package/generic/attribute_formatting_002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/attribute_formatting_002.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
 
@@ -39,7 +39,7 @@ $format->SQLiteIndex(
     0, // $chunk
 );
 
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/generic/caption_001.phpt
+++ b/tests/package/generic/caption_001.phpt
@@ -8,11 +8,11 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/caption_001.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
 $format->postConstruct();
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/generic/simplelist_001.phpt
+++ b/tests/package/generic/simplelist_001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/simplelist.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/generic/whitespace_formatting_001.phpt
+++ b/tests/package/generic/whitespace_formatting_001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/whitespace_formatting_001.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestGenericChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/bug49101-1.phpt
+++ b/tests/package/php/bug49101-1.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/bug49101-1.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/bug49101-2.phpt
+++ b/tests/package/php/bug49101-2.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/bug49101-1.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPBigXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/bug49102-1.phpt
+++ b/tests/package/php/bug49102-1.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/bug49102-1.xml";
 
-Config::init(["xml_file"          => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/bug_doc-en_GH-3179.phpt
+++ b/tests/package/php/bug_doc-en_GH-3179.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/bug_doc-en_GH-3197.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/class_rendering_001.phpt
+++ b/tests/package/php/class_rendering_001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/class_rendering_001.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/class_rendering_002.phpt
+++ b/tests/package/php/class_rendering_002.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/class_rendering_002.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/class_rendering_003.phpt
+++ b/tests/package/php/class_rendering_003.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_filePhpdoc = __DIR__ . "/data/class_rendering_001.xml";
 
-Config::init(["xml_file" => $xml_filePhpdoc]);
+$config->setXml_file($xml_filePhpdoc);
 
 $formatPhpdoc = new TestPHPChunkedXHTML;
-$renderPhpdoc = new TestRender(new Reader, new Config, $formatPhpdoc);
+$renderPhpdoc = new TestRender(new Reader, $config, $formatPhpdoc);
 
 ob_start();
 $renderPhpdoc->run();
@@ -20,10 +20,10 @@ $phpdocOutput = ob_get_clean();
 
 $xml_fileReferenceWithRole = __DIR__ . "/data/class_rendering_002.xml";
 
-Config::init(["xml_file" => $xml_fileReferenceWithRole]);
+$config->setXml_file($xml_fileReferenceWithRole);
 
 $formatReferenceWithRole = new TestPHPChunkedXHTML;
-$renderReferenceWithRole = new TestRender(new Reader, new Config, $formatReferenceWithRole);
+$renderReferenceWithRole = new TestRender(new Reader, $config, $formatReferenceWithRole);
 
 ob_start();
 $renderReferenceWithRole->run();

--- a/tests/package/php/constant_links_001.phpt
+++ b/tests/package/php/constant_links_001.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/constant_links.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $indices = [
     [
@@ -47,7 +47,7 @@ foreach ($indices as $index) {
     );
 }
 
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/exception_rendering_001.phpt
+++ b/tests/package/php/exception_rendering_001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/exception_rendering_001.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/exception_rendering_002.phpt
+++ b/tests/package/php/exception_rendering_002.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/exception_rendering_002.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/exception_rendering_003.phpt
+++ b/tests/package/php/exception_rendering_003.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_filePhpdoc = __DIR__ . "/data/exception_rendering_001.xml";
 
-Config::init(["xml_file" => $xml_filePhpdoc]);
+$config->setXml_file($xml_filePhpdoc);
 
 $formatPhpdoc = new TestPHPChunkedXHTML;
-$renderPhpdoc = new TestRender(new Reader, new Config, $formatPhpdoc);
+$renderPhpdoc = new TestRender(new Reader, $config, $formatPhpdoc);
 
 ob_start();
 $renderPhpdoc->run();
@@ -20,10 +20,10 @@ $phpdocOutput = ob_get_clean();
 
 $xml_fileReferenceWithRole = __DIR__ . "/data/exception_rendering_002.xml";
 
-Config::init(["xml_file" => $xml_fileReferenceWithRole]);
+$config->setXml_file($xml_fileReferenceWithRole);
 
 $formatReferenceWithRole = new TestPHPChunkedXHTML;
-$renderReferenceWithRole = new TestRender(new Reader, new Config, $formatReferenceWithRole);
+$renderReferenceWithRole = new TestRender(new Reader, $config, $formatReferenceWithRole);
 
 ob_start();
 $renderReferenceWithRole->run();

--- a/tests/package/php/faq001.phpt
+++ b/tests/package/php/faq001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/faq001.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/type_rendering_001.phpt
+++ b/tests/package/php/type_rendering_001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/type_rendering_methodsynopsis_return_types.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/type_rendering_002.phpt
+++ b/tests/package/php/type_rendering_002.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/type_rendering_methodsynopsis_parameters.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/type_rendering_003.phpt
+++ b/tests/package/php/type_rendering_003.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/type_rendering_constructorsynopsis_parameters-and-return-type.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/package/php/variablelist_rendering_001.phpt
+++ b/tests/package/php/variablelist_rendering_001.phpt
@@ -8,10 +8,10 @@ require_once __DIR__ . "/../../setup.php";
 
 $xml_file = __DIR__ . "/data/variablelist_rendering_001.xml";
 
-Config::init(["xml_file" => $xml_file]);
+$config->setXml_file($xml_file);
 
 $format = new TestPHPChunkedXHTML;
-$render = new TestRender(new Reader, new Config, $format);
+$render = new TestRender(new Reader, $config, $format);
 
 $render->run();
 ?>

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -8,9 +8,10 @@ spl_autoload_register(["phpdotnet\\phd\\Autoloader", "autoload"]);
 
 require_once __INSTALLDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "functions.php";
 
-Config::init([
-    "lang_dir"  => __INSTALLDIR__ . DIRECTORY_SEPARATOR
-                    . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR
-                    . "data" . DIRECTORY_SEPARATOR . "langs" . DIRECTORY_SEPARATOR,
-    "package_dirs" => [__INSTALLDIR__],
-]);
+$config = new Config;
+
+$config->init([]);
+$config->setLang_dir(__INSTALLDIR__ . DIRECTORY_SEPARATOR
+. "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR
+. "data" . DIRECTORY_SEPARATOR . "langs" . DIRECTORY_SEPARATOR);
+$config->setPackage_dirs([__INSTALLDIR__]);


### PR DESCRIPTION
Refactor usage of the `Config` class by instantiating an object and using it with its non-static methods in all tests and `render.php`.

This is the first PR in converting `Config` used as a static global variable for settings/options to eventually using non-static properties. The changes in this PR do not change how the changed files are working and do not add/remove dependencies while possible follow up PRs will have to add at least one dependency (an instantiated `Config` object) or change some functionality to remove their dependency on the global static `Config` class.