### PR TITLE
Avoid double escaping in web search (fix #198)

### DIFF
--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -274,7 +274,8 @@ contributors($setup);
             $entries[] = [
                 $index["sdesc"], $index["filename"], $index["element"]
             ];
-            $descriptions[$id] = $index["ldesc"];
+            $descriptions[$id] = html_entity_decode(
+                $index["ldesc"], ENT_COMPAT, "UTF-8");
         }
         return [$entries, $descriptions];
     }


### PR DESCRIPTION
This is escaped at https://github.com/php/web-php/blob/5d926b3/js/search.js#L421.