### PR TITLE
Add config as a dependency of format

### DIFF
--- a/phpdotnet/phd/Format.php
+++ b/phpdotnet/phd/Format.php
@@ -21,6 +21,8 @@ abstract class Format extends ObjectStorage
      */
     const LDESC = 2;
 
+    protected Config $config;
+
     private $elementmap = array();
     private $textmap = array();
     private $formatname = "UNKNOWN";
@@ -62,7 +64,8 @@ abstract class Format extends ObjectStorage
     */
     protected $CURRENT_ID = "";
 
-    public function __construct() {
+    public function __construct(Config $config) {
+        $this->config = $config;
         if (Config::indexcache()) {
             $this->indexRepository = Config::indexcache();
             if (!($this instanceof Index)) {

--- a/phpdotnet/phd/Format/Abstract/Manpage.php
+++ b/phpdotnet/phd/Format/Abstract/Manpage.php
@@ -4,6 +4,10 @@ namespace phpdotnet\phd;
 abstract class Format_Abstract_Manpage extends Format {
     public $role = false;
 
+    public function __construct(Config $config) {
+        parent::__construct($config);
+    }
+
     public function UNDEF($open, $name, $attrs, $props) {
         if ($open) {
             trigger_error("No mapper found for '{$name}'", E_USER_WARNING);

--- a/phpdotnet/phd/Format/Abstract/PDF.php
+++ b/phpdotnet/phd/Format/Abstract/PDF.php
@@ -132,7 +132,8 @@ class PdfWriter {
     // To temporarily store $current(s)
     private $old = array();
 
-    function __construct($pageWidth = 210, $pageHeight = 297) {
+    function __construct($pageWidth = 210, $pageHeight = 297, Config $config) {
+        parent::__construct($config);
     	// Initialization of properties
     	$this->haruDoc = new \HaruDoc;
     	$this->haruDoc->addPageLabel(1, \HaruPage::NUM_STYLE_DECIMAL, 1, "Page ");

--- a/phpdotnet/phd/Format/Abstract/XHTML.php
+++ b/phpdotnet/phd/Format/Abstract/XHTML.php
@@ -14,8 +14,8 @@ abstract class Format_Abstract_XHTML extends Format {
     protected $mediamanager = null;
     protected $lang = 'en';
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
     }
 
     public function transformFromMap($open, $tag, $name, $attrs, $props) {

--- a/phpdotnet/phd/Format/Factory.php
+++ b/phpdotnet/phd/Format/Factory.php
@@ -39,11 +39,11 @@ abstract class Format_Factory {
         return $this->packageName;
     }
 
-    public final function createFormat($format) {
+    public final function createFormat($format, ...$formatParams) {
         if (isset($this->formats[$format]) && $this->formats[$format]) {
             $classname = __NAMESPACE__ . "\\" . $this->formats[$format];
 
-            $obj = new $classname();
+            $obj = new $classname(...$formatParams);
             if (!($obj instanceof Format)) {
                 throw new \Exception("All Formats must inherit Format");
              }

--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -105,9 +105,12 @@ class Index extends Format
     private $POST_REPLACEMENT_VALUES  = array();
     private int $exampleCounter = 0;
 
-    public function __construct(IndexRepository $indexRepository) {
+    public function __construct(
+        IndexRepository $indexRepository,
+        Config $config
+    ) {
         $this->indexRepository = $indexRepository;
-        parent::__construct();
+        parent::__construct($config);
     }
 
     public function transformFromMap($open, $tag, $name, $attrs, $props) {

--- a/phpdotnet/phd/Package/Generic/BigXHTML.php
+++ b/phpdotnet/phd/Package/Generic/BigXHTML.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_Generic_BigXHTML extends Package_Generic_XHTML {
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("Big-XHTML");
         $this->setTitle("Index");
         $this->setChunked(false);

--- a/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_Generic_ChunkedXHTML extends Package_Generic_XHTML {
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("Chunked-XHTML");
         $this->setTitle("Index");
         $this->setChunked(true);

--- a/phpdotnet/phd/Package/Generic/Manpage.php
+++ b/phpdotnet/phd/Package/Generic/Manpage.php
@@ -256,8 +256,8 @@ class Package_Generic_Manpage extends Format_Abstract_Manpage {
         "firstrefname"          => true,
     );
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
 
         $this->registerFormatName("Generic Unix Manual Pages");
         $this->setExt(Config::ext() === null ? ".3.gz" : Config::ext());

--- a/phpdotnet/phd/Package/Generic/PDF.php
+++ b/phpdotnet/phd/Package/Generic/PDF.php
@@ -296,8 +296,8 @@ abstract class Package_Generic_PDF extends Format_Abstract_PDF {
         "callouts"              => 0,
     );
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->setExt(Config::ext() === null ? ".pdf" : Config::ext());
         $this->pdfDoc = new PdfWriter();
     }

--- a/phpdotnet/phd/Package/Generic/TocFeed.php
+++ b/phpdotnet/phd/Package/Generic/TocFeed.php
@@ -131,9 +131,9 @@ abstract class Package_Generic_TocFeed extends Format
     /**
      * Creates a new instance.
      */
-    public function __construct()
+    public function __construct(Config $config)
     {
-        parent::__construct();
+        parent::__construct($config);
         $this->registerFormatName($this->formatName);
         $this->setTitle('Index');
         $this->setChunked(true);

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -530,8 +530,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     protected int $exampleCounter = 0;
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerPIHandlers($this->pihandlers);
         $this->setExt(Config::ext() === null ? ".html" : Config::ext());
     }

--- a/phpdotnet/phd/Package/IDE/Base.php
+++ b/phpdotnet/phd/Package/IDE/Base.php
@@ -76,6 +76,10 @@ abstract class Package_IDE_Base extends Format {
         'seealso'               => array(),
     );
 
+    public function __construct(Config $config){
+        parent::__construct($config);
+    }
+
     public function createLink($for, &$desc = null, $type = Format::SDESC) {}
     public function UNDEF($open, $name, $attrs, $props) {}
     public function TEXT($value) {}

--- a/phpdotnet/phd/Package/IDE/Funclist.php
+++ b/phpdotnet/phd/Package/IDE/Funclist.php
@@ -14,7 +14,8 @@ class Package_IDE_Funclist extends Format {
     protected $isRefname = false;
     protected $buffer = "";
 
-    public function __construct() {
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("IDE-Funclist");
         $this->setExt(Config::ext() === null ? ".txt" : Config::ext());
     }

--- a/phpdotnet/phd/Package/IDE/JSON.php
+++ b/phpdotnet/phd/Package/IDE/JSON.php
@@ -3,7 +3,8 @@ namespace phpdotnet\phd;
 
 class Package_IDE_JSON extends Package_IDE_Base {
 
-    public function __construct() {
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName('IDE-JSON');
         $this->setExt(Config::ext() === null ? ".json" : Config::ext());
     }

--- a/phpdotnet/phd/Package/IDE/PHP.php
+++ b/phpdotnet/phd/Package/IDE/PHP.php
@@ -3,7 +3,8 @@ namespace phpdotnet\phd;
 
 class Package_IDE_PHP extends Package_IDE_Base {
 
-    public function __construct() {
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName('IDE-PHP');
         $this->setExt(Config::ext() === null ? ".php" : Config::ext());
     }

--- a/phpdotnet/phd/Package/IDE/PHPStub.php
+++ b/phpdotnet/phd/Package/IDE/PHPStub.php
@@ -2,7 +2,8 @@
 namespace phpdotnet\phd;
 class Package_IDE_PHPStub extends Package_IDE_Base {
 
-    public function __construct() {
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName('IDE-PHPStub');
         $this->setExt(Config::ext() === null ? ".php" : Config::ext());
     }

--- a/phpdotnet/phd/Package/IDE/SQLite.php
+++ b/phpdotnet/phd/Package/IDE/SQLite.php
@@ -6,7 +6,8 @@ class Package_IDE_SQLite extends Package_IDE_Base {
     private $sql = array();
     private $db = null;
 
-    public function __construct() {
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName('IDE-SQLite');
         $this->setExt(Config::ext() === null ? ".sqlite" : Config::ext());
     }

--- a/phpdotnet/phd/Package/IDE/XML.php
+++ b/phpdotnet/phd/Package/IDE/XML.php
@@ -3,7 +3,8 @@ namespace phpdotnet\phd;
 
 class Package_IDE_XML extends Package_IDE_Base {
 
-    public function __construct() {
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName('IDE-XML');
         $this->setExt(Config::ext() === null ? ".xml" : Config::ext());
     }

--- a/phpdotnet/phd/Package/PEAR/BigXHTML.php
+++ b/phpdotnet/phd/Package/PEAR/BigXHTML.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_PEAR_BigXHTML extends Package_PEAR_XHTML {
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PEAR-BigXHTML");
         $this->setTitle("PEAR Manual");
         $this->setExt(Config::ext() === null ? ".html" : Config::ext());

--- a/phpdotnet/phd/Package/PEAR/CHM.php
+++ b/phpdotnet/phd/Package/PEAR/CHM.php
@@ -194,8 +194,8 @@ class Package_PEAR_CHM extends Package_PEAR_ChunkedXHTML {
 	// Project files Output directory
 	protected $chmdir;
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PEAR-CHM");
     }
 

--- a/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_PEAR_ChunkedXHTML extends Package_PEAR_XHTML {
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PEAR-Chunked-XHTML");
         $this->setTitle("PEAR Manual");
         $this->setExt(Config::ext() === null ? ".html" : Config::ext());

--- a/phpdotnet/phd/Package/PEAR/TocFeed.php
+++ b/phpdotnet/phd/Package/PEAR/TocFeed.php
@@ -84,9 +84,9 @@ class Package_PEAR_TocFeed extends Package_Generic_TocFeed
     /**
      * Create new instance.
      */
-    public function __construct()
+    public function __construct(Config $config)
     {
-        parent::__construct();
+        parent::__construct($config);
 
         $language = Config::language();
         $variables = array('targetBaseUri', 'feedBaseUri', 'idprefix');

--- a/phpdotnet/phd/Package/PEAR/Web.php
+++ b/phpdotnet/phd/Package/PEAR/Web.php
@@ -14,9 +14,9 @@ namespace phpdotnet\phd;
  */
 class Package_PEAR_Web extends Package_PEAR_ChunkedXHTML
 {
-    public function __construct()
+    public function __construct(Config $config)
     {
-        parent::__construct();
+        parent::__construct($config);
         $this->registerFormatName('PEAR-Web');
         $this->setExt(Config::ext() === null ? '.php' : Config::ext());
     }

--- a/phpdotnet/phd/Package/PEAR/XHTML.php
+++ b/phpdotnet/phd/Package/PEAR/XHTML.php
@@ -405,8 +405,8 @@ abstract class Package_PEAR_XHTML extends Package_Generic_XHTML {
     /**
      * Constructor
      */
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->myelementmap = array_merge(parent::getDefaultElementMap(), static::getDefaultElementMap());
         $this->mytextmap = array_merge(parent::getDefaultTextMap(), static::getDefaultTextMap());
         $this->dchunk = array_merge(parent::getDefaultChunkInfo(), static::getDefaultChunkInfo());

--- a/phpdotnet/phd/Package/PHP/BigPDF.php
+++ b/phpdotnet/phd/Package/PHP/BigPDF.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_PHP_BigPDF extends Package_PHP_PDF {
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-BigPDF");
     }
 

--- a/phpdotnet/phd/Package/PHP/BigXHTML.php
+++ b/phpdotnet/phd/Package/PHP/BigXHTML.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_PHP_BigXHTML extends Package_PHP_XHTML {
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-BigXHTML");
         $this->setTitle("PHP Manual");
         $this->setChunked(false);

--- a/phpdotnet/phd/Package/PHP/CHM.php
+++ b/phpdotnet/phd/Package/PHP/CHM.php
@@ -202,8 +202,8 @@ class Package_PHP_CHM extends Package_PHP_ChunkedXHTML
     // Project files Output directory
     protected $chmdir;
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-CHM");
     }
 

--- a/phpdotnet/phd/Package/PHP/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/PHP/ChunkedXHTML.php
@@ -4,8 +4,8 @@ namespace phpdotnet\phd;
 class Package_PHP_ChunkedXHTML extends Package_PHP_Web {
     private $nav = "";
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-Chunked-XHTML");
         $this->setExt(Config::ext() === null ? ".html" : Config::ext());
     }

--- a/phpdotnet/phd/Package/PHP/EnhancedCHM.php
+++ b/phpdotnet/phd/Package/PHP/EnhancedCHM.php
@@ -9,8 +9,8 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
     // Where are the usernotes?
     protected $userNotesBaseDir = null;
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-EnhancedCHM");
     }
 

--- a/phpdotnet/phd/Package/PHP/Epub.php
+++ b/phpdotnet/phd/Package/PHP/Epub.php
@@ -23,8 +23,8 @@ class Package_PHP_Epub extends Package_PHP_ChunkedXHTML
         'epub_file'     => '',
     );
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->setExt('.xhtml');
         $this->registerFormatName("PHP-Epub");
     }

--- a/phpdotnet/phd/Package/PHP/HowTo.php
+++ b/phpdotnet/phd/Package/PHP/HowTo.php
@@ -4,8 +4,8 @@ namespace phpdotnet\phd;
 class Package_PHP_HowTo extends Package_PHP_Web {
     private $nav = "";
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-HowTo");
     }
 

--- a/phpdotnet/phd/Package/PHP/KDevelop.php
+++ b/phpdotnet/phd/Package/PHP/KDevelop.php
@@ -65,8 +65,8 @@ class Package_PHP_KDevelop extends Format {
     // CHM Index Map
     protected $hhkStream;
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-KDevelop");
         $this->setTitle("PHP Manual");
         $this->setExt(Config::ext() === null ? ".php" : Config::ext());

--- a/phpdotnet/phd/Package/PHP/Manpage.php
+++ b/phpdotnet/phd/Package/PHP/Manpage.php
@@ -37,8 +37,8 @@ class Package_PHP_Manpage extends Package_Generic_Manpage {
     /* Default Chunk settings */
     protected $dchunk          = array();
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
 
         $this->registerFormatName("PHP-Functions");
         $this->setTitle("PHP Manual");

--- a/phpdotnet/phd/Package/PHP/PDF.php
+++ b/phpdotnet/phd/Package/PHP/PDF.php
@@ -97,8 +97,8 @@ class Package_PHP_PDF extends Package_Generic_PDF {
         "root-outline"              => null,
     );
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-PDF");
         $this->setTitle("PHP Manual");
     }

--- a/phpdotnet/phd/Package/PHP/TocFeed.php
+++ b/phpdotnet/phd/Package/PHP/TocFeed.php
@@ -132,9 +132,9 @@ class Package_PHP_TocFeed extends Package_Generic_TocFeed
     /**
      * Create new instance.
      */
-    public function __construct()
+    public function __construct(Config $config)
     {
-        parent::__construct();
+        parent::__construct($config);
 
         $language = Config::language();
         $variables = array('targetBaseUri', 'feedBaseUri', 'idprefix');

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -8,8 +8,8 @@ class Package_PHP_Web extends Package_PHP_XHTML {
     /** $var array<string, array<string, mixed>> */
     protected array $history = [];
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->registerFormatName("PHP-Web");
         $this->setTitle("PHP Manual");
         $this->setChunked(true);

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -208,8 +208,8 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         'phpdoc'        => 'PI_PHPDOCHandler',
     );
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(Config $config) {
+        parent::__construct($config);
         $this->myelementmap = array_merge(parent::getDefaultElementMap(), static::getDefaultElementMap());
         $this->mytextmap = array_merge(parent::getDefaultTextMap(), static::getDefaultTextMap());
         $this->dchunk = array_merge(parent::getDefaultChunkInfo(), static::getDefaultChunkInfo());

--- a/phpdotnet/phd/TestGenericChunkedXHTML.php
+++ b/phpdotnet/phd/TestGenericChunkedXHTML.php
@@ -2,6 +2,10 @@
 namespace phpdotnet\phd;
 
 class TestGenericChunkedXHTML extends Package_Generic_ChunkedXHTML {
+    public function __construct(Config $config) {
+        parent::__construct($config);
+    }
+
     public function update($event, $val = null) {
         switch($event) {
         case Render::CHUNK:

--- a/phpdotnet/phd/TestPHPChunkedXHTML.php
+++ b/phpdotnet/phd/TestPHPChunkedXHTML.php
@@ -2,6 +2,10 @@
 namespace phpdotnet\phd;
 
 class TestPHPChunkedXHTML extends Package_PHP_ChunkedXHTML {
+    public function __construct(Config $config) {
+        parent::__construct($config);
+    }
+
     public function update($event, $val = null) {
         switch($event) {
         case Render::CHUNK:

--- a/render.php
+++ b/render.php
@@ -124,7 +124,7 @@ $config->set_indexcache($indexRepository);
 if (requireIndexing($config)) {
     v("Indexing...", VERBOSE_INDEXING);
     // Create indexer
-    $format = new Index($config->indexcache());
+    $format = new Index($config->indexcache(), $config);
     $render->attach($format);
 
     $reader = make_reader($config);
@@ -148,7 +148,7 @@ foreach((array)$config->package() as $package) {
 
     // Register the formats
     foreach ($config->output_format() as $format) {
-        $render->attach($factory->createFormat($format));
+        $render->attach($factory->createFormat($format, $config));
     }
 }
 

--- a/tests/bug_doc-en_GH-3353.phpt
+++ b/tests/bug_doc-en_GH-3353.phpt
@@ -19,7 +19,7 @@ $config->set_indexcache($indexRepository);
 
 
 // Indexing
-$index = new TestIndex($indexRepository);
+$index = new TestIndex($indexRepository, $config);
 $render->attach($index);
 
 $reader = new Reader;
@@ -30,7 +30,7 @@ $render->detach($index);
 
 
 // Rendering
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render->attach($format);
 
 $reader = new Reader;

--- a/tests/bug_doc-en_GH-3428.phpt
+++ b/tests/bug_doc-en_GH-3428.phpt
@@ -15,7 +15,7 @@ $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 $config->set_indexcache($indexRepository);
 
-$index = new TestIndex($indexRepository);
+$index = new TestIndex($indexRepository, $config);
 
 $render = new TestRender(new Reader, $config, null, $index);
 
@@ -29,9 +29,9 @@ var_dump($indexes);
 
 $render = new TestRender(new Reader, $config);
 
-$format1 = new TestGenericChunkedXHTML;
-$format2 = new TestGenericChunkedXHTML;
-$format3 = new TestGenericChunkedXHTML;
+$format1 = new TestGenericChunkedXHTML($config);
+$format2 = new TestGenericChunkedXHTML($config);
+$format3 = new TestGenericChunkedXHTML($config);
 
 $render->attach($format1);
 $render->attach($format2);

--- a/tests/example_numbering_001.phpt
+++ b/tests/example_numbering_001.phpt
@@ -15,7 +15,7 @@ $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 $config->set_indexcache($indexRepository);
 
-$index = new TestIndex($indexRepository);
+$index = new TestIndex($indexRepository, $config);
 
 $render = new TestRender(new Reader, $config, null, $index);
 
@@ -27,7 +27,7 @@ echo "Indexes stored:\n";
 
 var_dump($indexes);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 
 $render = new TestRender(new Reader, $config, $format);
 

--- a/tests/index/bug_GH-98.phpt
+++ b/tests/index/bug_GH-98.phpt
@@ -14,7 +14,7 @@ $config->setXml_file($xml_file);
 $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 
-$index = new TestIndex($indexRepository);
+$index = new TestIndex($indexRepository, $config);
 $render = new TestRender(new Reader, $config, null, $index);
 
 $render->run();

--- a/tests/index/indexing_001.phpt
+++ b/tests/index/indexing_001.phpt
@@ -14,7 +14,7 @@ $config->setXml_file($xml_file);
 $indexRepository = new IndexRepository(new \SQLite3(":memory:"));
 $indexRepository->init();
 
-$index = new TestIndex($indexRepository);
+$index = new TestIndex($indexRepository, $config);
 $render = new TestRender(new Reader, $config, null, $index);
 
 $render->run();

--- a/tests/package/generic/001.phpt
+++ b/tests/package/generic/001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/001-1.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/generic/002.phpt
+++ b/tests/package/generic/002.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/002.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/generic/003.phpt
+++ b/tests/package/generic/003.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/003.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/generic/attribute_formatting_001.phpt
+++ b/tests/package/generic/attribute_formatting_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/attribute_formatting_001.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 
 $format->SQLiteIndex(
     null, // $context,

--- a/tests/package/generic/attribute_formatting_002.phpt
+++ b/tests/package/generic/attribute_formatting_002.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/attribute_formatting_002.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 
 $format->SQLiteIndex(
     null, // $context,

--- a/tests/package/generic/attribute_formatting_003.phpt
+++ b/tests/package/generic/attribute_formatting_003.phpt
@@ -12,7 +12,7 @@ $config = new Config;
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 
 $format->SQLiteIndex(
     null, // $context,

--- a/tests/package/generic/caption_001.phpt
+++ b/tests/package/generic/caption_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/caption_001.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 $format->postConstruct();
 $render = new TestRender(new Reader, $config, $format);
 

--- a/tests/package/generic/simplelist_001.phpt
+++ b/tests/package/generic/simplelist_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/simplelist.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/generic/whitespace_formatting_001.phpt
+++ b/tests/package/generic/whitespace_formatting_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/whitespace_formatting_001.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestGenericChunkedXHTML;
+$format = new TestGenericChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/bug49101-1.phpt
+++ b/tests/package/php/bug49101-1.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/bug49101-1.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/bug49101-2.phpt
+++ b/tests/package/php/bug49101-2.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/bug49101-1.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPBigXHTML;
+$format = new TestPHPBigXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/bug49102-1.phpt
+++ b/tests/package/php/bug49102-1.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/bug49102-1.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/bug_doc-en_GH-3179.phpt
+++ b/tests/package/php/bug_doc-en_GH-3179.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/bug_doc-en_GH-3197.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/class_rendering_001.phpt
+++ b/tests/package/php/class_rendering_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/class_rendering_001.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/class_rendering_002.phpt
+++ b/tests/package/php/class_rendering_002.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/class_rendering_002.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/class_rendering_003.phpt
+++ b/tests/package/php/class_rendering_003.phpt
@@ -10,7 +10,7 @@ $xml_filePhpdoc = __DIR__ . "/data/class_rendering_001.xml";
 
 $config->setXml_file($xml_filePhpdoc);
 
-$formatPhpdoc = new TestPHPChunkedXHTML;
+$formatPhpdoc = new TestPHPChunkedXHTML($config);
 $renderPhpdoc = new TestRender(new Reader, $config, $formatPhpdoc);
 
 ob_start();
@@ -22,7 +22,7 @@ $xml_fileReferenceWithRole = __DIR__ . "/data/class_rendering_002.xml";
 
 $config->setXml_file($xml_fileReferenceWithRole);
 
-$formatReferenceWithRole = new TestPHPChunkedXHTML;
+$formatReferenceWithRole = new TestPHPChunkedXHTML($config);
 $renderReferenceWithRole = new TestRender(new Reader, $config, $formatReferenceWithRole);
 
 ob_start();

--- a/tests/package/php/constant_links_001.phpt
+++ b/tests/package/php/constant_links_001.phpt
@@ -29,7 +29,7 @@ $indices = [
     ],
 ];
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 
 foreach ($indices as $index) {
     $format->SQLiteIndex(

--- a/tests/package/php/exception_rendering_001.phpt
+++ b/tests/package/php/exception_rendering_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/exception_rendering_001.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/exception_rendering_002.phpt
+++ b/tests/package/php/exception_rendering_002.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/exception_rendering_002.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/exception_rendering_003.phpt
+++ b/tests/package/php/exception_rendering_003.phpt
@@ -10,7 +10,7 @@ $xml_filePhpdoc = __DIR__ . "/data/exception_rendering_001.xml";
 
 $config->setXml_file($xml_filePhpdoc);
 
-$formatPhpdoc = new TestPHPChunkedXHTML;
+$formatPhpdoc = new TestPHPChunkedXHTML($config);
 $renderPhpdoc = new TestRender(new Reader, $config, $formatPhpdoc);
 
 ob_start();
@@ -22,7 +22,7 @@ $xml_fileReferenceWithRole = __DIR__ . "/data/exception_rendering_002.xml";
 
 $config->setXml_file($xml_fileReferenceWithRole);
 
-$formatReferenceWithRole = new TestPHPChunkedXHTML;
+$formatReferenceWithRole = new TestPHPChunkedXHTML($config);
 $renderReferenceWithRole = new TestRender(new Reader, $config, $formatReferenceWithRole);
 
 ob_start();

--- a/tests/package/php/faq001.phpt
+++ b/tests/package/php/faq001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/faq001.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/type_rendering_001.phpt
+++ b/tests/package/php/type_rendering_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/type_rendering_methodsynopsis_return_types.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/type_rendering_002.phpt
+++ b/tests/package/php/type_rendering_002.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/type_rendering_methodsynopsis_parameters.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/type_rendering_003.phpt
+++ b/tests/package/php/type_rendering_003.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/type_rendering_constructorsynopsis_parameters-and-r
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();

--- a/tests/package/php/variablelist_rendering_001.phpt
+++ b/tests/package/php/variablelist_rendering_001.phpt
@@ -10,7 +10,7 @@ $xml_file = __DIR__ . "/data/variablelist_rendering_001.xml";
 
 $config->setXml_file($xml_file);
 
-$format = new TestPHPChunkedXHTML;
+$format = new TestPHPChunkedXHTML($config);
 $render = new TestRender(new Reader, $config, $format);
 
 $render->run();


### PR DESCRIPTION
Add Config as a dependency to Format and all it subclasses.
Inject Config into every Format subclass at instantiation.
Fix tests.

This is a follow up to #139. As mentioned there, this PR adds `Config` as a dependency to `Format` and all its subclasses, and injects a `Config` object into every subclass of `Format` (in `render.php` and `Factory.php`).