### PR TITLE
Move constant definitions to a dedicated file

### DIFF
--- a/phpdotnet/phd/Config.php
+++ b/phpdotnet/phd/Config.php
@@ -1,10 +1,6 @@
 <?php
 namespace phpdotnet\phd;
 
-if (!defined("__INSTALLDIR__")) {
-    define("__INSTALLDIR__", "@php_dir@" == "@"."php_dir@" ? dirname(dirname(__DIR__)) : "@php_dir@");
-}
-
 class Config
 {
     const VERSION = '@phd_version@';

--- a/phpdotnet/phd/constants.php
+++ b/phpdotnet/phd/constants.php
@@ -1,0 +1,35 @@
+<?php
+namespace phpdotnet\phd;
+
+// @php_dir@ gets replaced by pear with the install dir. use __DIR__ when
+// running from SVN
+define("__INSTALLDIR__", "@php_dir@" == "@"."php_dir@" ? dirname(__DIR__, 2) : "@php_dir@");
+
+// PhD verbose flags
+define('VERBOSE_ERRORS',                 (E_USER_DEPRECATED            << 1) - 1);
+
+// Informationals
+define('VERBOSE_INDEXING',               E_USER_DEPRECATED             << 1);
+define('VERBOSE_FORMAT_RENDERING',       VERBOSE_INDEXING              << 1);
+define('VERBOSE_THEME_RENDERING',        VERBOSE_FORMAT_RENDERING      << 1);
+define('VERBOSE_RENDER_STYLE',           VERBOSE_THEME_RENDERING       << 1);
+define('VERBOSE_PARTIAL_READING',        VERBOSE_RENDER_STYLE          << 1);
+define('VERBOSE_PARTIAL_CHILD_READING',  VERBOSE_PARTIAL_READING       << 1);
+define('VERBOSE_TOC_WRITING',            VERBOSE_PARTIAL_CHILD_READING << 1);
+define('VERBOSE_CHUNK_WRITING',          VERBOSE_TOC_WRITING           << 1);
+define('VERBOSE_MESSAGES',               VERBOSE_CHUNK_WRITING         << 1);
+
+define('VERBOSE_INFO',                   ((VERBOSE_MESSAGES            << 1) - 1) & ~VERBOSE_ERRORS);
+
+
+// Warnings
+define('VERBOSE_NOVERSION',              VERBOSE_MESSAGES              << 1);
+define('VERBOSE_BROKEN_LINKS',           VERBOSE_NOVERSION             << 1);
+define('VERBOSE_MISSING_ATTRIBUTES',     VERBOSE_BROKEN_LINKS          << 1);
+define('VERBOSE_OLD_LIBXML',             VERBOSE_MISSING_ATTRIBUTES    << 1);
+
+define('VERBOSE_WARNINGS',               ((VERBOSE_OLD_LIBXML  << 1) - 1) & ~VERBOSE_ERRORS & ~VERBOSE_INFO);
+
+
+define('VERBOSE_ALL',                    (VERBOSE_OLD_LIBXML   << 1) - 1);
+define('VERBOSE_DEFAULT',                (VERBOSE_ALL^(VERBOSE_PARTIAL_CHILD_READING|VERBOSE_CHUNK_WRITING|VERBOSE_WARNINGS|VERBOSE_TOC_WRITING)));

--- a/phpdotnet/phd/functions.php
+++ b/phpdotnet/phd/functions.php
@@ -3,35 +3,6 @@ namespace phpdotnet\phd;
 
 /* {{{ PhD error & message handler */
 
-// PhD verbose flags
-define('VERBOSE_ERRORS',                 (E_USER_DEPRECATED            << 1) - 1);
-
-// Informationals
-define('VERBOSE_INDEXING',               E_USER_DEPRECATED             << 1);
-define('VERBOSE_FORMAT_RENDERING',       VERBOSE_INDEXING              << 1);
-define('VERBOSE_THEME_RENDERING',        VERBOSE_FORMAT_RENDERING      << 1);
-define('VERBOSE_RENDER_STYLE',           VERBOSE_THEME_RENDERING       << 1);
-define('VERBOSE_PARTIAL_READING',        VERBOSE_RENDER_STYLE          << 1);
-define('VERBOSE_PARTIAL_CHILD_READING',  VERBOSE_PARTIAL_READING       << 1);
-define('VERBOSE_TOC_WRITING',            VERBOSE_PARTIAL_CHILD_READING << 1);
-define('VERBOSE_CHUNK_WRITING',          VERBOSE_TOC_WRITING           << 1);
-define('VERBOSE_MESSAGES',               VERBOSE_CHUNK_WRITING         << 1);
-
-define('VERBOSE_INFO',                   ((VERBOSE_MESSAGES            << 1) - 1) & ~VERBOSE_ERRORS);
-
-
-// Warnings
-define('VERBOSE_NOVERSION',              VERBOSE_MESSAGES              << 1);
-define('VERBOSE_BROKEN_LINKS',           VERBOSE_NOVERSION             << 1);
-define('VERBOSE_MISSING_ATTRIBUTES',     VERBOSE_BROKEN_LINKS          << 1);
-define('VERBOSE_OLD_LIBXML',             VERBOSE_MISSING_ATTRIBUTES    << 1);
-
-define('VERBOSE_WARNINGS',               ((VERBOSE_OLD_LIBXML  << 1) - 1) & ~VERBOSE_ERRORS & ~VERBOSE_INFO);
-
-
-define('VERBOSE_ALL',                    (VERBOSE_OLD_LIBXML   << 1) - 1);
-define('VERBOSE_DEFAULT',                (VERBOSE_ALL^(VERBOSE_PARTIAL_CHILD_READING|VERBOSE_CHUNK_WRITING|VERBOSE_WARNINGS|VERBOSE_TOC_WRITING)));
-
 $olderrrep = error_reporting();
 error_reporting($olderrrep | VERBOSE_DEFAULT);
 

--- a/render.php
+++ b/render.php
@@ -2,12 +2,7 @@
 <?php
 namespace phpdotnet\phd;
 
-// @php_dir@ gets replaced by pear with the install dir. use __DIR__ when
-// running from SVN
-if (!defined("__INSTALLDIR__")) {
-    define("__INSTALLDIR__", '@php_dir@' == '@'.'php_dir@' ? __DIR__ : '@php_dir@');
-}
-
+require_once __DIR__ . '/phpdotnet/phd/constants.php';
 require_once __INSTALLDIR__ . '/phpdotnet/phd/Autoloader.php';
 require_once __INSTALLDIR__ . '/phpdotnet/phd/functions.php';
 Autoloader::setPackageDirs([__INSTALLDIR__]);

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -1,8 +1,7 @@
 <?php
 namespace phpdotnet\phd;
 
-define("__INSTALLDIR__", "@php_dir@" == "@"."php_dir@" ? dirname(__DIR__) : "@php_dir@");
-
+require_once dirname(__DIR__) . '/phpdotnet/phd/constants.php';
 require_once __INSTALLDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPARATOR . "phd" . DIRECTORY_SEPARATOR . "Autoloader.php";
 Autoloader::setPackageDirs([__INSTALLDIR__]);
 spl_autoload_register(["phpdotnet\\phd\\Autoloader", "autoload"]);


### PR DESCRIPTION
Move all constant definitions to a dedicated file and include that in the main and test renderer files.