### PR TITLE
Remove Config from Autoloader

### DIFF
--- a/phpdotnet/phd/Autoloader.php
+++ b/phpdotnet/phd/Autoloader.php
@@ -1,16 +1,19 @@
 <?php
 namespace phpdotnet\phd;
 
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'Config.php';
-
 class Autoloader
 {
+    /**
+     * @var array<string> Absolute pathnames to package directories
+     */
+    private static array $package_dirs = [];
+
     public static function autoload($name)
     {
         // Only try autoloading classes we know about (i.e. from our own namespace)
         if (strncmp('phpdotnet\phd\\', $name, 14) === 0) {
             $filename = DIRECTORY_SEPARATOR . str_replace(array('\\', '_'), DIRECTORY_SEPARATOR, $name) . '.php';
-            foreach(Config::package_dirs() as $dir) {
+            foreach(self::$package_dirs as $dir) {
                 $file = $dir . $filename;
 
                 // Using fopen() because it has use_include_path parameter.
@@ -23,11 +26,16 @@ class Autoloader
 
                 return false;
             }
-            v('Cannot find file for %s: %s', $name, $file, E_USER_ERROR);
+            v('Cannot find file for %s: %s', $name, $file ?? $filename, E_USER_ERROR);
         }
 
         return false;
     }
+
+    /**
+     * @var array<string> Absolute pathnames to package directories
+     */
+    public static function setPackageDirs(array $dirs): void {
+        self::$package_dirs = $dirs;
+    }
 }
-
-

--- a/render.php
+++ b/render.php
@@ -10,6 +10,7 @@ if (!defined("__INSTALLDIR__")) {
 
 require_once __INSTALLDIR__ . '/phpdotnet/phd/Autoloader.php';
 require_once __INSTALLDIR__ . '/phpdotnet/phd/functions.php';
+Autoloader::setPackageDirs([__INSTALLDIR__]);
 
 spl_autoload_register(array(__NAMESPACE__ . "\\Autoloader", "autoload"));
 
@@ -38,6 +39,10 @@ $optionsParser = new Options_Parser(
 $commandLineOptions = $optionsParser->getopt();
 
 $config->init($commandLineOptions);
+
+if (isset($commandLineOptions["package_dirs"])) {
+    Autoloader::setPackageDirs($config->package_dirs());
+}
 
 /* If no docbook file was passed, die */
 if (!is_dir($config->xml_root()) || !is_file($config->xml_file())) {

--- a/tests/autoloader/autoloader_001.phpt
+++ b/tests/autoloader/autoloader_001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Autoloader 001 - Autoload format from external directory
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../setup.php";
+
+Autoloader::setPackageDirs([
+    realpath(__DIR__ . DIRECTORY_SEPARATOR . "external_directory_test")
+]);
+
+$format = new TestFormat;
+
+echo "Done"
+?>
+--EXPECT--
+Done

--- a/tests/autoloader/external_directory_test/phpdotnet/phd/TestFormat.php
+++ b/tests/autoloader/external_directory_test/phpdotnet/phd/TestFormat.php
@@ -1,0 +1,4 @@
+<?php
+namespace phpdotnet\phd;
+
+class TestFormat {}

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -4,6 +4,7 @@ namespace phpdotnet\phd;
 define("__INSTALLDIR__", "@php_dir@" == "@"."php_dir@" ? dirname(__DIR__) : "@php_dir@");
 
 require_once __INSTALLDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "Autoloader.php";
+Autoloader::setPackageDirs([__INSTALLDIR__]);
 spl_autoload_register(["phpdotnet\\phd\\Autoloader", "autoload"]);
 
 require_once __INSTALLDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "functions.php";


### PR DESCRIPTION
Remove `Config from Autoloader` by replacing it with a static array and a setter method. 
Update `render.php` and `setup.php` to pass package directories to `Autoloader`. 
Add test.