### PR TITLE
Add property linking

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -462,6 +462,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             /* DEFAULT */          false,
             'footnote'             => 'format_footnote_para_text',
         ),
+        'property'              => [
+           /* DEFAULT */           'format_property_text',
+        ],
         /* FIXME: This is one crazy stupid workaround for footnotes */
         'constant'              => array(
             /* DEFAULT */          'format_constant_text',
@@ -1843,6 +1846,30 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return false;
     }
+    
+    public function format_property_text($value, $tag) {
+        if (! str_contains($value, '::')) {
+            return $value;
+        }
+        
+        $tempLinkValue = str_replace(
+            array("\\", "_", "$"),
+            array("-", "-", ""),
+            strtolower(trim($value, "_"))
+        );
+        
+        list($extensionAndClass, $property) = explode("::", $tempLinkValue);
+        $normalizedLinkFormat = $extensionAndClass . ".props." . trim($property, "-");
+        
+        $link = $this->createLink($normalizedLinkFormat);
+        
+        if ($link === null || $link === "") {
+            return $value;
+        }
+        
+        return '<a href="' . $link . '">' . $value . '</a>';
+    }
+    
     public function admonition_title($title, $lang)
     {
         return '<strong class="' .(strtolower($title)). '">' .($this->autogen($title, $lang)). '</strong>';

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1853,8 +1853,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         
         $tempLinkValue = str_replace(
-            array("\\", "_", "$"),
-            array("-", "-", ""),
+            ["\\", "_", "$"],
+            ["-", "-", ""],
             strtolower(trim($value, "_"))
         );
         

--- a/tests/package/php/data/property_linking.xml
+++ b/tests/package/php/data/property_linking.xml
@@ -6,6 +6,9 @@
   <para>
    <property>Vendor\Namespace::$definitely_exists</property>
   </para>
+  <para>
+   <property>Vendor\Namespace::$definitelyExists2</property>
+  </para>
  </section>
 
  <section>
@@ -13,12 +16,18 @@
   <para>
    <property>Vendor\Namespace::$this_does_not_exist</property>
   </para>
+  <para>
+   <property>Vendor\Namespace::$thisDoesNotExist2</property>
+  </para>
  </section>
 
  <section>
   <para>3. Properties with leading and trailing underscores in ID</para>
   <para>
    <property>Extension\Class::$__leading_and_trailing_undescores__</property>
+  </para>
+  <para>
+   <property>Extension\Class::$__leadingAndTrailingUndescores2__</property>
   </para>
  </section>
 

--- a/tests/package/php/data/property_linking.xml
+++ b/tests/package/php/data/property_linking.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="property_linking" xmlns="http://docbook.org/ns/docbook">
+
+ <section>
+  <para>1. Existing property</para>
+  <para>
+   <property>Vendor\Namespace::$definitely_exists</property>
+  </para>
+ </section>
+
+ <section>
+  <para>2. Nonexistent properties</para>
+  <para>
+   <property>Vendor\Namespace::$this_does_not_exist</property>
+  </para>
+ </section>
+
+ <section>
+  <para>3. Properties with leading and trailing underscores in ID</para>
+  <para>
+   <property>Extension\Class::$__leading_and_trailing_undescores__</property>
+  </para>
+ </section>
+
+</chapter>

--- a/tests/package/php/property_linking.phpt
+++ b/tests/package/php/property_linking.phpt
@@ -1,0 +1,72 @@
+--TEST--
+Property linking 001
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xml_file = __DIR__ . "/data/property_linking.xml";
+
+$config->setXml_file($xml_file);
+
+$indices = [
+    [
+        "docbook_id" => "vendor-namespace.props.definitely-exists",
+        "filename"   => "extensionname.page",
+    ],
+    [
+        "docbook_id" => "extension-class.props.leading-and-trailing-undescores",
+        "filename"   => "extensionname2.page2",
+    ],
+];
+
+$format = new TestPHPChunkedXHTML($config, $outputHandler);
+
+foreach ($indices as $index) {
+    $format->SQLiteIndex(
+        null, // $context,
+        null, // $index,
+        $index["docbook_id"] ?? "", // $id,
+        $index["filename"] ?? "", // $filename,
+        $index["parent_id"] ?? "", // $parent,
+        $index["sdesc"] ?? "", // $sdesc,
+        $index["ldesc"] ?? "", // $ldesc,
+        $index["element"] ?? "", // $element,
+        $index["previous"] ?? "", // $previous,
+        $index["next"] ?? "", // $next,
+        $index["chunk"] ?? 0, // $chunk
+    );
+}
+
+$render = new TestRender(new Reader($outputHandler), $config, $format);
+
+$render->run();
+?>
+--EXPECTF--
+Filename: property_linking.html
+Content:
+<div id="property_linking" class="chapter">
+
+ <div class="section">
+  <p class="para">%d. Existing property</p>
+  <p class="para">
+   <span class="property"><a href="extensionname.page.html#vendor-namespace.props.definitely-exists">Vendor\Namespace::$definitely_exists</a></span>
+  </p>
+ </div>
+
+ <div class="section">
+  <p class="para">%d. Nonexistent properties</p>
+  <p class="para">
+   <span class="property">Vendor\Namespace::$this_does_not_exist</span>
+  </p>
+ </div>
+
+ <div class="section">
+  <p class="para">%d. Properties with leading and trailing underscores in ID</p>
+  <p class="para">
+   <span class="property"><a href="extensionname2.page2.html#extension-class.props.leading-and-trailing-undescores">Extension\Class::$__leading_and_trailing_undescores__</a></span>
+  </p>
+ </div>
+
+</div>

--- a/tests/package/php/property_linking.phpt
+++ b/tests/package/php/property_linking.phpt
@@ -16,7 +16,15 @@ $indices = [
         "filename"   => "extensionname.page",
     ],
     [
+        "docbook_id" => "vendor-namespace.props.definitelyexists2",
+        "filename"   => "extensionname.page",
+    ],
+    [
         "docbook_id" => "extension-class.props.leading-and-trailing-undescores",
+        "filename"   => "extensionname2.page2",
+    ],
+    [
+        "docbook_id" => "extension-class.props.leadingandtrailingundescores2",
         "filename"   => "extensionname2.page2",
     ],
 ];
@@ -53,6 +61,9 @@ Content:
   <p class="para">
    <span class="property"><a href="extensionname.page.html#vendor-namespace.props.definitely-exists">Vendor\Namespace::$definitely_exists</a></span>
   </p>
+  <p class="para">
+   <span class="property"><a href="extensionname.page.html#vendor-namespace.props.definitelyexists2">Vendor\Namespace::$definitelyExists2</a></span>
+  </p>
  </div>
 
  <div class="section">
@@ -60,12 +71,18 @@ Content:
   <p class="para">
    <span class="property">Vendor\Namespace::$this_does_not_exist</span>
   </p>
+  <p class="para">
+   <span class="property">Vendor\Namespace::$thisDoesNotExist2</span>
+  </p>
  </div>
 
  <div class="section">
   <p class="para">%d. Properties with leading and trailing underscores in ID</p>
   <p class="para">
    <span class="property"><a href="extensionname2.page2.html#extension-class.props.leading-and-trailing-undescores">Extension\Class::$__leading_and_trailing_undescores__</a></span>
+  </p>
+  <p class="para">
+   <span class="property"><a href="extensionname2.page2.html#extension-class.props.leadingandtrailingundescores2">Extension\Class::$__leadingAndTrailingUndescores2__</a></span>
   </p>
  </div>
 


### PR DESCRIPTION
Add linking to `<property>` elements. 

This works the same way `<constant>` tag linking works and is based on the understanding that `<property>` elements are only to be used for class properties. As with constant linking, property linking  requires the `<property>` elements to include a FQN (eg. `<property>DOMNameSpaceNode::$parentElement</property>` instead of just `<property>$parentElement</property>`) and an element with the appropriate xml ID (eg. `<varlistentry xml:id="domnamespacenode.props.parentelement">`).

Reference issue: https://github.com/php/phd/issues/164