### PR TITLE
Bump minimum PHP version to 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and what the different parts of its pipeline are, please refer to the
 
 ## Requirements
 
-- PHP 8.0+
+- PHP 8.1+
 - DOM, libXML2, XMLReader and SQLite3.
 
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0.0",
+        "php": ">=8.1.0",
         "ext-dom": "*",
         "ext-sqlite3": "*",
         "ext-xmlreader": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d0351e184b76f317e07b9900e1035b1",
+    "content-hash": "7a1172b1a17b8a58fd3f50557a48316e",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -13,7 +13,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0.0",
+        "php": ">=8.1.0",
         "ext-dom": "*",
         "ext-sqlite3": "*",
         "ext-xmlreader": "*"


### PR DESCRIPTION
The code uses the `never` type which was introduced in PHP 8.1 so we need to bump the minimum version. 