### PR TITLE
Add property and constant attribute rendering

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1218,12 +1218,26 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     public function format_fieldsynopsis($open, $name, $attrs) {
         $this->cchunk["fieldsynopsis"] = $this->dchunk["fieldsynopsis"];
         if ($open) {
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+                $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
+            }
             return '<div class="'.$name.'">';
+        }
+        if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+            $this->popRole();
         }
         return ";</div>\n";
     }
 
     public function format_fieldsynopsis_modifier_text($value, $tag) {
+        if ($this->getRole() === "attribute") {
+            $attribute = trim(strtolower($value), "#[]\\");
+            $href = Format::getFilename("class.$attribute");
+            if ($href) {
+                return '<a href="' . $href . $this->getExt() . '">' .$value. '</a> ';
+            }
+            return false;
+        }
         $this->cchunk["fieldsynopsis"]["modifier"] = trim($value);
         return $this->TEXT($value);
     }

--- a/tests/package/generic/attribute_formatting_003.phpt
+++ b/tests/package/generic/attribute_formatting_003.phpt
@@ -52,7 +52,7 @@ Content:
  <div class="section">
   <p class="para">1. Property/Constant with unknown attributes</p>
   <div class="classsynopsis"><div class="classsynopsisinfo">
-
+   
     <span class="modifier">class</span> <strong class="classname">ClassName</strong>
     {</div>
    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Properties/Constants */</div>
@@ -70,7 +70,7 @@ Content:
  <div class="section">
   <p class="para">2. Property/Constant with known attributes</p>
   <div class="classsynopsis"><div class="classsynopsisinfo">
-
+   
     <span class="modifier">class</span> <strong class="classname">ClassName</strong>
     {</div>
    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Properties/Constants */</div>

--- a/tests/package/generic/attribute_formatting_003.phpt
+++ b/tests/package/generic/attribute_formatting_003.phpt
@@ -1,0 +1,88 @@
+--TEST--
+Attribute formatting 003 - Class properties/constants
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/attribute_formatting_003.xml";
+
+$config = new Config;
+
+$config->setXml_file($xml_file);
+
+$format = new TestGenericChunkedXHTML;
+
+$format->SQLiteIndex(
+    null, // $context,
+    null, // $index,
+    "class.knownattribute", // $id,
+    "file.knownattribute.is.in", // $filename,
+    "", // $parent,
+    "", // $sdesc,
+    "", // $ldesc,
+    "", // $element,
+    "", // $previous,
+    "", // $next,
+    0, // $chunk
+);
+$format->SQLiteIndex(
+    null, // $context,
+    null, // $index,
+    "class.anotherknownattribute", // $id,
+    "file.anotherknownattribute.is.in", // $filename,
+    "", // $parent,
+    "", // $sdesc,
+    "", // $ldesc,
+    "", // $element,
+    "", // $previous,
+    "", // $next,
+    0, // $chunk
+);
+
+$render = new TestRender(new Reader, $config, $format);
+
+$render->run();
+?>
+--EXPECT--
+Filename: attribute-formatting-003.html
+Content:
+<div id="attribute-formatting-003" class="chapter">
+ <div class="section">
+  <p class="para">1. Property/Constant with unknown attributes</p>
+  <div class="classsynopsis"><div class="classsynopsisinfo">
+
+    <span class="modifier">class</span> <strong class="classname">ClassName</strong>
+    {</div>
+   <div class="classsynopsisinfo classsynopsisinfo_comment">/* Properties/Constants */</div>
+   <div class="fieldsynopsis">
+    <span class="attribute">#[\UnknownAttribute]</span><br>
+    <span class="attribute">#[\AnotherUnknownAttribute]</span><br>
+    <span class="modifier">public</span>
+    <span class="modifier">readonly</span>
+    <span class="type">string</span>
+    <var class="varname">$CONSTANT_NAME</var>;</div>
+
+  }</div>
+ </div>
+
+ <div class="section">
+  <p class="para">2. Property/Constant with known attributes</p>
+  <div class="classsynopsis"><div class="classsynopsisinfo">
+
+    <span class="modifier">class</span> <strong class="classname">ClassName</strong>
+    {</div>
+   <div class="classsynopsisinfo classsynopsisinfo_comment">/* Properties/Constants */</div>
+   <div class="fieldsynopsis">
+    <span class="attribute"><a href="file.knownattribute.is.in.html">#[\KnownAttribute]</a> </span><br>
+    <span class="attribute"><a href="file.anotherknownattribute.is.in.html">#[\AnotherKnownAttribute]</a> </span><br>
+    <span class="modifier">public</span>
+    <span class="modifier">readonly</span>
+    <span class="type">string</span>
+    <var class="varname">$propertyName</var>;</div>
+
+  }</div>
+ </div>
+
+</div>

--- a/tests/package/generic/data/attribute_formatting_003.xml
+++ b/tests/package/generic/data/attribute_formatting_003.xml
@@ -1,0 +1,38 @@
+<chapter xml:id="attribute-formatting-003">
+ <section>
+  <para>1. Property/Constant with unknown attributes</para>
+  <classsynopsis class="class">
+   <ooclass>
+    <classname>ClassName</classname>
+   </ooclass>
+   <classsynopsisinfo role="comment">Properties/Constants</classsynopsisinfo>
+   <fieldsynopsis>
+    <modifier role="attribute">#[\UnknownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherUnknownAttribute]</modifier>
+    <modifier>public</modifier>
+    <modifier>readonly</modifier>
+    <type>string</type>
+    <varname>CONSTANT_NAME</varname>
+   </fieldsynopsis>
+  </classsynopsis>
+ </section>
+
+ <section>
+  <para>2. Property/Constant with known attributes</para>
+  <classsynopsis class="class">
+   <ooclass>
+    <classname>ClassName</classname>
+   </ooclass>
+   <classsynopsisinfo role="comment">Properties/Constants</classsynopsisinfo>
+   <fieldsynopsis>
+    <modifier role="attribute">#[\KnownAttribute]</modifier>
+    <modifier role="attribute">#[\AnotherKnownAttribute]</modifier>
+    <modifier>public</modifier>
+    <modifier>readonly</modifier>
+    <type>string</type>
+    <varname>propertyName</varname>
+   </fieldsynopsis>
+  </classsynopsis>
+ </section>
+
+</chapter>


### PR DESCRIPTION
Add class property and constant attribute rendering support.

This, the [parameter](#127) and the [class, method and function](#135) attribute PRs together close https://github.com/php/doc-en/issues/3405.