### PR TITLE
Add support enum links

### DIFF
--- a/phpdotnet/phd/Index.php
+++ b/phpdotnet/phd/Index.php
@@ -454,7 +454,7 @@ class Index extends Format
     public function format_reference($open, $name, $attrs, $props) {
         if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
             $name = match ($attrs[Reader::XMLNS_DOCBOOK]['role']) {
-                "class" => "phpdoc:classref",
+                "class", "enum" => "phpdoc:classref",
                 "exception" => "phpdoc:exceptionref",
                 default => $name,
             };

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -118,6 +118,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
                 'classsynopsis' => 'format_classsynopsis_oo_name_text',
             ]
         ],
+        'enumname' => [
+            /* DEFAULT */ 'format_classname_text',
+            'oointerface' => [
+                /* DEFAULT */     'format_classname_text',
+                'classsynopsis' => 'format_classsynopsis_oo_name_text',
+            ]
+        ],
         'methodname'            => array(
             /* DEFAULT */          'format_function_text',
             'constructorsynopsis' => array(

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -715,6 +715,10 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         default:
             /* Check if its a classname. */
             $href = Format::getFilename("class.$t");
+            if (!$href) {
+                /* Check if its a enumname. */
+                $href = Format::getFilename("enum.$t");
+            }
         }
 
         if ($href === false) {

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -120,7 +120,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         ],
         'enumname' => [
             /* DEFAULT */ 'format_classname_text',
-            'oointerface' => [
+            'ooenum' => [
                 /* DEFAULT */     'format_classname_text',
                 'classsynopsis' => 'format_classsynopsis_oo_name_text',
             ]

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -716,7 +716,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             /* Check if its a classname. */
             $href = Format::getFilename("class.$t");
             if (!$href) {
-                /* Check if its a enumname. */
+                /* Check if its an enumname. */
                 $href = Format::getFilename("enum.$t");
             }
         }

--- a/tests/package/php/data/enum_link_rendering.xml
+++ b/tests/package/php/data/enum_link_rendering.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="enum_link_rendering" xmlns="http://docbook.org/ns/docbook">
+
+ <section>
+  <para>1. Existing Enum linking</para>
+  <enumname>Enum\Namespace\Existing_Enum</enumname>
+  <enumname>\Enum\Namespace\Existing_Enum</enumname>
+ </section>
+
+ <section>
+  <para>2. Enum linking (non-FQN) in method/function parameter and return type</para>
+  <methodsynopsis>
+   <type>Enum\Namespace\Existing_Enum</type><methodname>method_name</methodname>
+   <methodparam><type>Enum\Namespace\Existing_Enum</type><parameter>paramName</parameter></methodparam>
+  </methodsynopsis>
+ </section>
+ 
+ <section>
+  <para>3. Enum linking (FQN) in method/function parameter and return type</para>
+  <methodsynopsis>
+   <type>\Enum\Namespace\Existing_Enum</type><methodname>method_name</methodname>
+   <methodparam><type>\Enum\Namespace\Existing_Enum</type><parameter>paramName</parameter></methodparam>
+  </methodsynopsis>
+ </section>
+
+</chapter>

--- a/tests/package/php/enum_link_rendering.phpt
+++ b/tests/package/php/enum_link_rendering.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Enum link rendering
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$config->xmlFile = __DIR__ . "/data/enum_link_rendering.xml";
+
+$format = new TestPHPChunkedXHTML($config, $outputHandler);
+$format->SQLiteIndex(
+    null, // $context,
+    null, // $index,
+    "enum.enum-namespace-existing-enum", // $id,
+    "enumname.enumpage", // $filename,
+    "", // $parent,
+    "", // $sdesc,
+    "", // $ldesc,
+    "phpdoc:classref", // $element,
+    "", // $previous,
+    "", // $next,
+    0, // $chunk
+);
+
+$format->addClassname("enum.enum-namespace-existing-enum", "enum\\namespace\\existing_enum");
+
+$render = new TestRender(new Reader($outputHandler), $config, $format);
+$render->run();
+?>
+--EXPECT--
+Filename: enum_link_rendering.html
+Content:
+<div id="enum_link_rendering" class="chapter">
+
+ <div class="section">
+  <p class="para">1. Existing Enum linking</p>
+  <span class="enumname"><a href="enum.enum-namespace-existing-enum.html" class="enumname">Enum\Namespace\Existing_Enum</a></span>
+  <span class="enumname"><a href="enum.enum-namespace-existing-enum.html" class="enumname">\Enum\Namespace\Existing_Enum</a></span>
+ </div>
+
+ <div class="section">
+  <p class="para">2. Enum linking (non-FQN) in method/function parameter and return type</p>
+  <div class="methodsynopsis dc-description"><span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">Enum\Namespace\Existing_Enum</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">Enum\Namespace\Existing_Enum</a></span></div>
+
+ </div>
+ 
+ <div class="section">
+  <p class="para">3. Enum linking (FQN) in method/function parameter and return type</p>
+  <div class="methodsynopsis dc-description"><span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">\Enum\Namespace\Existing_Enum</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">\Enum\Namespace\Existing_Enum</a></span></div>
+
+ </div>
+
+</div>


### PR DESCRIPTION
In my local:

<img width="1169" alt="スクリーンショット 2025-01-31 17 27 57" src="https://github.com/user-attachments/assets/cfc70a22-7f2b-4707-a645-1515c1349bfa" />

Actually, it would be nice to be able to link `RoundingMode::HalfAwayFromZero` as well, but that might be a good idea to wait for a follow-up.