### PR TITLE
Fix PHP highlighting for PHP ≥ 8.3

### DIFF
--- a/phpdotnet/phd/Highlighter.php
+++ b/phpdotnet/phd/Highlighter.php
@@ -63,10 +63,15 @@ class Highlighter
 
         if ($role == 'php') {
             try {
-                return strtr(highlight_string($text, 1), [
-                    '&nbsp;' => ' ',
-                    "\n" => '',
-                ]);
+                $highlight = highlight_string($text, true);
+                if (PHP_VERSION_ID >= 80300) {
+                    return $highlight;
+                } else {
+                    return strtr($highlight, [
+                        '&nbsp;' => ' ',
+                        "\n" => '',
+                    ]);
+                }
             } catch (\ParseException $e) {
                 v("Parse error while highlighting PHP code: %s\nText: %s", (string) $e, $text, E_USER_WARNING);
 


### PR DESCRIPTION
PHP 8.3 changed the details of highlighting PHP code[1], basically like we did[2] at roughly the same time.  However, both don't work well together, so we avoid that.

[1] <https://github.com/php/php-src/pull/11913>
[2] <https://github.com/php/phd/pull/79>

---

The following is certainly not desireable:

![example](https://github.com/user-attachments/assets/df0f6afd-4bb9-4a38-b0b6-9a29d909ce7c)

cc @TimWolla, @kamil-tekiela 