### PR TITLE
Fix element map so changelog rows are handled correctly

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -98,7 +98,7 @@ class Index extends Format
     private $inChangelog = false;
     private $currentChangelog = array();
     private string $currentChangeLogString = "";
-    private $changelog        = array();
+    protected $changelog       = array();
     private $currentMembership = null;
     private $commit     = array();
     private $POST_REPLACEMENT_INDEXES = array();

--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -419,17 +419,19 @@ class Index extends Format
             $this->currentChangelog[] = htmlentities(trim($this->currentChangeLogString), ENT_COMPAT, "UTF-8");
         }
     }
+
     public function format_row($open, $name, $attrs, $props) {
-        if ($open) {
-            if ($this->inChangelog) {
-                end($this->ids); prev($this->ids);
-                $this->currentChangelog = array($this->currentMembership, current($this->ids));
-            }
-            return;
-        }
         if ($this->inChangelog) {
-            $this->changelog[$this->currentid][] = $this->currentChangelog;
+            if ($open) {
+                $parent_id = $this->ids[count($this->ids) - 2];
+                $this->currentChangelog = array($this->currentMembership, $parent_id);
+            } else {
+                $this->changelog[$this->currentid][] = $this->currentChangelog;
+            }
         }
+
+        /* Fall back to regular handling so contents get processed */
+        return $this->UNDEF($open, $name, $attrs, $props);
     }
 
     public function processFilename() {

--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -63,9 +63,9 @@ class Index extends Format
     'titleabbrev'           => 'format_short_desc',
     'example'               => 'format_example',
     'refsect1'              => 'format_refsect1',
-    'tbody'                 => array(
+    'row'                   => array(
         /* DEFAULT */          null,
-        'row'               => 'format_row',
+        'tbody'             => 'format_row',
     ),
     'entry'                 => array(
         /* DEFAULT */          null,

--- a/phpdotnet/phd/IndexRepository.php
+++ b/phpdotnet/phd/IndexRepository.php
@@ -103,14 +103,16 @@ SQL;
         $log = "";
         foreach($changelog as $id => $arr) {
             foreach($arr as $entry) {
-                $log .= sprintf(
-                    "INSERT INTO changelogs (membership, docbook_id, parent_id, version, description) VALUES('%s', '%s', '%s', '%s', '%s');\n",
-                    $this->db->escapeString($entry[0] ?? ''),
-                    $this->db->escapeString($id),
-                    $this->db->escapeString($entry[1]),
-                    $this->db->escapeString($entry[2]),
-                    $this->db->escapeString($entry[3])
-                );
+                foreach(preg_split('/,\s+/', $entry[2]) as $version) {
+                    $log .= sprintf(
+                        "INSERT INTO changelogs (membership, docbook_id, parent_id, version, description) VALUES('%s', '%s', '%s', '%s', '%s');\n",
+                        $this->db->escapeString($entry[0] ?? ''),
+                        $this->db->escapeString($id),
+                        $this->db->escapeString($entry[1]),
+                        $this->db->escapeString($version),
+                        $this->db->escapeString($entry[3])
+                    );
+                }
             }
         }
         $this->db->exec('BEGIN TRANSACTION; ' . $log. ' COMMIT');

--- a/phpdotnet/phd/PI/PHPDOCHandler.php
+++ b/phpdotnet/phd/PI/PHPDOCHandler.php
@@ -118,7 +118,7 @@ class PI_PHPDOCHandler extends PIHandler {
     // usort() callback function used in generate-changelog-for, higest (newest) version first
     // 1.2.11 comes before 1.2.2, then function name (actually its id.. but close enough :))
     protected static function _sortByVersion($a, $b) {
-        $retval = -1 * strnatcasecmp($a["version"], $b["version"]);
+        $retval = -1 * version_compare($a["version"], $b["version"]);
 
         if ($retval === 0) {
             return strnatcasecmp($a["docbook_id"], $b["docbook_id"]);

--- a/phpdotnet/phd/PI/PHPDOCHandler.php
+++ b/phpdotnet/phd/PI/PHPDOCHandler.php
@@ -138,7 +138,7 @@ class PI_PHPDOCHandler extends PIHandler {
 
         $version = "";
         foreach($changelogs as $entry) {
-            if (!$this->_changelogSince || strnatcasecmp($entry["version"], $this->_changelogSince) >= 0) {
+            if (!$this->_changelogSince || version_compare($entry["version"], $this->_changelogSince) >= 0) {
                 $link = $this->format->createLink($entry["docbook_id"], $desc);
                 if ($version == $entry["version"]) {
                     $v = "&nbsp;";

--- a/phpdotnet/phd/TestIndex.php
+++ b/phpdotnet/phd/TestIndex.php
@@ -5,4 +5,8 @@ class TestIndex extends Index {
     public function getNfo(): array {
         return $this->nfo;
     }
+
+    public function getChangelog(): array {
+        return $this->changelog;
+    }
 }

--- a/tests/bug_GH-87.phpt
+++ b/tests/bug_GH-87.phpt
@@ -1,0 +1,65 @@
+--TEST--
+GH-87 Broken links for constants in table rows
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/setup.php";
+
+$xml_file = __DIR__ . "/data/bug_GH-87.xml";
+
+$config->setForce_index(true);
+$config->setXml_file($xml_file);
+
+$indexRepository = new IndexRepository(new \SQLite3(":memory:"));
+$indexRepository->init();
+$config->set_indexcache($indexRepository);
+
+$index = new TestIndex($indexRepository, $config);
+
+$render = new TestRender(new Reader, $config, null, $index);
+
+$render->run();
+
+$render = new TestRender(new Reader, $config);
+
+$format = new TestGenericChunkedXHTML($config);
+
+$render->attach($format);
+
+$render->run();
+
+?>
+--EXPECT--
+Filename: constants.html
+Content:
+<div id="constants" class="chapter">
+ <div class="section">
+  <p class="para">Constant within a table (GH-87)</p>
+  <p class="para">
+   <table class="doctable informaltable">
+    
+     <thead>
+      <tr>
+       <th>Header</th>
+      </tr>
+
+     </thead>
+
+     <tbody class="tbody">
+      <tr id="constant.defined">
+       <td><strong><code>CONSTANT_IS_DEFINED</code></strong></td>
+      </tr>
+
+     </tbody>
+    
+   </table>
+
+  </p>
+ </div>
+ <div class="section">
+  <p class="para">
+   <a href="constants.html#constant.defined" class="link">CONSTANT_IS_DEFINED</a>
+  </p>
+ </div>
+</div>

--- a/tests/data/bug_GH-87.xml
+++ b/tests/data/bug_GH-87.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="constants">
+ <section>
+  <para>Constant within a table (GH-87)</para>
+  <para>
+   <informaltable>
+    <tgroup cols="1">
+     <thead>
+      <row>
+       <entry>Header</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row xml:id="constant.defined">
+       <entry><constant>CONSTANT_IS_DEFINED</constant></entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </section>
+ <section>
+  <para>
+   <link linkend="constant.defined">CONSTANT_IS_DEFINED</link>
+  </para>
+ </section>
+</chapter>

--- a/tests/index/data/indexing_001.xml
+++ b/tests/index/data/indexing_001.xml
@@ -108,12 +108,31 @@
   <title>The <interfacename>Traversable</interfacename> interface</title>
   <titleabbrev>Traversable</titleabbrev>
   <partintro>
-   <section role="changelog">
+   <refsect1 role="changelog">
     <title xmlns="http://docbook.org/ns/docbook">Changelog</title>
     <para>
-     Changes
+     <informaltable>
+      <tgroup cols="2">
+       <thead>
+        <row>
+         <entry>Version</entry>
+         <entry>Description</entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>7.3.4, 8.0.0</entry>
+         <entry>Something happened.</entry>
+        </row>
+        <row>
+         <entry>PECL example 3.5.4</entry>
+         <entry>Something happened in PECL.</entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </informaltable>
     </para>
-   </section>
+   </refsect1>
   </partintro>
  </phpdoc:classref>
 

--- a/tests/index/indexing_001.phpt
+++ b/tests/index/indexing_001.phpt
@@ -24,6 +24,12 @@ $indexes = array_keys($index->getNfo());
 echo "Indexes stored:\n";
 
 var_dump($indexes);
+
+$changelog = array_keys($index->getChangelog());
+
+echo "Changelog stored:\n";
+
+var_dump($changelog);
 ?>
 --EXPECT--
 Indexes stored:
@@ -57,5 +63,10 @@ array(15) {
   [13]=>
   string(19) "reserved.interfaces"
   [14]=>
+  string(17) "class.traversable"
+}
+Changelog stored:
+array(1) {
+  [0]=>
   string(17) "class.traversable"
 }


### PR DESCRIPTION
https://www.php.net/manual/en/doc.changelog.php is empty because this was backwards and changelog entries weren't actually being indexed.