### PR TITLE
Use trigger_error() for errors

### DIFF
--- a/phpdotnet/phd/Autoloader.php
+++ b/phpdotnet/phd/Autoloader.php
@@ -26,7 +26,7 @@ class Autoloader
 
                 return false;
             }
-            v('Cannot find file for %s: %s', $name, $file ?? $filename, E_USER_ERROR);
+            trigger_error(vsprintf('Cannot find file for %s: %s', [$name, $file ?? $filename]), E_USER_ERROR);
         }
 
         return false;

--- a/phpdotnet/phd/Highlighter.php
+++ b/phpdotnet/phd/Highlighter.php
@@ -73,7 +73,7 @@ class Highlighter
                     ]);
                 }
             } catch (\ParseException $e) {
-                v("Parse error while highlighting PHP code: %s\nText: %s", (string) $e, $text, E_USER_WARNING);
+                trigger_error(vsprintf("Parse error while highlighting PHP code: %s\nText: %s", [(string) $e, $text]), E_USER_WARNING);
 
                 return '<pre class="'. ($role ? $role . 'code' : 'programlisting') .'">'
                     . htmlspecialchars($text, ENT_QUOTES, 'UTF-8')

--- a/phpdotnet/phd/Options/Handler.php
+++ b/phpdotnet/phd/Options/Handler.php
@@ -213,11 +213,11 @@ class Options_Handler implements Options_Interface
         if (!file_exists($v)) {
             v("Creating output directory..", VERBOSE_MESSAGES);
             if (!mkdir($v, 0777, true)) {
-                v("Can't create output directory : %s", $v, E_USER_ERROR);
+                trigger_error(vsprintf("Can't create output directory : %s", [$v]), E_USER_ERROR);
             }
             v("Output directory created", VERBOSE_MESSAGES);
         } elseif (!is_dir($v)) {
-            v("Output directory is a file?", E_USER_ERROR);
+            trigger_error("Output directory is a file?", E_USER_ERROR);
         }
         if (!is_dir($v) || !is_readable($v)) {
             trigger_error(sprintf("'%s' is not a valid directory", $v), E_USER_ERROR);
@@ -480,7 +480,7 @@ class Options_Handler implements Options_Interface
                     $packages[] = $path;
                 }
             } else {
-                v('Invalid path: %s', $val, E_USER_WARNING);
+                trigger_error(vsprintf('Invalid path: %s', [$val]), E_USER_WARNING);
             }
         }
         return ['package_dirs' => $packages];

--- a/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
@@ -74,11 +74,11 @@ class Package_Generic_ChunkedXHTML extends Package_Generic_XHTML {
             $this->postConstruct();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    v("Output directory is a file?", E_USER_ERROR);
+                    trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    v("Can't create output directory", E_USER_ERROR);
+                    trigger_error("Can't create output directory", E_USER_ERROR);
                 }
             }
             if ($this->config->css()) {

--- a/phpdotnet/phd/Package/Generic/Manpage.php
+++ b/phpdotnet/phd/Package/Generic/Manpage.php
@@ -312,11 +312,11 @@ class Package_Generic_Manpage extends Format_Abstract_Manpage {
             $this->setOutputDir($this->config->output_dir() . strtolower($this->toValidName($this->getFormatName())) . '/');
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    v("Output directory is a file?", E_USER_ERROR);
+                    trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    v("Can't create output directory", E_USER_ERROR);
+                    trigger_error("Can't create output directory", E_USER_ERROR);
                 }
             }
             break;

--- a/phpdotnet/phd/Package/Generic/TocFeed.php
+++ b/phpdotnet/phd/Package/Generic/TocFeed.php
@@ -222,11 +222,11 @@ abstract class Package_Generic_TocFeed extends Format
             $dir = $this->getOutputDir();
             if (file_exists($dir)) {
                 if (!is_dir($dir)) {
-                    v('Output directory is a file?', E_USER_ERROR);
+                    trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
             } else {
                 if (!mkdir($dir, 0777, true)) {
-                    v('Cannot create output directory', E_USER_ERROR);
+                    trigger_error("Can't create output directory", E_USER_ERROR);
                 }
             }
             break;

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -635,7 +635,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 if ($style = file_get_contents($css)) {
                     $this->stylesheets[] = $style;
                 } else {
-                    v("Stylesheet %s not fetched.", $css, E_USER_WARNING);
+                    trigger_error(vsprintf("Stylesheet %s not fetched.", [$css]), E_USER_WARNING);
                 }
             }
             return;
@@ -647,11 +647,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $stylesDir .= 'styles/';
         if (file_exists($stylesDir)) {
             if (!is_dir($stylesDir)) {
-                v("The styles/ directory is a file?", E_USER_ERROR);
+                trigger_error("The styles/ directory is a file?", E_USER_ERROR);
             }
         } else {
             if (!mkdir($stylesDir, 0777, true)) {
-                v("Can't create the styles/ directory.", E_USER_ERROR);
+                trigger_error("Can't create the styles/ directory.", E_USER_ERROR);
             }
         }
         foreach ((array)$this->config->css() as $css) {
@@ -660,7 +660,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if (@copy($css, $stylesDir . $dest)) {
                 $this->stylesheets[] = $dest;
             } else {
-                v('Impossible to copy the %s file.', $css, E_USER_WARNING);
+                trigger_error(vsprintf('Impossible to copy the %s file.', [$css]), E_USER_WARNING);
             }
         }
     }
@@ -2300,7 +2300,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
         if (isset($attrs[Reader::XMLNS_DOCBOOK]["action"])) {
             if ($attrs[Reader::XMLNS_DOCBOOK]["action"] !== "simul") {
-                v('No support for keycombo action = %s', $attrs[Reader::XMLNS_DOCBOOK]["action"], E_USER_WARNING);
+                trigger_error(vsprintf('No support for keycombo action = %s', [$attrs[Reader::XMLNS_DOCBOOK]["action"]]), E_USER_WARNING);
             }
         }
         if ($open) {

--- a/phpdotnet/phd/Package/IDE/Base.php
+++ b/phpdotnet/phd/Package/IDE/Base.php
@@ -215,11 +215,11 @@ abstract class Package_IDE_Base extends Format {
         $this->setOutputDir($this->config->output_dir() . strtolower($this->getFormatName()) . '/');
         if (file_exists($this->getOutputDir())) {
             if (!is_dir($this->getOutputDir())) {
-                v('Output directory is a file?', E_USER_ERROR);
+                trigger_error("Output directory is a file?", E_USER_ERROR);
             }
         } else {
             if (!mkdir($this->getOutputDir(), 0777, true)) {
-                v("Can't create output directory", E_USER_ERROR);
+                trigger_error("Can't create output directory", E_USER_ERROR);
             }
         }
     }

--- a/phpdotnet/phd/Package/PEAR/CHM.php
+++ b/phpdotnet/phd/Package/PEAR/CHM.php
@@ -403,7 +403,7 @@ $1</head>',
 		$stylesheet = file_get_contents("http://pear.php.net/css/$name.css");
 		if ($stylesheet) return $stylesheet;
 		else {
-			v("Stylesheet %s not fetched. Uses default rendering style.", $name, E_USER_WARNING);
+			trigger_error(vsprintf("Stylesheet %s not fetched. Uses default rendering style.", [$name]), E_USER_WARNING);
 			return "";
 		}
     }

--- a/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
@@ -72,11 +72,11 @@ class Package_PEAR_ChunkedXHTML extends Package_PEAR_XHTML {
             $this->postConstruct();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    v("Output directory is a file?", E_USER_ERROR);
+                    trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    v("Can't create output directory", E_USER_ERROR);
+                    trigger_error("Can't create output directory", E_USER_ERROR);
                 }
             }
             if ($this->config->css()) {

--- a/phpdotnet/phd/Package/PHP/BigPDF.php
+++ b/phpdotnet/phd/Package/PHP/BigPDF.php
@@ -37,7 +37,7 @@ class Package_PHP_BigPDF extends Package_PHP_PDF {
             try {
                 $pdfDoc->setCompressionMode(\HaruDoc::COMP_ALL);
             } catch (\HaruException $e) {
-                v("PDF Compression failed, you need to compile libharu with Zlib...", E_USER_WARNING);
+                trigger_error("PDF Compression failed, you need to compile libharu with Zlib...", E_USER_WARNING);
             }
             parent::setPdfDoc($pdfDoc);
 

--- a/phpdotnet/phd/Package/PHP/EnhancedCHM.php
+++ b/phpdotnet/phd/Package/PHP/EnhancedCHM.php
@@ -22,7 +22,7 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
             // Use %TEMP%/usernotes as base directory for Usernotes.
             $temp = sys_get_temp_dir();
             if (!$temp || !is_dir($temp)) {
-                v('Unable to locate the systems temporary system directory for EnhancedCHM.', E_USER_ERROR);
+                trigger_error('Unable to locate the systems temporary system directory for EnhancedCHM.', E_USER_ERROR);
                 break;
             }
 
@@ -30,7 +30,7 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
 
             // Make the usernotes directory.
             if(!file_exists($this->userNotesBaseDir) || is_file($this->userNotesBaseDir)) {
-                mkdir($this->userNotesBaseDir, 0777, true) or v("Can't create the usernotes directory : %s", $this->userNotesBaseDir, E_USER_ERROR);
+                mkdir($this->userNotesBaseDir, 0777, true) or trigger_error(vsprintf("Can't create the usernotes directory : %s", [$this->userNotesBaseDir]), E_USER_ERROR);
             }
 
             // Get the local last-updated value.
@@ -50,7 +50,7 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
                 }
 
                 if (!extension_loaded('bz2')) {
-                    v('The BZip2 extension is not available.', E_USER_ERROR);
+                    trigger_error('The BZip2 extension is not available.', E_USER_ERROR);
                     break;
                 }
 
@@ -61,7 +61,7 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
 
                 // Use a decompression stream filter to save having to store anything locally other than the expanded user notes.
                 if (false === ($fpNotes = fopen('http://www.php.net/backend/notes/all.bz2', 'rb'))) {
-                    v('Failed to access the usernotes archive.', E_USER_ERROR);
+                    trigger_error('Failed to access the usernotes archive.', E_USER_ERROR);
                     break;
                 }
 

--- a/phpdotnet/phd/Package/PHP/HowTo.php
+++ b/phpdotnet/phd/Package/PHP/HowTo.php
@@ -25,11 +25,11 @@ class Package_PHP_HowTo extends Package_PHP_Web {
             $this->postConstruct();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    v("Output directory is a file?", E_USER_ERROR);
+                    trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    v("Can't create output directory", E_USER_ERROR);
+                    trigger_error("Can't create output directory", E_USER_ERROR);
                 }
             }
             break;

--- a/phpdotnet/phd/Package/PHP/PDF.php
+++ b/phpdotnet/phd/Package/PHP/PDF.php
@@ -149,7 +149,7 @@ class Package_PHP_PDF extends Package_Generic_PDF {
             try {
                 $pdfDoc->setCompressionMode(\HaruDoc::COMP_ALL);
             } catch (\HaruException $e) {
-                v("PDF Compression failed, you need to compile libharu with Zlib...", E_USER_WARNING);
+                trigger_error("PDF Compression failed, you need to compile libharu with Zlib...", E_USER_WARNING);
             }
             parent::setPdfDoc($pdfDoc);
             if (isset($attrs[Reader::XMLNS_XML]["base"]) && $base = $attrs[Reader::XMLNS_XML]["base"])

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -84,11 +84,11 @@ class Package_PHP_Web extends Package_PHP_XHTML {
             $this->loadHistoryInfo();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    v("Output directory is a file?", E_USER_ERROR);
+                    trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    v("Can't create output directory", E_USER_ERROR);
+                    trigger_error("Can't create output directory", E_USER_ERROR);
                 }
             }
             if ($this->getFormatName() == "PHP-Web") {
@@ -275,13 +275,14 @@ contributors($setup);
             return $info;
         }
         if (!is_file($filename)) {
-            v("Can't find sources file (%s), skipping!", $filename, E_USER_NOTICE);
+            trigger_error(vsprintf("Can't find sources file (%s), skipping!", [$filename]), E_USER_NOTICE);
             return array();
         }
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            v("Can't open the sources file (%s)", $filename, E_USER_ERROR);
+            trigger_error(vsprintf("Can't open the sources file (%s)", [$filename]), E_USER_ERROR);
+            return array();
         }
         $info = array();
         $r->read();
@@ -304,7 +305,7 @@ contributors($setup);
 
     public function sourceInfo($id) {
         if (!isset($this->sources[$id])) {
-            v("Missing source for: %s", $id, E_USER_WARNING);
+            trigger_error(vsprintf("Missing source for: %s", [$id]), E_USER_WARNING);
         }
         return isset($this->sources[$id]) ? $this->sources[$id] : null;
     }

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -247,13 +247,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             return $info;
         }
         if (!is_file($filename)) {
-            v("Can't find Version information file (%s), skipping!", $filename, E_USER_WARNING);
+            trigger_error(vsprintf("Can't find Version information file (%s), skipping!", [$filename]), E_USER_WARNING);
             return array();
         }
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            v("Can't open the version info file (%s)", $filename, E_USER_ERROR);
+            trigger_error(vsprintf("Can't open the version info file (%s)", [$filename]), E_USER_ERROR);
         }
         $versions = array();
         while($r->read()) {
@@ -284,13 +284,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             return $info;
         }
         if (!is_file($filename)) {
-            v("Can't find Version information file (%s), skipping!", $filename, E_USER_WARNING);
+            trigger_error(vsprintf("Can't find Version information file (%s), skipping!", [$filename]), E_USER_WARNING);
             return array();
         }
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            v("Can't open the version info file (%s)", $filename, E_USER_ERROR);
+            trigger_error(vsprintf("Can't open the version info file (%s)", [$filename]), E_USER_ERROR);
         }
         $deprecated = array();
         while($r->read()) {
@@ -318,13 +318,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             return $info;
         }
         if (!is_file($filename)) {
-            v("Can't find acronym file (%s), skipping", $filename, E_USER_WARNING);
+            trigger_error(vsprintf("Can't find acronym file (%s), skipping", [$filename]), E_USER_WARNING);
             return array();
         }
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            v("Could not open file for accessing acronym information (%s)", $filename, E_USER_ERROR);
+            trigger_error(vsprintf("Could not open file for accessing acronym information (%s)", [$filename]), E_USER_ERROR);
         }
 
         $acronyms = array();
@@ -989,7 +989,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             }
             else {
                 $id = uniqid();
-                v("Uhm. Can't find an ID for a chunk? - Generating a random one (%s)\n%s", $id, $this->getDebugTree($name, $props), E_USER_WARNING);
+                trigger_error(vsprintf("Uhm. Can't find an ID for a chunk? - Generating a random one (%s)\n%s", [$id, $this->getDebugTree($name, $props)]), E_USER_WARNING);
             }
 
             $this->CURRENT_CHUNK = $this->CURRENT_ID = $id;

--- a/render.php
+++ b/render.php
@@ -46,11 +46,11 @@ if (!is_dir($config->xml_root()) || !is_file($config->xml_file())) {
 if (!file_exists($config->output_dir())) {
     v("Creating output directory..", VERBOSE_MESSAGES);
     if (!mkdir($config->output_dir(), 0777, True)) {
-        v("Can't create output directory : %s", $config->output_dir(), E_USER_ERROR);
+        trigger_error(vsprintf("Can't create output directory : %s", [$config->output_dir()]), E_USER_ERROR);
     }
     v("Output directory created", VERBOSE_MESSAGES);
 } elseif (!is_dir($config->output_dir())) {
-    v("Output directory is not a file?", E_USER_ERROR);
+    trigger_error("Output directory is not a file?", E_USER_ERROR);
 }
 
 // This needs to be moved. Preferably into the PHP package.


### PR DESCRIPTION
Use `trigger_error()` for triggering the error handler for errors instead of the custom function `v()`. `vsprintf()` is used with some errors as this function is used in function `v()` where formatted strings are being passed to the error handler.

I think this change makes sense semantically and will help with separating the intertwined error handling/info message printing of `PhD`.