### PR TITLE
Add links to constants with replaceable tags

### DIFF
--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -77,7 +77,7 @@ class Render extends ObjectStorage
                         $r->name === "type" ||
                         $r->name === "classsynopsis" ||
                         $r->name === "qandaset" ||
-                        in_array($r->name, ["methodsynopsis", "constructorsynopsis", "destructorsynopsis"], true)
+                        in_array($r->name, ["methodsynopsis", "constructorsynopsis", "destructorsynopsis", "constant"], true)
                     )
                 ) {
                     $innerXml = $r->readInnerXml();

--- a/tests/package/php/constant_links_001.phpt
+++ b/tests/package/php/constant_links_001.phpt
@@ -27,6 +27,10 @@ $indices = [
         "docbook_id" => "extension-class.constants.leading-and-trailing-undescores2",
         "filename"   => "extensionname4.constantspage4",
     ],
+    [
+        "docbook_id" => "constant.extension-namespace-definitely-exists3",
+        "filename"   => "extensionname.constantspage",
+    ],
 ];
 
 $format = new TestPHPChunkedXHTML($config);
@@ -77,6 +81,13 @@ Content:
   <strong><code><a href="extensionname3.constantspage3.html#constant.leading-and-trailing-undescores">__LEADING_AND_TRAILING_UNDESCORES__</a></code></strong>
   <p class="para">
    <strong><code><a href="extensionname4.constantspage4.html#extension-class.constants.leading-and-trailing-undescores2">Extension\Class::__LEADING_AND_TRAILING_UNDESCORES2__</a></code></strong>
+  </p>
+ </div>
+ 
+ <div class="section">
+  <p class="para">4. Constant with replacable parts links to first ID in the index</p>
+  <p class="para">
+   <strong><code><a href="extensionname.constantspage.html#constant.extension-namespace-definitely-exists">Extension\Namespace\DEFINITELY_<span class="replaceable">SHOULD_EXIST</span></a></code></strong>
   </p>
  </div>
 

--- a/tests/package/php/data/constant_links.xml
+++ b/tests/package/php/data/constant_links.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<chapter xml:id="constant_links">
+<chapter xml:id="constant_links" xmlns="http://docbook.org/ns/docbook">
 
  <section>
   <para>1. Existing constants</para>
@@ -22,6 +22,13 @@
   <constant>__LEADING_AND_TRAILING_UNDESCORES__</constant>
   <para>
    <constant>Extension\Class::__LEADING_AND_TRAILING_UNDESCORES2__</constant>
+  </para>
+ </section>
+ 
+ <section>
+  <para>4. Constant with replacable parts links to first ID in the index</para>
+  <para>
+   <constant>Extension\Namespace\DEFINITELY_<replaceable>SHOULD_EXIST</replaceable></constant>
   </para>
  </section>
 


### PR DESCRIPTION
Add links to constants with replaceable tags by processing them when the constant tag is being closed. Also add a test.

This currently only works with one set of `<replaceable>` tags per constant (due to issues making the regex non-greedy). In practice, this shouldn't be an issue as we have no constants with more than one set of these tags.

The implementation feels a little hacky but more or less matches the processing of all other tags where post-processing is needed (all the class-based `synposis*` tags and their children).