### PR TITLE
Improve search index generation for PHP.net

### DIFF
--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -224,6 +224,28 @@ contributors($setup);
         $ids = array();
         $desc = array();
         foreach($this->indexes as $id => $index) {
+            // Skip indexes that are not chunks
+            if (!$index["chunk"]) {
+                continue;
+            }
+
+            // Handle items with long description but no short description
+            if (empty($index["sdesc"]) && !empty($index["ldesc"])) {
+                // Use long desc as short desc
+                $index["sdesc"] = $index["ldesc"];
+
+                // Find the parent book and use its long desc
+                $parentId = $index['parent_id'];
+                while (isset($this->indexes[$parentId])) {
+                    $parent = $this->indexes[$parentId];
+                    if ($parent['element'] == 'book') {
+                        $index["ldesc"] = Format::getLongDescription($parent['docbook_id']);
+                        break;
+                    }
+                    $parentId = $parent['parent_id'];
+                }
+            }
+
             $ids[] = array($index["sdesc"], $index["filename"], $index["element"]);
             $desc[$id] = $index["ldesc"];
         }

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -236,7 +236,7 @@ contributors($setup);
                 // elements (no parent) or in case the index structure is broken.
                 while (isset($this->indexes[$parentId])) {
                     $parent = $this->indexes[$parentId];
-                    if ($parent['element'] == 'book') {
+                    if ($parent['element'] === 'book') {
                         $index["ldesc"] = Format::getLongDescription($parent['docbook_id']);
                         break;
                     }

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -228,7 +228,7 @@ contributors($setup);
                 continue;
             }
 
-            if (empty($index["sdesc"]) && !empty($index["ldesc"])) {
+            if ($index["sdesc"] === "" && $index["ldesc"] !== "") {
                 $index["sdesc"] = $index["ldesc"];
 
                 $parentId = $index['parent_id'];

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -232,6 +232,8 @@ contributors($setup);
                 $index["sdesc"] = $index["ldesc"];
 
                 $parentId = $index['parent_id'];
+                // isset() to guard against undefined array keys, either for root
+                // elements (no parent) or in case the index structure is broken.
                 while (isset($this->indexes[$parentId])) {
                     $parent = $this->indexes[$parentId];
                     if ($parent['element'] == 'book') {

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -224,17 +224,13 @@ contributors($setup);
         $ids = array();
         $desc = array();
         foreach($this->indexes as $id => $index) {
-            // Skip indexes that are not chunks
             if (!$index["chunk"]) {
                 continue;
             }
 
-            // Handle items with long description but no short description
             if (empty($index["sdesc"]) && !empty($index["ldesc"])) {
-                // Use long desc as short desc
                 $index["sdesc"] = $index["ldesc"];
 
-                // Find the parent book and use its long desc
                 $parentId = $index['parent_id'];
                 while (isset($this->indexes[$parentId])) {
                     $parent = $this->indexes[$parentId];


### PR DESCRIPTION
> [!NOTE]
> This is a companion PR to https://github.com/php/web-php/pull/1084, but it is not dependent on it and can be merged independently.

## Intro
PHD index entries can have both short (sdesc) and long (ldesc) descriptions. Often, the short description is empty, leading to the current fallback mechanism in `getShortDescription` and `getLongDescription`:

```php
// phpdotnet/phd/Format.php
final public function getLongDescription($id, &$isLDesc = null) {
    if ($this->indexes[$id]["ldesc"]) {
        $isLDesc = true;
        return $this->indexes[$id]["ldesc"];
    } else {
        $isLDesc = false;
        return $this->indexes[$id]["sdesc"];
    }
}
final public function getShortDescription($id, &$isSDesc = null) {
    if ($this->indexes[$id]["sdesc"]) {
        $isSDesc = true;
        return $this->indexes[$id]["sdesc"];
    } else {
        $isSDesc = false;
        return $this->indexes[$id]["ldesc"];
    }
}
```

## Problem
The current search index JSON generation doesn't utilize this fallback
mechanism, resulting in missing entries in PHP.net search results.

## Solution
This PR addresses the issue by:

- Using the long description as the title when the short description is empty.
- Using the parent book title as the long description in such cases.
- Ignoring non-page entries (non-chunk entries) when generating the search index JSON.

## Impact

- Improves search result completeness and accuracy.
- Reduces search index size by excluding irrelevant entries.

## Examples

Currently, "PHP Manual > Language Reference > Types > String" is missing from search results due to an empty short description. This change will use "Strings" (the long description) as the title and "Language Reference" (the parent book title) as the long description.

search-index.json
```diff
 [
-  "",
+  "Strings",
   "language.types.string",
   "sect1"
 ],
-[
-  "",
-  "language.types.string",
-  "sect2"
-],

...
  [
-   "",
+   "Enumerations",
    "language.types.enumerations",
    "sect1"
  ],
```

search-description.json
```diff
-  "language.types.string": "Strings",
+  "language.types.string": "Language Reference",
...
-  "language.types.enumerations": "Enumerations",
+  "language.types.enumerations": "Language Reference",
```

# Statistics
| stat | before | after | change
--- | --- | --- | ---
Entries count | 29,765 | 11,256 | -62%
Entries lacking title (sdesc) | 19,955 | 0 | -100%
Search index size | 1,383KB | 693KB | -50%

## Generated Search Index Diff Preview
Only the first 100 lines are shown for brevity.

```diff
 [
   [
-    "",
+    "Copyright",
     "copyright",
     "legalnotice"
   ],
   [
-    "",
-    "index",
-    "info"
-  ],
-  [
-    "",
-    "index",
-    "book"
-  ],
-  [
-    "",
-    "preface",
-    "section"
-  ],
-  [
-    "",
+    "Preface",
     "preface",
     "preface"
   ],
   [
-    "",
-    "intro-whatis",
-    "example"
-  ],
-  [
-    "",
+    "What is PHP?",
     "intro-whatis",
     "section"
   ],
   [
-    "",
+    "What can PHP do?",
     "intro-whatcando",
     "section"
   ],
   [
-    "",
+    "Introduction",
     "introduction",
     "chapter"
   ],
   [
-    "",
+    "What do I need?",
     "tutorial.requirements",
     "section"
   ],
   [
-    "",
-    "tutorial.firstpage",
-    "example"
-  ],
-  [
-    "",
-    "tutorial.firstpage",
-    "example"
-  ],
-  [
-    "",
+    "Your first PHP-enabled page",
     "tutorial.firstpage",
     "section"
   ],
   [
-    "",
-    "tutorial.useful",
-    "example"
-  ],
-  [
-    "",
-    "tutorial.useful",
-    "example"
-  ],
-  [
-    "",
-    "tutorial.useful",
-    "example"
-  ],
-  [
-    "",
+    "Something Useful",
     "tutorial.useful",
     "section"
   ],
   [
-    "",
-    "tutorial.forms",
-    "example"
-  ],
```