### PR TITLE
Apply PSR-12 coding standard fixes (elseif, new(), visibility, modifier order, short type keywords)

### DIFF
--- a/package-pman.php
+++ b/package-pman.php
@@ -5,7 +5,7 @@ require_once "PEAR/PackageFileManager2.php";
 
 PEAR::setErrorHandling(PEAR_ERROR_DIE);
 
-$packagexml = new PEAR_PackageFileManager2;
+$packagexml = new PEAR_PackageFileManager2();
 $packagexml->setOptions(array(
   "outputdirectory"      => ".",
   "filelistgenerator"    => "file",

--- a/phpdotnet/phd/Config.php
+++ b/phpdotnet/phd/Config.php
@@ -149,7 +149,7 @@ class Config
      *    the manual docbook file are compared. If the index is older than
      *    the docbook file, indexing will be done.
      *
-     * @return boolean True if indexing is required.
+     * @return bool True if indexing is required.
      */
     public function requiresIndexing(): bool {
         if (! $this->indexCache) {

--- a/phpdotnet/phd/Format.php
+++ b/phpdotnet/phd/Format.php
@@ -7,19 +7,19 @@ abstract class Format extends ObjectStorage
      * Represents a short description.
      * Used in createLink()
      *
-     * @var    integer
+     * @var    int
      * @usedby createLink()
      */
-    const SDESC = 1;
+    public const SDESC = 1;
 
     /**
      * Represents a long description.
      * Used in createLink()
      *
-     * @var    integer
+     * @var    int
      * @usedby createLink()
      */
-    const LDESC = 2;
+    public const LDESC = 2;
 
     protected Config $config;
     protected OutputHandler $outputHandler;
@@ -86,7 +86,7 @@ abstract class Format extends ObjectStorage
      *
      * @param string  $for   Chunk ID
      * @param string  &$desc Description of link, to be filled if neccessary
-     * @param integer $type  Format of description, Format::SDESC or
+     * @param int $type  Format of description, Format::SDESC or
      *                       Format::LDESC
      *
      * @return string|null|void Relative or absolute URI to access $for
@@ -121,7 +121,7 @@ abstract class Format extends ObjectStorage
      *     Called when a new chunk is opened or closed.
      *     Value is either Render::OPEN or Render::CLOSE
      *
-     * @param integer $event Event flag (see Render class)
+     * @param int $event Event flag (see Render class)
      * @param mixed   $value Additional value flag. Depends
      *                       on $event type
      *
@@ -129,13 +129,13 @@ abstract class Format extends ObjectStorage
      */
     abstract public function update($event, $value = null);
 
-    public final function parsePI($target, $data) {
+    final public function parsePI($target, $data) {
         if (isset($this->pihandlers[$target])) {
             return $this->pihandlers[$target]->parse($target, $data);
         }
     }
 
-    public final function registerPIHandlers($pihandlers) {
+    final public function registerPIHandlers($pihandlers) {
         foreach ($pihandlers as $target => $classname) {
             $class = __NAMESPACE__ . "\\" . $classname;
             $this->pihandlers[$target] = new $class($this);
@@ -172,7 +172,7 @@ abstract class Format extends ObjectStorage
     /**
      * Calls update().
      *
-     * @param integer $event Event flag. See Render class for constants
+     * @param int $event Event flag. See Render class for constants
      *                       like Render::INIT and Render::CHUNK
      * @param mixed   $val   Value; depends on $event flag
      *
@@ -421,7 +421,7 @@ abstract class Format extends ObjectStorage
      *
      * @param string $id XML ID to get chunk status for
      *
-     * @return boolean True if it is to be chunked
+     * @return bool True if it is to be chunked
      */
     final public function isChunkID($id)
     {

--- a/phpdotnet/phd/Format/Factory.php
+++ b/phpdotnet/phd/Format/Factory.php
@@ -7,39 +7,39 @@ abstract class Format_Factory {
     private $optionsHandler = null;
     private $pversion = "unknown";
 
-    public final function getPackageVersion() {
+    final public function getPackageVersion() {
         return $this->pversion;
     }
-    public final function setPackageVersion($version) {
+    final public function setPackageVersion($version) {
         $this->pversion = $version;
     }
-    public final function getOutputFormats() {
+    final public function getOutputFormats() {
         return array_keys($this->formats);
     }
 
-    public final function registerOutputFormats($formats) {
+    final public function registerOutputFormats($formats) {
         $this->formats = $formats;
     }
 
-    public final function getOptionsHandler() {
+    final public function getOptionsHandler() {
         return $this->optionsHandler;
     }
 
-    public final function registerOptionsHandler(Options_Interface $optionsHandler) {
+    final public function registerOptionsHandler(Options_Interface $optionsHandler) {
         $this->optionsHandler = $optionsHandler;
     }
 
-    protected final function setPackageName($name) {
+    final protected function setPackageName($name) {
         if (!is_string($name)) {
             throw new \Exception("Package names must be strings..");
         }
         $this->packageName = $name;
     }
-    public final function getPackageName() {
+    final public function getPackageName() {
         return $this->packageName;
     }
 
-    public final function createFormat($format, ...$formatParams) {
+    final public function createFormat($format, ...$formatParams) {
         if (isset($this->formats[$format]) && $this->formats[$format]) {
             $classname = __NAMESPACE__ . "\\" . $this->formats[$format];
 
@@ -52,7 +52,7 @@ abstract class Format_Factory {
         trigger_error("This format is not supported by this package", E_USER_ERROR);
     }
 
-    public static final function createFactory($package) {
+    final public static function createFactory($package) {
         static $factories = array();
 
         if (!is_string($package)) {
@@ -71,7 +71,7 @@ abstract class Format_Factory {
         return $factories[$package];
     }
 
-    public final function __toString() {
+    final public function __toString() {
         return $this->getPackageName();
     }
 }

--- a/phpdotnet/phd/Highlighter.php
+++ b/phpdotnet/phd/Highlighter.php
@@ -57,7 +57,7 @@ class Highlighter
             return "\n.PP\n.nf\n"
                 . str_replace("\\", "\\\\", trim($text))
                 . "\n.fi";
-        } else if ($format != 'xhtml') {
+        } elseif ($format != 'xhtml') {
             return $text;
         }
 

--- a/phpdotnet/phd/Highlighter/GeSHi11x.php
+++ b/phpdotnet/phd/Highlighter/GeSHi11x.php
@@ -62,7 +62,7 @@ class Highlighter_GeSHi11x extends Highlighter
         require_once GESHI_CLASSES_ROOT
             . 'renderers/class.' . strtolower($rendererclass) . '.php';
         $rendererclass = '\\' . $rendererclass;
-        $renderer = new $rendererclass;
+        $renderer = new $rendererclass();
 
 
         return new self($renderer);

--- a/phpdotnet/phd/MediaManager.php
+++ b/phpdotnet/phd/MediaManager.php
@@ -36,7 +36,7 @@ class MediaManager
     /**
     * If the image media directory exists
     *
-    * @var boolean
+    * @var bool
     */
     protected $media_dir_exists = false;
 
@@ -109,7 +109,7 @@ class MediaManager
     * based upon a specific language, then fallback to the English translation.
     *
     * @param string  $filename      Original filename
-    * @param boolean $allowfallback If the required file cannot be found then fallback to English
+    * @param bool $allowfallback If the required file cannot be found then fallback to English
     *
     * @return string Exact location of the file referenced with $filename or False if file not found.
     */

--- a/phpdotnet/phd/PIHandler.php
+++ b/phpdotnet/phd/PIHandler.php
@@ -11,7 +11,7 @@ abstract class PIHandler {
         $this->format = $format;
     }
 
-    public abstract function parse($target, $data);
+    abstract public function parse($target, $data);
 
 }
 

--- a/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
@@ -79,10 +79,8 @@ class Package_Generic_ChunkedXHTML extends Package_Generic_XHTML {
                 if (!is_dir($this->getOutputDir())) {
                     trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
-            } else {
-                if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
-                }
+            } elseif (!mkdir($this->getOutputDir(), 0777, true)) {
+                trigger_error("Can't create output directory", E_USER_ERROR);
             }
             if ($this->config->css) {
                 $this->fetchStylesheet();

--- a/phpdotnet/phd/Package/Generic/Manpage.php
+++ b/phpdotnet/phd/Package/Generic/Manpage.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_Generic_Manpage extends Format_Abstract_Manpage {
-    const OPEN_CHUNK    = 0x01;
-    const CLOSE_CHUNK   = 0x02;
+    public const OPEN_CHUNK = 0x01;
+    public const CLOSE_CHUNK = 0x02;
 
      private $elementmap = array( /* {{{ */
         'acronym'               => 'format_suppressed_tags',
@@ -318,10 +318,8 @@ class Package_Generic_Manpage extends Format_Abstract_Manpage {
                 if (!is_dir($this->getOutputDir())) {
                     trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
-            } else {
-                if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
-                }
+            } elseif (!mkdir($this->getOutputDir(), 0777, true)) {
+                trigger_error("Can't create output directory", E_USER_ERROR);
             }
             break;
         case Render::VERBOSE:

--- a/phpdotnet/phd/Package/Generic/TocFeed.php
+++ b/phpdotnet/phd/Package/Generic/TocFeed.php
@@ -200,7 +200,7 @@ abstract class Package_Generic_TocFeed extends Format
      *     Called when a new chunk is opened or closed.
      *     Value is either Render::OPEN or Render::CLOSE
      *
-     * @param integer $event Event flag (see Render class)
+     * @param int $event Event flag (see Render class)
      * @param mixed   $value Additional value flag. Depends
      *                       on $event type
      *
@@ -226,10 +226,8 @@ abstract class Package_Generic_TocFeed extends Format
                 if (!is_dir($dir)) {
                     trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
-            } else {
-                if (!mkdir($dir, 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
-                }
+            } elseif (!mkdir($dir, 0777, true)) {
+                trigger_error("Can't create output directory", E_USER_ERROR);
             }
             break;
 
@@ -267,7 +265,7 @@ abstract class Package_Generic_TocFeed extends Format
      *                        header and footer
      * @param string $content XML Atom content to save
      *
-     * @return boolean True if the file has been written, false if not.
+     * @return bool True if the file has been written, false if not.
      *
      * @uses Format::getFilename()
      * @uses header()
@@ -297,7 +295,7 @@ abstract class Package_Generic_TocFeed extends Format
     /**
      * Format a chunked element
      *
-     * @param boolean $open  If the tag is opened or closed
+     * @param bool $open  If the tag is opened or closed
      * @param string  $name  Name of the tag
      * @param array   $attrs XML tag attributes
      * @param array   $props FIXME
@@ -493,7 +491,7 @@ XML;
      * @param string  $for   Chunk ID
      * @param string  &$desc Description of link, to be filled if neccessary.
      *                       Not used here.
-     * @param integer $type  Format of description, Format::SDESC or
+     * @param int $type  Format of description, Format::SDESC or
      *                       Format::LDESC.
      *                       Not used here.
      *

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1,480 +1,531 @@
 <?php
 namespace phpdotnet\phd;
 
-abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
+abstract class Package_Generic_XHTML extends Format_Abstract_XHTML
+{
     private $myelementmap = array( /* {{{ */
-        'abstract'              => 'div', /* Docbook-xsl prints "abstract"... */
-        'abbrev'                => 'abbr',
-        'acronym'               => 'acronym',
-        'affiliation'           => 'format_suppressed_tags',
-        'alt'                   => 'format_suppressed_tags',
-        'arg'                   => 'format_suppressed_tags',
-        'article'               => 'format_container_chunk_top',
-        'author'                => array(
-            /* DEFAULT */          'format_author',
-            'authorgroup'       => 'format_authorgroup_author',
+        'abstract' => 'div', /* Docbook-xsl prints "abstract"... */
+        'abbrev' => 'abbr',
+        'acronym' => 'acronym',
+        'affiliation' => 'format_suppressed_tags',
+        'alt' => 'format_suppressed_tags',
+        'arg' => 'format_suppressed_tags',
+        'article' => 'format_container_chunk_top',
+        'author' => array(
+            /* DEFAULT */
+            'format_author',
+            'authorgroup' => 'format_authorgroup_author',
         ),
-        'authorgroup'           => 'div',
-        'authorinitials'        => 'format_entry',
-        'appendix'              => 'format_container_chunk_top',
-        'application'           => 'span',
-        'blockquote'            => 'blockquote',
-        'bibliography'          => array(
-            /* DEFAULT */          'format_div',
-            'article'           => 'format_chunk',
-            'book'              => 'format_chunk',
-            'part'              => 'format_chunk',
+        'authorgroup' => 'div',
+        'authorinitials' => 'format_entry',
+        'appendix' => 'format_container_chunk_top',
+        'application' => 'span',
+        'blockquote' => 'blockquote',
+        'bibliography' => array(
+            /* DEFAULT */
+            'format_div',
+            'article' => 'format_chunk',
+            'book' => 'format_chunk',
+            'part' => 'format_chunk',
         ),
-        'book'                  => 'format_container_chunk_top',
-        'caption'               => 'format_caption',
-        'chapter'               => 'format_container_chunk_top',
-        'citetitle'             => 'em',
-        'cmdsynopsis'           => 'format_cmdsynopsis',
-        'co'                    => 'format_co',
-        'colophon'              => 'format_chunk',
-        'copyright'             => 'format_copyright',
-        'date'                  => array(
-            /* DEFAULT */          'p',
-           'revision'           => 'format_entry',
+        'book' => 'format_container_chunk_top',
+        'caption' => 'format_caption',
+        'chapter' => 'format_container_chunk_top',
+        'citetitle' => 'em',
+        'cmdsynopsis' => 'format_cmdsynopsis',
+        'co' => 'format_co',
+        'colophon' => 'format_chunk',
+        'copyright' => 'format_copyright',
+        'date' => array(
+            /* DEFAULT */
+            'p',
+            'revision' => 'format_entry',
         ),
-        'editor'                => 'format_editor',
-        'edition'               => 'format_suppressed_tags',
-        'email'                 => 'format_suppressed_tags',
-        'errortext'             => 'code',
-        'firstname'             => 'format_name',
-        'footnote'              => 'format_footnote',
-        'footnoteref'           => 'format_footnoteref',
-        'funcdef'               => 'format_suppressed_tags',
-        'funcsynopsis'          => 'div',
-        'funcsynopsisinfo'      => 'pre',
-        'function'              => 'span',
-        'funcprototype'         => 'code',
-        'surname'               => 'format_name',
-        'othername'             => 'format_name',
-        'optional'              => 'span',
-        'honorific'             => 'span',
-        'glossary'              => array(
-            /* DEFAULT */          'format_div',
-            'article'           => 'format_chunk',
-            'book'              => 'format_chunk',
-            'part'              => 'format_chunk',
+        'editor' => 'format_editor',
+        'edition' => 'format_suppressed_tags',
+        'email' => 'format_suppressed_tags',
+        'errortext' => 'code',
+        'firstname' => 'format_name',
+        'footnote' => 'format_footnote',
+        'footnoteref' => 'format_footnoteref',
+        'funcdef' => 'format_suppressed_tags',
+        'funcsynopsis' => 'div',
+        'funcsynopsisinfo' => 'pre',
+        'function' => 'span',
+        'funcprototype' => 'code',
+        'surname' => 'format_name',
+        'othername' => 'format_name',
+        'optional' => 'span',
+        'honorific' => 'span',
+        'glossary' => array(
+            /* DEFAULT */
+            'format_div',
+            'article' => 'format_chunk',
+            'book' => 'format_chunk',
+            'part' => 'format_chunk',
         ),
-        'calloutlist'           => 'format_calloutlist',
-        'callout'               => 'format_callout',
-        'caution'               => 'format_admonition',
-        'citation'              => 'format_citation',
-        'citerefentry'          => 'span',
-        'code'                  => 'code',
-        'collab'                => 'span',
-        'collabname'            => 'span',
-        'contrib'               => 'format_suppressed_tags',
-        'colspec'               => 'format_colspec',
-        'command'               => 'strong',
-        'computeroutput'        => 'span',
+        'calloutlist' => 'format_calloutlist',
+        'callout' => 'format_callout',
+        'caution' => 'format_admonition',
+        'citation' => 'format_citation',
+        'citerefentry' => 'span',
+        'code' => 'code',
+        'collab' => 'span',
+        'collabname' => 'span',
+        'contrib' => 'format_suppressed_tags',
+        'colspec' => 'format_colspec',
+        'command' => 'strong',
+        'computeroutput' => 'span',
         /* FIXME: This is one crazy stupid workaround for footnotes */
-        'constant'              => array(
-            /* DEFAULT */          'format_constant',
-            'para'              => array(
-                /* DEFAULT */      'format_constant',
-                'footnote'      => 'format_footnote_constant',
+        'constant' => array(
+            /* DEFAULT */
+            'format_constant',
+            'para' => array(
+                /* DEFAULT */
+                'format_constant',
+                'footnote' => 'format_footnote_constant',
             ),
         ),
-        'constructorsynopsis'   => 'format_methodsynopsis',
-        'destructorsynopsis'    => 'format_methodsynopsis',
-        'emphasis'              => 'format_emphasis',
-        'entry'                 => array (
-            /* DEFAULT */          'format_entry',
-            'row'               => array(
-                /* DEFAULT */      'format_entry',
-                'thead'         => 'format_th_entry',
-                'tfoot'         => 'format_th_entry',
-                'tbody'         => 'format_entry',
+        'constructorsynopsis' => 'format_methodsynopsis',
+        'destructorsynopsis' => 'format_methodsynopsis',
+        'emphasis' => 'format_emphasis',
+        'entry' => array(
+            /* DEFAULT */
+            'format_entry',
+            'row' => array(
+                /* DEFAULT */
+                'format_entry',
+                'thead' => 'format_th_entry',
+                'tfoot' => 'format_th_entry',
+                'tbody' => 'format_entry',
             ),
         ),
-        'envar'                 => 'var',
-        'errortype'             => 'span',
-        'errorcode'             => 'span',
-        'example'               => 'format_example',
-        'formalpara'            => 'p',
-        'fieldsynopsis'         => array(
-            /* DEFAULT */          'format_fieldsynopsis',
-            'entry'             => 'format_div',
+        'envar' => 'var',
+        'errortype' => 'span',
+        'errorcode' => 'span',
+        'example' => 'format_example',
+        'formalpara' => 'p',
+        'fieldsynopsis' => array(
+            /* DEFAULT */
+            'format_fieldsynopsis',
+            'entry' => 'format_div',
         ),
-        'figure'                => 'div',
-        'filename'              => 'var',
-        'glossentry'            => 'li',
-        'glossdef'              => 'p',
-        'glosslist'             => 'format_itemizedlist',
-        'glossterm'             => 'span',
-        'holder'                => 'span',
-        'imageobject'           => 'format_div',
-        'imagedata'             => 'format_imagedata',
-        'important'             => 'format_admonition',
-        'index'                 => array(
-            /* DEFAULT */          'format_div',
-            'article'           => 'format_chunk',
-            'book'              => 'format_chunk',
-            'part'              => 'format_chunk',
+        'figure' => 'div',
+        'filename' => 'var',
+        'glossentry' => 'li',
+        'glossdef' => 'p',
+        'glosslist' => 'format_itemizedlist',
+        'glossterm' => 'span',
+        'holder' => 'span',
+        'imageobject' => 'format_div',
+        'imagedata' => 'format_imagedata',
+        'important' => 'format_admonition',
+        'index' => array(
+            /* DEFAULT */
+            'format_div',
+            'article' => 'format_chunk',
+            'book' => 'format_chunk',
+            'part' => 'format_chunk',
         ),
-        'info'                  => array(
-            /* DEFAULT */         'format_div',
-            'note'              => 'span',
+        'info' => array(
+            /* DEFAULT */
+            'format_div',
+            'note' => 'span',
         ),
-        'informalexample'       => 'format_div',
-        'informaltable'         => 'format_table',
-        'indexdiv'              => 'format_dl',
-        'indexentry'            => 'dd',
-        'initializer'           => 'format_initializer',
-        'itemizedlist'          => 'format_itemizedlist',
-        'keycap'                => 'format_keycap',
-        'keycombo'              => 'format_keycombo',
-        'legalnotice'           => 'format_chunk',
-        'listitem'              => array(
-            /* DEFAULT */          'li',
-            'varlistentry'      => 'format_varlistentry_listitem',
+        'informalexample' => 'format_div',
+        'informaltable' => 'format_table',
+        'indexdiv' => 'format_dl',
+        'indexentry' => 'dd',
+        'initializer' => 'format_initializer',
+        'itemizedlist' => 'format_itemizedlist',
+        'keycap' => 'format_keycap',
+        'keycombo' => 'format_keycombo',
+        'legalnotice' => 'format_chunk',
+        'listitem' => array(
+            /* DEFAULT */
+            'li',
+            'varlistentry' => 'format_varlistentry_listitem',
         ),
-        'literal'               => 'format_literal',
-        'literallayout'         => 'pre',
-        'link'                  => 'format_link',
-        'manvolnum'             => 'format_manvolnum',
-        'inlinemediaobject'     => 'format_mediaobject',
-        'mediaobject'           => 'format_mediaobject',
-        'methodparam'           => 'format_methodparam',
-        'methodsynopsis'        => 'format_methodsynopsis',
-        'methodname'            => 'format_methodname',
-        'member'                => 'format_member',
-        'modifier'              => array(
-            /* DEFAULT */          'format_modifier',
-            'methodparam'       => 'format_methodparam_modifier',
+        'literal' => 'format_literal',
+        'literallayout' => 'pre',
+        'link' => 'format_link',
+        'manvolnum' => 'format_manvolnum',
+        'inlinemediaobject' => 'format_mediaobject',
+        'mediaobject' => 'format_mediaobject',
+        'methodparam' => 'format_methodparam',
+        'methodsynopsis' => 'format_methodsynopsis',
+        'methodname' => 'format_methodname',
+        'member' => 'format_member',
+        'modifier' => array(
+            /* DEFAULT */
+            'format_modifier',
+            'methodparam' => 'format_methodparam_modifier',
         ),
-        'note'                  => 'format_note',
-        'orgname'               => 'span',
-        'othercredit'           => 'format_div',
+        'note' => 'format_note',
+        'orgname' => 'span',
+        'othercredit' => 'format_div',
         /** Class Synopsis related tags */
-        'classsynopsis'         => 'format_classsynopsis',
-        'classsynopsisinfo'     => 'format_classsynopsisinfo',
-        'ooclass'               => array(
-            /* DEFAULT */          'span',
-            'classsynopsis'     => 'format_classsynopsis_generic_oo_tag',
+        'classsynopsis' => 'format_classsynopsis',
+        'classsynopsisinfo' => 'format_classsynopsisinfo',
+        'ooclass' => array(
+            /* DEFAULT */
+            'span',
+            'classsynopsis' => 'format_classsynopsis_generic_oo_tag',
         ),
-        'ooexception'           => [
-            /* DEFAULT */          'span',
-            'classsynopsis'     => 'format_classsynopsis_generic_oo_tag',
+        'ooexception' => [
+            /* DEFAULT */
+            'span',
+            'classsynopsis' => 'format_classsynopsis_generic_oo_tag',
         ],
-        'oointerface'           => array(
-            /* DEFAULT */          'span',
-            'classsynopsis'     => 'format_classsynopsis_generic_oo_tag',
+        'oointerface' => array(
+            /* DEFAULT */
+            'span',
+            'classsynopsis' => 'format_classsynopsis_generic_oo_tag',
             'classsynopsisinfo' => 'format_classsynopsisinfo_oointerface',
         ),
-        'classname'             => [
-            /* DEFAULT */          'span',
-            'ooclass'           => [
-                /* DEFAULT */          'span',
-                'classsynopsis'     => 'format_classsynopsis_ooclass_classname',
+        'classname' => [
+            /* DEFAULT */
+            'span',
+            'ooclass' => [
+                /* DEFAULT */
+                'span',
+                'classsynopsis' => 'format_classsynopsis_ooclass_classname',
                 'classsynopsisinfo' => 'format_classsynopsisinfo_ooclass_classname',
             ],
         ],
-        'exceptionname'             => [
-            /* DEFAULT */          'span',
-            'ooexception'           => [
-                /* DEFAULT */          'span',
-                'classsynopsis'     => 'format_classsynopsis_ooclass_classname',
+        'exceptionname' => [
+            /* DEFAULT */
+            'span',
+            'ooexception' => [
+                /* DEFAULT */
+                'span',
+                'classsynopsis' => 'format_classsynopsis_ooclass_classname',
             ],
         ],
-        'interfacename'         => array(
-            /* DEFAULT */          'span',
-            'oointerface'       => array(
-                /* DEFAULT */          'span',
+        'interfacename' => array(
+            /* DEFAULT */
+            'span',
+            'oointerface' => array(
+                /* DEFAULT */
+                'span',
                 'classsynopsis' => 'format_classsynopsis_oointerface_interfacename',
                 'classsynopsisinfo' => 'format_classsynopsisinfo_oointerface_interfacename',
             ),
         ),
         /** Enum synopsis related */
         'enumsynopsis' => 'format_enumsynopsis',
-        'enumname'              => [
-            /* DEFAULT */          'span',
-            'enumsynopsis'      => 'format_enumsynopsis_enumname'
+        'enumname' => [
+            /* DEFAULT */
+            'span',
+            'enumsynopsis' => 'format_enumsynopsis_enumname'
         ],
-        'enumitem'              => 'format_enumitem',
-        'enumidentifier'        => 'format_enumidentifier',
-        'enumvalue'             => 'format_enumvalue',
-        'enumitemdescription'   => 'format_enumitemdescription',
-        'option'                => 'format_option',
-        'orderedlist'           => 'format_orderedlist',
-        'para'                  => array(
-            /* DEFAULT */          'p',
-            'example'           => 'format_example_content',
-            'footnote'          => 'format_footnote_para',
-            'refsect1'          => 'format_refsect1_para',
-            'question'          => 'format_suppressed_tags',
+        'enumitem' => 'format_enumitem',
+        'enumidentifier' => 'format_enumidentifier',
+        'enumvalue' => 'format_enumvalue',
+        'enumitemdescription' => 'format_enumitemdescription',
+        'option' => 'format_option',
+        'orderedlist' => 'format_orderedlist',
+        'para' => array(
+            /* DEFAULT */
+            'p',
+            'example' => 'format_example_content',
+            'footnote' => 'format_footnote_para',
+            'refsect1' => 'format_refsect1_para',
+            'question' => 'format_suppressed_tags',
         ),
-        'paramdef'              => 'format_suppressed_tags',
-        'parameter'             => array(
-            /* DEFAULT */          'format_parameter',
-            'methodparam'       => 'format_methodparam_parameter',
+        'paramdef' => 'format_suppressed_tags',
+        'parameter' => array(
+            /* DEFAULT */
+            'format_parameter',
+            'methodparam' => 'format_methodparam_parameter',
         ),
-        'part'                  => 'format_container_chunk_top',
-        'partintro'             => 'format_div',
-        'personname'            => 'format_personname',
-        'personblurb'           => 'format_div',
-        'phrase'                => 'span',
-        'preface'               => 'format_chunk',
-        'printhistory'          => 'format_div',
-        'primaryie'             => 'format_suppressed_tags',
-        'procedure'             => 'format_procedure',
-        'productname'           => 'span',
-        'programlisting'        => 'format_programlisting',
-        'prompt'                => 'span',
-        'propname'              => 'span',
-        'property'              => array(
-            /* DEFAULT */          'span',
+        'part' => 'format_container_chunk_top',
+        'partintro' => 'format_div',
+        'personname' => 'format_personname',
+        'personblurb' => 'format_div',
+        'phrase' => 'span',
+        'preface' => 'format_chunk',
+        'printhistory' => 'format_div',
+        'primaryie' => 'format_suppressed_tags',
+        'procedure' => 'format_procedure',
+        'productname' => 'span',
+        'programlisting' => 'format_programlisting',
+        'prompt' => 'span',
+        'propname' => 'span',
+        'property' => array(
+            /* DEFAULT */
+            'span',
             'classsynopsisinfo' => 'format_varname',
         ),
-        'proptype'              => 'span',
-        'pubdate'               => 'format_div', /* Docbook-XSL prints "published" */
-        'refentry'              => 'format_chunk',
-        'refentrytitle'         => 'span',
-        'refpurpose'            => 'p',
-        'reference'             => 'format_container_chunk_below',
-        'refsect1'              => 'format_refsect',
-        'refsect2'              => 'format_refsect',
-        'refsect3'              => 'format_refsect',
-        'refsynopsisdiv'        => 'div',
-        'refname'               => 'h1',
-        'refnamediv'            => 'div',
-        'releaseinfo'           => 'div',
-        'replaceable'           => array(
-            /* DEFAULT */          'span',
-            'constant'          => 'format_replaceable',
+        'proptype' => 'span',
+        'pubdate' => 'format_div', /* Docbook-XSL prints "published" */
+        'refentry' => 'format_chunk',
+        'refentrytitle' => 'span',
+        'refpurpose' => 'p',
+        'reference' => 'format_container_chunk_below',
+        'refsect1' => 'format_refsect',
+        'refsect2' => 'format_refsect',
+        'refsect3' => 'format_refsect',
+        'refsynopsisdiv' => 'div',
+        'refname' => 'h1',
+        'refnamediv' => 'div',
+        'releaseinfo' => 'div',
+        'replaceable' => array(
+            /* DEFAULT */
+            'span',
+            'constant' => 'format_replaceable',
         ),
-        'revhistory'            => 'format_table',
-        'revision'              => 'format_row',
-        'revremark'             => 'format_entry',
-        'row'                   => 'format_row',
-        'screen'                => 'format_screen',
-        'screenshot'            => 'format_div',
-        'sect1'                 => 'format_chunk',
-        'sect2'                 => 'div',
-        'sect3'                 => 'div',
-        'sect4'                 => 'div',
-        'sect5'                 => 'div',
-        'section'               => array(
-            /* DEFAULT */          'div',
-            'sect1'                => 'format_section_chunk',
-            'chapter'              => 'format_section_chunk',
-            'appendix'             => 'format_section_chunk',
-            'article'              => 'format_section_chunk',
-            'part'                 => 'format_section_chunk',
-            'reference'            => 'format_section_chunk',
-            'refentry'             => 'format_section_chunk',
-            'index'                => 'format_section_chunk',
-            'bibliography'         => 'format_section_chunk',
-            'glossary'             => 'format_section_chunk',
-            'colopone'             => 'format_section_chunk',
-            'book'                 => 'format_section_chunk',
-            'set'                  => 'format_section_chunk',
-            'setindex'             => 'format_section_chunk',
-            'legalnotice'          => 'format_section_chunk',
+        'revhistory' => 'format_table',
+        'revision' => 'format_row',
+        'revremark' => 'format_entry',
+        'row' => 'format_row',
+        'screen' => 'format_screen',
+        'screenshot' => 'format_div',
+        'sect1' => 'format_chunk',
+        'sect2' => 'div',
+        'sect3' => 'div',
+        'sect4' => 'div',
+        'sect5' => 'div',
+        'section' => array(
+            /* DEFAULT */
+            'div',
+            'sect1' => 'format_section_chunk',
+            'chapter' => 'format_section_chunk',
+            'appendix' => 'format_section_chunk',
+            'article' => 'format_section_chunk',
+            'part' => 'format_section_chunk',
+            'reference' => 'format_section_chunk',
+            'refentry' => 'format_section_chunk',
+            'index' => 'format_section_chunk',
+            'bibliography' => 'format_section_chunk',
+            'glossary' => 'format_section_chunk',
+            'colopone' => 'format_section_chunk',
+            'book' => 'format_section_chunk',
+            'set' => 'format_section_chunk',
+            'setindex' => 'format_section_chunk',
+            'legalnotice' => 'format_section_chunk',
         ),
-        'seg'                   => 'format_seg',
-        'segmentedlist'         => 'format_segmentedlist',
-        'seglistitem'           => 'format_seglistitem',
-        'segtitle'              => 'format_suppressed_tags',
-        'set'                   => 'format_container_chunk_top',
-        'setindex'              => 'format_chunk',
-        'shortaffil'            => 'format_suppressed_tags',
-        'sidebar'               => 'format_note',
-        'simplelist'            => 'format_simplelist',
-        'simplesect'            => 'div',
-        'simpara'               => array(
-            /* DEFAULT */          'p',
-            'note'              => 'span',
-            'listitem'          => 'span',
-            'entry'             => 'span',
-            'example'           => 'format_example_content',
+        'seg' => 'format_seg',
+        'segmentedlist' => 'format_segmentedlist',
+        'seglistitem' => 'format_seglistitem',
+        'segtitle' => 'format_suppressed_tags',
+        'set' => 'format_container_chunk_top',
+        'setindex' => 'format_chunk',
+        'shortaffil' => 'format_suppressed_tags',
+        'sidebar' => 'format_note',
+        'simplelist' => 'format_simplelist',
+        'simplesect' => 'div',
+        'simpara' => array(
+            /* DEFAULT */
+            'p',
+            'note' => 'span',
+            'listitem' => 'span',
+            'entry' => 'span',
+            'example' => 'format_example_content',
         ),
-        'spanspec'              => 'format_suppressed_tags',
-        'step'                  => 'format_step',
-        'superscript'           => 'sup',
-        'subscript'             => 'sub',
-        'systemitem'            => 'format_systemitem',
-        'symbol'                => 'span',
-        'synopsis'              => 'pre',
-        'tag'                   => 'code',
-        'table'                 => 'format_table',
-        'firstterm'             => 'format_term',
-        'term'                  => array(
-            /* DEFAULT */          'format_term',
-            'varlistentry'      => 'format_varlistentry_term'
+        'spanspec' => 'format_suppressed_tags',
+        'step' => 'format_step',
+        'superscript' => 'sup',
+        'subscript' => 'sub',
+        'systemitem' => 'format_systemitem',
+        'symbol' => 'span',
+        'synopsis' => 'pre',
+        'tag' => 'code',
+        'table' => 'format_table',
+        'firstterm' => 'format_term',
+        'term' => array(
+            /* DEFAULT */
+            'format_term',
+            'varlistentry' => 'format_varlistentry_term'
         ),
-        'tfoot'                 => 'format_th',
-        'tbody'                 => 'format_tbody',
-        'td'                    => 'format_th',
-        'th'                    => 'format_th',
-        'thead'                 => 'format_th',
-        'tgroup'                => 'format_tgroup',
-        'tip'                   => 'format_admonition',
-        'title'                 => array(
-            /* DEFAULT */          'h1',
-            'example'           => 'format_example_title',
-            'formalpara'        => 'h5',
-            'info'              => array(
-                /* DEFAULT */      'h1',
-                'example'       => 'format_example_title',
-                'note'          => 'format_note_title',
-                'table'         => 'format_table_title',
+        'tfoot' => 'format_th',
+        'tbody' => 'format_tbody',
+        'td' => 'format_th',
+        'th' => 'format_th',
+        'thead' => 'format_th',
+        'tgroup' => 'format_tgroup',
+        'tip' => 'format_admonition',
+        'title' => array(
+            /* DEFAULT */
+            'h1',
+            'example' => 'format_example_title',
+            'formalpara' => 'h5',
+            'info' => array(
+                /* DEFAULT */
+                'h1',
+                'example' => 'format_example_title',
+                'note' => 'format_note_title',
+                'table' => 'format_table_title',
                 'informaltable' => 'format_table_title',
 
-                'article'       => 'format_container_chunk_top_title',
-                'appendix'      => 'format_container_chunk_top_title',
-                'book'          => 'format_container_chunk_top_title',
-                'chapter'       => 'format_container_chunk_top_title',
-                'part'          => 'format_container_chunk_top_title',
-                'set'           => 'format_container_chunk_top_title',
+                'article' => 'format_container_chunk_top_title',
+                'appendix' => 'format_container_chunk_top_title',
+                'book' => 'format_container_chunk_top_title',
+                'chapter' => 'format_container_chunk_top_title',
+                'part' => 'format_container_chunk_top_title',
+                'set' => 'format_container_chunk_top_title',
 
             ),
-            'indexdiv'          => 'dt',
-            'legalnotice'       => 'h4',
-            'note'              => 'format_note_title',
-            'phd:toc'           => 'strong',
-            'procedure'         => 'strong',
-            'refsect1'          => 'h3',
-            'refsect2'          => 'h4',
-            'refsect3'          => 'h5',
-            'section'           => 'h2',
-            'sect1'             => 'h2',
-            'sect2'             => 'h3',
-            'sect3'             => 'h4',
-            'sect4'             => 'h5',
-            'segmentedlist'     => 'format_table_title',
-            'table'             => 'format_table_title',
-            'variablelist'      => 'format_variablelist_title',
-            'article'           => 'format_container_chunk_top_title',
-            'appendix'          => 'format_container_chunk_top_title',
-            'book'              => 'format_container_chunk_top_title',
-            'chapter'           => 'format_container_chunk_top_title',
-            'part'              => 'format_container_chunk_top_title',
-            'set'               => 'format_container_chunk_top_title',
+            'indexdiv' => 'dt',
+            'legalnotice' => 'h4',
+            'note' => 'format_note_title',
+            'phd:toc' => 'strong',
+            'procedure' => 'strong',
+            'refsect1' => 'h3',
+            'refsect2' => 'h4',
+            'refsect3' => 'h5',
+            'section' => 'h2',
+            'sect1' => 'h2',
+            'sect2' => 'h3',
+            'sect3' => 'h4',
+            'sect4' => 'h5',
+            'segmentedlist' => 'format_table_title',
+            'table' => 'format_table_title',
+            'variablelist' => 'format_variablelist_title',
+            'article' => 'format_container_chunk_top_title',
+            'appendix' => 'format_container_chunk_top_title',
+            'book' => 'format_container_chunk_top_title',
+            'chapter' => 'format_container_chunk_top_title',
+            'part' => 'format_container_chunk_top_title',
+            'set' => 'format_container_chunk_top_title',
         ),
-        'titleabbrev'           => 'format_suppressed_tags',
-        'token'                 => 'code',
-        'tr'                    => 'format_row',
-        'trademark'             => 'format_trademark',
-        'type'                  => 'span',
-        'userinput'             => 'format_userinput',
-        'uri'                   => 'code',
-        'variablelist'          => 'format_variablelist',
-        'varlistentry'          => 'format_varlistentry',
-        'varname'               => array(
-            /* DEFAULT */          'var',
-            'fieldsynopsis'     => 'format_fieldsynopsis_varname',
+        'titleabbrev' => 'format_suppressed_tags',
+        'token' => 'code',
+        'tr' => 'format_row',
+        'trademark' => 'format_trademark',
+        'type' => 'span',
+        'userinput' => 'format_userinput',
+        'uri' => 'code',
+        'variablelist' => 'format_variablelist',
+        'varlistentry' => 'format_varlistentry',
+        'varname' => array(
+            /* DEFAULT */
+            'var',
+            'fieldsynopsis' => 'format_fieldsynopsis_varname',
         ),
-        'void'                  => 'format_void',
-        'warning'               => 'format_admonition',
-        'xref'                  => 'format_xref',
-        'year'                  => 'span',
-        'quote'                 => 'q',
-        'qandaset'              => 'format_qandaset',
-        'qandaentry'            => 'dl',
-        'question'              => array(
-            /* DEFAULT */          'format_question',
-            'questions'         => 'format_phd_question', // From the PhD namespace
+        'void' => 'format_void',
+        'warning' => 'format_admonition',
+        'xref' => 'format_xref',
+        'year' => 'span',
+        'quote' => 'q',
+        'qandaset' => 'format_qandaset',
+        'qandaentry' => 'dl',
+        'question' => array(
+            /* DEFAULT */
+            'format_question',
+            'questions' => 'format_phd_question', // From the PhD namespace
         ),
-        'questions'             => 'ol', // From the PhD namespace
-        'answer'                => 'dd',
+        'questions' => 'ol', // From the PhD namespace
+        'answer' => 'dd',
 
         //phpdoc: implemented in the PHP Package
-        'phpdoc:classref'       => 'format_suppressed_tags',
-        'phpdoc:exception'      => 'format_suppressed_tags',
-        'phpdoc:exceptionref'   => 'format_suppressed_tags',
-        'phpdoc:varentry'       => 'format_suppressed_tags',
+        'phpdoc:classref' => 'format_suppressed_tags',
+        'phpdoc:exception' => 'format_suppressed_tags',
+        'phpdoc:exceptionref' => 'format_suppressed_tags',
+        'phpdoc:varentry' => 'format_suppressed_tags',
 
         //phd
-        'phd:toc'               => 'format_phd_toc',
+        'phd:toc' => 'format_phd_toc',
 
     ); /* }}} */
 
     private $mytextmap = array(
-        'segtitle'             => 'format_segtitle_text',
-        'affiliation'          => 'format_suppressed_text',
-        'contrib'              => 'format_suppressed_text',
-        'shortaffil'           => 'format_suppressed_text',
-        'edition'              => 'format_suppressed_text',
+        'segtitle' => 'format_segtitle_text',
+        'affiliation' => 'format_suppressed_text',
+        'contrib' => 'format_suppressed_text',
+        'shortaffil' => 'format_suppressed_text',
+        'edition' => 'format_suppressed_text',
 
-        'programlisting'       => 'format_programlisting_text',
-        'screen'               => 'format_screen_text',
-        'alt'                  => 'format_alt_text',
-        'modifier'             => array(
-            /* DEFAULT */         false,
-            'fieldsynopsis'    => 'format_fieldsynopsis_modifier_text',
-            'methodparam'      => 'format_modifier_text',
-            'methodsynopsis'   => 'format_modifier_text',
+        'programlisting' => 'format_programlisting_text',
+        'screen' => 'format_screen_text',
+        'alt' => 'format_alt_text',
+        'modifier' => array(
+            /* DEFAULT */
+            false,
+            'fieldsynopsis' => 'format_fieldsynopsis_modifier_text',
+            'methodparam' => 'format_modifier_text',
+            'methodsynopsis' => 'format_modifier_text',
             'constructorsynopsis' => 'format_modifier_text',
-            'ooclass'          => 'format_modifier_text',
-            'ooexception'      => 'format_modifier_text',
-            'oointerface'      => 'format_modifier_text',
+            'ooclass' => 'format_modifier_text',
+            'ooexception' => 'format_modifier_text',
+            'oointerface' => 'format_modifier_text',
         ),
-        'replaceable'          => array(
-            /* DEFAULT */         false,
-            'constant'         => 'format_suppressed_text',
+        'replaceable' => array(
+            /* DEFAULT */
+            false,
+            'constant' => 'format_suppressed_text',
         ),
         /** Those are used to retrieve the class/interface name to be able to remove it from method names */
         'classname' => [
-            /* DEFAULT */ false,
+            /* DEFAULT */
+            false,
             'ooclass' => [
-                /* DEFAULT */     false,
+                /* DEFAULT */
+                false,
                 /** This is also used by the legacy display to not display the class name at all */
                 'classsynopsis' => 'format_classsynopsis_ooclass_classname_text',
             ]
         ],
         'exceptionname' => [
-            /* DEFAULT */ false,
+            /* DEFAULT */
+            false,
             'ooexception' => [
-                /* DEFAULT */     false,
+                /* DEFAULT */
+                false,
                 'classsynopsis' => 'format_classsynopsis_oo_name_text',
             ]
         ],
         'interfacename' => [
-            /* DEFAULT */ false,
+            /* DEFAULT */
+            false,
             'oointerface' => [
-                /* DEFAULT */     false,
+                /* DEFAULT */
+                false,
                 'classsynopsis' => 'format_classsynopsis_oo_name_text',
             ]
         ],
-        'methodname'           => array(
-            /* DEFAULT */         false,
+        'methodname' => array(
+            /* DEFAULT */
+            false,
             'constructorsynopsis' => array(
-                /* DEFAULT */     false,
+                /* DEFAULT */
+                false,
                 'classsynopsis' => 'format_classsynopsis_methodsynopsis_methodname_text',
             ),
-            'methodsynopsis'    => array(
-                /* DEFAULT */     false,
+            'methodsynopsis' => array(
+                /* DEFAULT */
+                false,
                 'classsynopsis' => 'format_classsynopsis_methodsynopsis_methodname_text',
             ),
             'destructorsynopsis' => array(
-                /* DEFAULT */     false,
+                /* DEFAULT */
+                false,
                 'classsynopsis' => 'format_classsynopsis_methodsynopsis_methodname_text',
             ),
         ),
-        'para'                  => array(
-            /* DEFAULT */          false,
-            'footnote'             => 'format_footnote_para_text',
+        'para' => array(
+            /* DEFAULT */
+            false,
+            'footnote' => 'format_footnote_para_text',
         ),
-        'property'              => [
-           /* DEFAULT */           'format_property_text',
+        'property' => [
+            /* DEFAULT */
+            'format_property_text',
         ],
         /* FIXME: This is one crazy stupid workaround for footnotes */
-        'constant'              => array(
-            /* DEFAULT */          'format_constant_text',
-            'para'              => array(
-                /* DEFAULT */      'format_constant_text',
-                'footnote'      => 'format_footnote_constant_text',
+        'constant' => array(
+            /* DEFAULT */
+            'format_constant_text',
+            'para' => array(
+                /* DEFAULT */
+                'format_constant_text',
+                'footnote' => 'format_footnote_constant_text',
             ),
         ),
-        'literal'               => 'format_literal_text',
-        'email'                 => 'format_email_text',
-        'titleabbrev'           => 'format_suppressed_text',
-        'member'                => 'format_member_text',
+        'literal' => 'format_literal_text',
+        'email' => 'format_email_text',
+        'titleabbrev' => 'format_suppressed_text',
+        'member' => 'format_member_text',
     );
 
     /** @var array */
@@ -486,60 +537,58 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     /** @var string */
     protected $CURRENT_CHUNK = "";
 
-     /* Current Chunk variables */
-    protected $cchunk      = array();
+    /* Current Chunk variables */
+    protected $cchunk = array();
     /* Default Chunk variables */
-    private $dchunk      = array(
+    private $dchunk = array(
         "classsynopsis" => [
-            "close"        => false,
-            "classname"    => false,
-            "interface"    => false, // bool: true when in interface
-            "ooclass"      => false,
-            "oointerface"  => false,
-            "legacy"       => true, // legacy rendering
+            "close" => false,
+            "classname" => false,
+            "interface" => false, // bool: true when in interface
+            "ooclass" => false,
+            "oointerface" => false,
+            "legacy" => true, // legacy rendering
         ],
-        "classsynopsisinfo"        => array(
-            "implements"                    => false,
-            "ooclass"                       => false,
+        "classsynopsisinfo" => array(
+            "implements" => false,
+            "ooclass" => false,
         ),
-        "examples"                 => 0,
-        "fieldsynopsis"            => array(
-            "modifier"                      => "public",
+        "examples" => 0,
+        "fieldsynopsis" => array(
+            "modifier" => "public",
         ),
-        "methodsynopsis"           => array(
-            "returntypes"          => array(),
-            "type_separator"       => array(),
+        "methodsynopsis" => array(
+            "returntypes" => array(),
+            "type_separator" => array(),
             "type_separator_stack" => array(),
         ),
-        "co"                       => 0,
-        "callouts"                 => 0,
-        "segmentedlist"            => array(
-            "segtitleclosed"       => false,
-            "segtitleopened"       => false,
+        "co" => 0,
+        "callouts" => 0,
+        "segmentedlist" => array(
+            "segtitleclosed" => false,
+            "segtitleopened" => false,
         ),
-        "table"                    => false,
-        "procedure"                => false,
-        "mediaobject"              => array(
-            "alt"                           => false,
+        "table" => false,
+        "procedure" => false,
+        "mediaobject" => array(
+            "alt" => false,
         ),
-        "footnote"                 => array(
+        "footnote" => array(),
+        "tablefootnotes" => array(),
+        "chunk_id" => null,
+        "varlistentry" => array(
+            "listitems" => array(),
         ),
-        "tablefootnotes"           => array(
-        ),
-        "chunk_id"                 => null,
-        "varlistentry"             => array(
-            "listitems"                     => array(),
-        ),
-        "simplelist"               => array(
-            "members"              => array(),
-            "type"                 => null,
-            "columns"              => null,
+        "simplelist" => array(
+            "members" => array(),
+            "type" => null,
+            "columns" => null,
         ),
     );
 
     protected $pihandlers = array(
-        'dbhtml'        => 'PI_DBHTMLHandler',
-        'dbtimestamp'   => 'PI_DBHTMLHandler',
+        'dbhtml' => 'PI_DBHTMLHandler',
+        'dbtimestamp' => 'PI_DBHTMLHandler',
     );
 
     protected $stylesheets = array();
@@ -555,31 +604,37 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     protected array $perPageExampleIds = [];
 
     public function __construct(
-        Config $config,
+        Config        $config,
         OutputHandler $outputHandler
-    ) {
+    )
+    {
         parent::__construct($config, $outputHandler);
         $this->registerPIHandlers($this->pihandlers);
         $this->setExt($this->config->ext === null ? ".html" : $this->config->ext);
     }
 
-    public function getDefaultElementMap() {
+    public function getDefaultElementMap()
+    {
         return $this->myelementmap;
     }
 
-    public function getDefaultTextMap() {
+    public function getDefaultTextMap()
+    {
         return $this->mytextmap;
     }
 
-    public function getChunkInfo() {
+    public function getChunkInfo()
+    {
         return $this->cchunk;
     }
 
-    public function getDefaultChunkInfo() {
+    public function getDefaultChunkInfo()
+    {
         return $this->dchunk;
     }
 
-    protected function createTOC($id, $name, $props, $depth = 1, $header = true) {
+    protected function createTOC($id, $name, $props, $depth = 1, $header = true)
+    {
         if (!$this->getChildren($id) || $depth == 0) {
             return "";
         }
@@ -596,13 +651,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             $link = $this->createLink($child);
 
             $list = "";
-            if ($depth > 1 ) {
-                $list = $this->createTOC($child, $name, $props, $depth -1, false);
+            if ($depth > 1) {
+                $list = $this->createTOC($child, $name, $props, $depth - 1, false);
             }
             if ($isLDesc && $isSDesc) {
                 $toc .= '<li><a href="' . $link . '">' . $short . '</a> — ' . $long . $list . "</li>\n";
             } else {
-                $toc .= '<li><a href="' . $link . '">' . $long . '</a>' . $list .  "</li>\n";
+                $toc .= '<li><a href="' . $link . '">' . $long . '</a>' . $list . "</li>\n";
             }
         }
         $toc .= "</ul>\n";
@@ -615,23 +670,25 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
 
     /**
-    * Handle a <phd:toc> tag.
-    */
-    function format_phd_toc($open, $name, $attrs, $props) {
+     * Handle a <phd:toc> tag.
+     */
+    public function format_phd_toc($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '<div class="phd-toc">';
         }
         return $this->createToc(
-            $attrs[Reader::XMLNS_PHD]['element'],
-            'phd-toc',
-            $props,
-            isset($attrs[Reader::XMLNS_PHD]['toc-depth'])
-                ? (int)$attrs[Reader::XMLNS_PHD]['toc-depth'] : 1,
-            false
-        ) . "</div>\n";
+                $attrs[Reader::XMLNS_PHD]['element'],
+                'phd-toc',
+                $props,
+                isset($attrs[Reader::XMLNS_PHD]['toc-depth'])
+                    ? (int)$attrs[Reader::XMLNS_PHD]['toc-depth'] : 1,
+                false
+            ) . "</div>\n";
     }
 
-    public function createLink($for, &$desc = null, $type = Format::SDESC) {
+    public function createLink($for, &$desc = null, $type = Format::SDESC)
+    {
         $retval = null;
         if (isset($this->indexes[$for])) {
             $rsl = $this->indexes[$for];
@@ -648,11 +705,12 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $retval;
     }
 
-    protected function createCSSLinks() {
+    protected function createCSSLinks()
+    {
         $cssLinks = '';
         foreach ((array)$this->stylesheets as $css) {
             if ($this->isChunked()) {
-                $cssLinks .= "<link media=\"all\" rel=\"stylesheet\" type=\"text/css\" href=\"styles/".$css."\" />\n";
+                $cssLinks .= "<link media=\"all\" rel=\"stylesheet\" type=\"text/css\" href=\"styles/" . $css . "\" />\n";
             } else {
                 $cssLinks .= "<style type=\"text/css\">\n" . $css . "\n</style>\n";
             }
@@ -660,7 +718,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $cssLinks;
     }
 
-    protected function fetchStylesheet($name = null) {
+    protected function fetchStylesheet($name = null)
+    {
         if (!$this->isChunked()) {
             foreach ((array)$this->config->css as $css) {
                 if ($style = file_get_contents($css)) {
@@ -680,10 +739,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if (!is_dir($stylesDir)) {
                 trigger_error("The styles/ directory is a file?", E_USER_ERROR);
             }
-        } else {
-            if (!mkdir($stylesDir, 0777, true)) {
-                trigger_error("Can't create the styles/ directory.", E_USER_ERROR);
-            }
+        } elseif (!mkdir($stylesDir, 0777, true)) {
+            trigger_error("Can't create the styles/ directory.", E_USER_ERROR);
         }
         foreach ((array)$this->config->css as $css) {
             $basename = basename($css);
@@ -696,30 +753,33 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
     }
 
-/* Functions format_* */
-    public function format_suppressed_tags($open, $name, $attrs, $props) {
+    /* Functions format_* */
+    public function format_suppressed_tags($open, $name, $attrs, $props)
+    {
         /* Ignore it */
         return "";
     }
-    public function format_suppressed_text($value, $tag) {
+
+    public function format_suppressed_text($value, $tag)
+    {
         /* Suppress any content */
         return "";
     }
 
-    public function format_link($open, $name, $attrs, $props) {
+    public function format_link($open, $name, $attrs, $props)
+    {
         if ($open) {
             $link = $class = $content = "";
 
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["linkend"])) {
                 $link = $this->createLink($attrs[Reader::XMLNS_DOCBOOK]["linkend"]);
-            }
-            elseif (isset($attrs[Reader::XMLNS_XLINK]["href"])) {
+            } elseif (isset($attrs[Reader::XMLNS_XLINK]["href"])) {
                 $link = $attrs[Reader::XMLNS_XLINK]["href"];
                 $class = " external";
                 $content = "&raquo;&nbsp;";
             }
             if ($props["empty"]) {
-                $content .= $link ."</a>";
+                $content .= $link . "</a>";
             }
 
             return '<a href="' . $link . '" class="' . $name . $class . '">' . $content;
@@ -727,24 +787,26 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return "</a>";
     }
 
-    public function format_xref($open, $name, $attrs, $props) {
+    public function format_xref($open, $name, $attrs, $props)
+    {
         if ($open) {
             $desc = "";
             $link = $this->createLink($attrs[Reader::XMLNS_DOCBOOK]["linkend"], $desc);
 
-            $ret = '<a href="' .$link. '" class="' .$name. '">' .$desc;
+            $ret = '<a href="' . $link . '" class="' . $name . '">' . $desc;
 
             if ($props["empty"]) {
-                return $ret. "</a>";
+                return $ret . "</a>";
             }
             return $ret;
         }
         return "</a>";
     }
 
-    public function format_option($open, $name, $attrs) {
+    public function format_option($open, $name, $attrs)
+    {
         if ($open) {
-            if(!isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+            if (!isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $attrs[Reader::XMLNS_DOCBOOK]["role"] = "unknown";
             }
             $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
@@ -764,10 +826,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</code>';
     }
 
-    public function format_literal_text($value, $tag) {
+    public function format_literal_text($value, $tag)
+    {
         switch ($this->getRole()) {
             case 'infdec':
-                $value = (string) (float)$value;
+                $value = (string)(float)$value;
                 $p = strpos($value, '.');
                 $str = substr($value, 0, $p + 1);
                 $str .= '<span style="text-decoration: overline;">';
@@ -779,49 +842,53 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
     }
 
-    public function format_copyright($open, $name, $attrs) {
+    public function format_copyright($open, $name, $attrs)
+    {
         if ($open) {
-            return '<div class="'.$name.'">&copy; ';
+            return '<div class="' . $name . '">&copy; ';
         }
         return '</div>';
     }
 
-    public function format_author($open, $name, $attrs, $props) {
+    public function format_author($open, $name, $attrs, $props)
+    {
         if ($open) {
-            return '<div class="' .$name. ' vcard">';
+            return '<div class="' . $name . ' vcard">';
         }
         return "</div>";
     }
 
-    public function format_personname($open, $name, $attrs, $props) {
+    public function format_personname($open, $name, $attrs, $props)
+    {
         if ($open) {
-            return '<span class="' .$name. ' fn">';
+            return '<span class="' . $name . ' fn">';
         }
         return "</span>";
     }
 
-    public function format_name($open, $name, $attrs) {
+    public function format_name($open, $name, $attrs)
+    {
         if ($open) {
             $class = "";
-            switch($name) {
-            case "firstname":
-                $class = " given-name";
-                break;
+            switch ($name) {
+                case "firstname":
+                    $class = " given-name";
+                    break;
 
-            case "surname":
-                $class = " family-name";
-                break;
+                case "surname":
+                    $class = " family-name";
+                    break;
 
-            case "othername":
-                if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
-                    /* We might want to add support for other roles */
-                    switch($attrs[Reader::XMLNS_DOCBOOK]["role"]) {
-                    case "nickname":
-                        $class = " nickname";
-                        break;
+                case "othername":
+                    if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+                        /* We might want to add support for other roles */
+                        switch ($attrs[Reader::XMLNS_DOCBOOK]["role"]) {
+                            case "nickname":
+                                $class = " nickname";
+                                break;
+                        }
                     }
-                }
-                break;
+                    break;
             }
 
             return ' <span class="' . $name . $class . '">';
@@ -829,12 +896,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</span> ';
     }
 
-    public function format_container_chunk_top($open, $name, $attrs, $props) {
+    public function format_container_chunk_top($open, $name, $attrs, $props)
+    {
         $hasAnnotations = array_key_exists('annotations', $attrs[Reader::XMLNS_DOCBOOK]);
 
         $this->cchunk = $this->dchunk;
         $this->cchunk["name"] = $name;
-        if(isset($attrs[Reader::XMLNS_XML]["id"])) {
+        if (isset($attrs[Reader::XMLNS_XML]["id"])) {
             $id = $attrs[Reader::XMLNS_XML]["id"];
         } else {
             $id = uniqid("phd");
@@ -848,7 +916,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             $this->CURRENT_CHUNK = $id;
             $this->notify(Render::CHUNK, Render::OPEN);
 
-            return '<div id="' .$id. '" class="' .$name. '">';
+            return '<div id="' . $id . '" class="' . $name . '">';
         }
 
         if ($hasAnnotations) {
@@ -862,9 +930,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             $toc = $this->createTOC($id, $name, $props);
         }
 
-        return $toc."</div>";
+        return $toc . "</div>";
     }
-    public function format_container_chunk_top_title($open, $name, $attrs, $props) {
+
+    public function format_container_chunk_top_title($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '<h1>';
         }
@@ -875,12 +945,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
         $this->TOC_WRITTEN[] = $id;
 
-        return '</h1>'.$toc;
+        return '</h1>' . $toc;
     }
-    public function format_container_chunk_below($open, $name, $attrs, $props) {
+
+    public function format_container_chunk_below($open, $name, $attrs, $props)
+    {
         $this->cchunk = $this->dchunk;
         $this->cchunk["name"] = $name;
-        if(isset($attrs[Reader::XMLNS_XML]["id"])) {
+        if (isset($attrs[Reader::XMLNS_XML]["id"])) {
             $id = $attrs[Reader::XMLNS_XML]["id"];
         } else {
             /* FIXME: This will obviously not exist in the db.. */
@@ -891,7 +963,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             $this->CURRENT_CHUNK = $id;
             $this->notify(Render::CHUNK, Render::OPEN);
 
-            return '<div id="' .$attrs[Reader::XMLNS_XML]["id"]. '" class="' .$name. '">';
+            return '<div id="' . $attrs[Reader::XMLNS_XML]["id"] . '" class="' . $name . '">';
         }
 
         $toc = '<ol>';
@@ -904,10 +976,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $this->notify(Render::CHUNK, Render::CLOSE);
         return $toc . '</div>';
     }
-    public function format_exception_chunk($open, $name, $attrs, $props) {
+
+    public function format_exception_chunk($open, $name, $attrs, $props)
+    {
         return $this->format_container_chunk_below($open, "reference", $attrs, $props);
     }
-    public function format_section_chunk($open, $name, $attrs, $props) {
+
+    public function format_section_chunk($open, $name, $attrs, $props)
+    {
         if ($open) {
             if (!isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $this->isSectionChunk[] = false;
@@ -921,10 +997,12 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return $this->transformFromMap($open, "div", $name, $attrs, $props);
     }
-    public function format_chunk($open, $name, $attrs, $props) {
+
+    public function format_chunk($open, $name, $attrs, $props)
+    {
         if ($open) {
             $this->cchunk = $this->dchunk;
-            if(isset($attrs[Reader::XMLNS_XML]["id"])) {
+            if (isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $id = $attrs[Reader::XMLNS_XML]["id"];
             } else {
                 $id = uniqid("phd");
@@ -936,64 +1014,68 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             }
 
             $this->CURRENT_CHUNK = $id;
-            $this->CURRENT_LANG  = $props["lang"];
+            $this->CURRENT_LANG = $props["lang"];
 
             $this->notify(Render::CHUNK, Render::OPEN);
-            return '<div id="' .$id. '" class="' .$class. '">';
+            return '<div id="' . $id . '" class="' . $class . '">';
         }
         $this->notify(Render::CHUNK, Render::CLOSE);
 
         $str = "";
         foreach ($this->cchunk["footnote"] as $k => $note) {
             $str .= '<div class="footnote">';
-            $str .= '<a name="fnid' .$note["id"]. '" href="#fn' .$note["id"]. '"><sup>[' .($k + 1). ']</sup></a>';
+            $str .= '<a name="fnid' . $note["id"] . '" href="#fn' . $note["id"] . '"><sup>[' . ($k + 1) . ']</sup></a>';
             $str .= $note["str"];
             $str .= "</div>\n";
         }
         $this->cchunk = $this->dchunk;
 
-        return $str. "</div>";
+        return $str . "</div>";
     }
-    public function format_refsect1_para($open, $name, $attrs, $props) {
+
+    public function format_refsect1_para($open, $name, $attrs, $props)
+    {
         if ($open) {
             switch ($props["sibling"]) {
-            case "methodsynopsis":
-            case "constructorsynopsis":
-            case "destructorsynopsis":
-                return '<p class="'.$name.' rdfs-comment">';
-                break;
+                case "methodsynopsis":
+                case "constructorsynopsis":
+                case "destructorsynopsis":
+                    return '<p class="' . $name . ' rdfs-comment">';
+                    break;
 
-            default:
-                return '<p class="'.$name.'">';
+                default:
+                    return '<p class="' . $name . '">';
             }
 
         }
         return '</p>';
     }
-    public function format_refsect($open, $name, $attrs) {
+
+    public function format_refsect($open, $name, $attrs)
+    {
         static $role = 0;
 
         if ($open) {
-            if(!isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+            if (!isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $attrs[Reader::XMLNS_DOCBOOK]["role"] = "unknown-" . ++$role;
             }
             $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
 
             if (isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $id = $attrs[Reader::XMLNS_XML]["id"];
-            }
-            else {
-                $id = $name. "-" . $this->CURRENT_CHUNK . "-" . $this->getRole();
+            } else {
+                $id = $name . "-" . $this->CURRENT_CHUNK . "-" . $this->getRole();
             }
 
-            return '<div class="' .$name.' ' .$this->getRole(). '" id="' . $id . '">';
+            return '<div class="' . $name . ' ' . $this->getRole() . '" id="' . $id . '">';
         }
         $this->popRole();
         return "</div>\n";
     }
 
     /** Legacy rendering functions for class synopsis tags that wraps the definition in a class synopsis info tag */
-    public function format_classsynopsisinfo_oointerface($open, $name, $attrs) {
+    public function format_classsynopsisinfo_oointerface($open, $name, $attrs)
+    {
         if ($open) {
             if ($this->cchunk["classsynopsisinfo"]["ooclass"] === false) {
                 return '<span class="' . $name . '">';
@@ -1002,13 +1084,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if ($this->cchunk["classsynopsisinfo"]["implements"] === false) {
                 $this->cchunk["classsynopsisinfo"]["implements"] = true;
                 if ($this->cchunk["classsynopsis"]["interface"]) {
-                    return '<span class="'.$name.'"><span class="modifier">extends</span> ';
+                    return '<span class="' . $name . '"><span class="modifier">extends</span> ';
                 }
 
-                return '<span class="'.$name.'"><span class="modifier">implements</span> ';
+                return '<span class="' . $name . '"><span class="modifier">implements</span> ';
             }
 
-            return '<span class="'.$name.'">, ';
+            return '<span class="' . $name . '">, ';
         }
 
         return "</span>";
@@ -1059,10 +1141,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $this->cchunk["classsynopsisinfo"] = $this->dchunk["classsynopsisinfo"];
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"]) && $attrs[Reader::XMLNS_DOCBOOK]["role"] == "comment") {
-                return '<div class="'.$name.' classsynopsisinfo_comment">/* ';
+                return '<div class="' . $name . ' classsynopsisinfo_comment">/* ';
             }
 
-            return '<div class="'.$name.'">';
+            return '<div class="' . $name . '">';
         }
 
         if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"]) && $attrs[Reader::XMLNS_DOCBOOK]["role"] == "comment") {
@@ -1075,7 +1157,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
 
     /** This method is common between both legacy and new rendering for setting up the classname in the current chunk */
-    public function format_classsynopsis_ooclass_classname_text($value, $tag) {
+    public function format_classsynopsis_ooclass_classname_text($value, $tag)
+    {
         /** If this is not defined this is the first ooclass/oointerface/ooexception and thus needs to
          *  set the class name to be able to remove it from the methods
          */
@@ -1090,7 +1173,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
 
     /** Class synopsis rendering for new/better markup */
-    public function format_classsynopsis_oo_name_text($value, $tag) {
+    public function format_classsynopsis_oo_name_text($value, $tag)
+    {
         /** If this is not defined this is the first ooclass/oointerface/ooexception and thus needs to
          *  set the class name to be able to remove it from the methods
          */
@@ -1171,7 +1255,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '';
     }
 
-    public function format_classsynopsis($open, $name, $attrs, $props) {
+    public function format_classsynopsis($open, $name, $attrs, $props)
+    {
         $this->cchunk["classsynopsis"] = $this->dchunk["classsynopsis"];
 
         /** Legacy presentation does not use the class attribute */
@@ -1188,7 +1273,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                     $this->cchunk["classsynopsis"]["interface"] = true;
                 }
 
-                return '<div class="'.$name.'">';
+                return '<div class="' . $name . '">';
             }
 
             /* Just always force the ending } to close the class as an opening { should always be present
@@ -1214,7 +1299,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
     }
 
-    public function format_classsynopsis_methodsynopsis_methodname_text($value, $tag) {
+    public function format_classsynopsis_methodsynopsis_methodname_text($value, $tag)
+    {
         $value = $this->TEXT($value);
         if ($this->cchunk["classsynopsis"]["classname"] === false) {
             return $value;
@@ -1236,7 +1322,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $method;
     }
 
-    public function format_enumsynopsis($open, $name, $attrs, $props) {
+    public function format_enumsynopsis($open, $name, $attrs, $props)
+    {
         if ($open) {
             //return '<div class="enumsynopsis">';
             return '<div class="classsynopsis"><div class="classsynopsisinfo">';
@@ -1244,7 +1331,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             return '}</div>';
         }
     }
-    public function format_enumsynopsis_enumname($open, $name, $attrs, $props): string {
+
+    public function format_enumsynopsis_enumname($open, $name, $attrs, $props): string
+    {
         if ($open) {
             /** Actual enum name in bold */
             return '<span class="modifier">enum</span> <strong class="classname">';
@@ -1253,25 +1342,33 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         //return "</strong><br/>{<br/>";
         return "</strong><br/>{</div>";
     }
-    public function format_enumitem($open, $name, $attrs, $props) {
+
+    public function format_enumitem($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '<div class="fieldsynopsis">';
         }
         return '</div>';
     }
-    public function format_enumidentifier($open, $name, $attrs, $props) {
+
+    public function format_enumidentifier($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '    <span class="modifier">case</span>  <span class="classname">';
         }
         return '</span>';
     }
-    public function format_enumvalue($open, $name, $attrs, $props) {
+
+    public function format_enumvalue($open, $name, $attrs, $props)
+    {
         if ($open) {
             return ' = ';
         }
         return '';
     }
-    public function format_enumitemdescription($open, $name, $attrs, $props) {
+
+    public function format_enumitemdescription($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '; //';
         }
@@ -1284,7 +1381,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
         if (isset($attrs[Reader::XMLNS_DOCBOOK]['role'])) {
             $role = $attrs[Reader::XMLNS_DOCBOOK]['role'];
-            if ( $role == "strong" || $role == "bold" ) {
+            if ($role == "strong" || $role == "bold") {
                 $name = "strong";
             }
         }
@@ -1296,13 +1393,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
     }
 
-    public function format_fieldsynopsis($open, $name, $attrs) {
+    public function format_fieldsynopsis($open, $name, $attrs)
+    {
         $this->cchunk["fieldsynopsis"] = $this->dchunk["fieldsynopsis"];
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
             }
-            return '<div class="'.$name.'">';
+            return '<div class="' . $name . '">';
         }
         if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
             $this->popRole();
@@ -1310,12 +1408,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return ";</div>\n";
     }
 
-    public function format_fieldsynopsis_modifier_text($value, $tag) {
+    public function format_fieldsynopsis_modifier_text($value, $tag)
+    {
         if ($this->getRole() === "attribute") {
             $attribute = trim(strtolower($value), "#[]\\");
             $href = Format::getFilename("class.$attribute");
             if ($href) {
-                return '<a href="' . $href . $this->getExt() . '">' .$value. '</a> ';
+                return '<a href="' . $href . $this->getExt() . '">' . $value . '</a> ';
             }
             return false;
         }
@@ -1323,7 +1422,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $this->TEXT($value);
     }
 
-    public function format_modifier($open, $name, $attrs, $props) {
+    public function format_modifier($open, $name, $attrs, $props)
+    {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
@@ -1340,7 +1440,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</span>';
     }
 
-    public function format_methodparam_modifier($open, $name, $attrs, $props) {
+    public function format_methodparam_modifier($open, $name, $attrs, $props)
+    {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
@@ -1354,18 +1455,20 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</span>';
     }
 
-    public function format_modifier_text($value, $tag) {
+    public function format_modifier_text($value, $tag)
+    {
         if ($this->getRole() === "attribute") {
             $attribute = trim(strtolower($value), "#[]\\");
             $href = Format::getFilename("class.$attribute");
             if ($href) {
-                return '<a href="' . $href . $this->getExt() . '">' .$value. '</a> ';
+                return '<a href="' . $href . $this->getExt() . '">' . $value . '</a> ';
             }
         }
         return false;
     }
 
-    public function format_methodsynopsis($open, $name, $attrs, $props) {
+    public function format_methodsynopsis($open, $name, $attrs, $props)
+    {
         if ($open) {
 
             $this->params = array(
@@ -1377,8 +1480,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 "paramCount" => substr_count($props["innerXml"], "<methodparam")
             );
 
-            $id = (isset($attrs[Reader::XMLNS_XML]["id"]) ? ' id="'.$attrs[Reader::XMLNS_XML]["id"].'"' : '');
-            return '<div class="'.$name.' dc-description"'.$id.'>';
+            $id = (isset($attrs[Reader::XMLNS_XML]["id"]) ? ' id="' . $attrs[Reader::XMLNS_XML]["id"] . '"' : '');
+            return '<div class="' . $name . ' dc-description"' . $id . '>';
         }
 
         $content = "";
@@ -1407,13 +1510,15 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return "</code>";
     }
 
-    public function format_initializer($open, $name, $attrs) {
+    public function format_initializer($open, $name, $attrs)
+    {
         if ($open) {
             $this->params["init"] = true;
-            return '<span class="'.$name.'"> = ';
+            return '<span class="' . $name . '"> = ';
         }
         return '</span>';
     }
+
     public function format_parameter($open, $name, $attrs, $props)
     {
         if ($props["empty"]) {
@@ -1428,7 +1533,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return "</code>";
     }
 
-    public function format_void($open, $name, $attrs, $props) {
+    public function format_void($open, $name, $attrs, $props)
+    {
         if (isset($props['sibling']) && $props['sibling'] == 'methodname') {
             return '(';
         } else {
@@ -1436,36 +1542,37 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
     }
 
-    public function format_methodparam($open, $name, $attrs) {
+    public function format_methodparam($open, $name, $attrs)
+    {
         if ($open) {
             $content = '';
-                if ($this->params["count"] === 0) {
-                    $content .= "(";
-                    if ($this->params["paramCount"] > 3) {
-                        $content .= "<br>&nbsp;&nbsp;&nbsp;&nbsp;";
-                    }
+            if ($this->params["count"] === 0) {
+                $content .= "(";
+                if ($this->params["paramCount"] > 3) {
+                    $content .= "<br>&nbsp;&nbsp;&nbsp;&nbsp;";
                 }
-                if (isset($attrs[Reader::XMLNS_DOCBOOK]["choice"]) && $attrs[Reader::XMLNS_DOCBOOK]["choice"] == "opt") {
-                    $this->params["opt"] = true;
+            }
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]["choice"]) && $attrs[Reader::XMLNS_DOCBOOK]["choice"] == "opt") {
+                $this->params["opt"] = true;
+            } else {
+                $this->params["opt"] = false;
+            }
+            if ($this->params["count"]) {
+                $content .= ",";
+                if ($this->params["paramCount"] > 3) {
+                    $content .= "<br>&nbsp;&nbsp;&nbsp;&nbsp;";
                 } else {
-                    $this->params["opt"] = false;
+                    $content .= " ";
                 }
-                if ($this->params["count"]) {
-                    $content .= ",";
-                    if ($this->params["paramCount"] > 3) {
-                        $content .= "<br>&nbsp;&nbsp;&nbsp;&nbsp;";
-                    } else {
-                        $content .= " ";
-                    }
-                }
-                $content .= '<span class="methodparam">';
-                ++$this->params["count"];
-                if (isset($attrs[Reader::XMLNS_DOCBOOK]["rep"]) && $attrs[Reader::XMLNS_DOCBOOK]["rep"] == "repeat") {
-                    $this->params["ellipsis"] = '...';
-                } else {
-                    $this->params["ellipsis"] = '';
-                }
-                return $content;
+            }
+            $content .= '<span class="methodparam">';
+            ++$this->params["count"];
+            if (isset($attrs[Reader::XMLNS_DOCBOOK]["rep"]) && $attrs[Reader::XMLNS_DOCBOOK]["rep"] == "repeat") {
+                $this->params["ellipsis"] = '...';
+            } else {
+                $this->params["ellipsis"] = '';
+            }
+            return $content;
         }
         if ($this->params["opt"] && !$this->params["init"]) {
             return '<span class="initializer"> = ?</span></span>';
@@ -1474,42 +1581,49 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return "</span>";
     }
 
-    public function format_methodname($open, $name, $attr) {
+    public function format_methodname($open, $name, $attr)
+    {
         if ($open) {
-            return ' <span class="' .$name. '">';
+            return ' <span class="' . $name . '">';
         }
         return '</span>';
     }
 
-    public function format_varname($open, $name, $attrs) {
+    public function format_varname($open, $name, $attrs)
+    {
         if ($open) {
-            return '<var class="'.$name.'">$';
+            return '<var class="' . $name . '">$';
         }
         return "</var>";
     }
-    public function format_fieldsynopsis_varname($open, $name, $attrs) {
+
+    public function format_fieldsynopsis_varname($open, $name, $attrs)
+    {
         if ($open) {
             if ($this->cchunk["fieldsynopsis"]["modifier"] === "const") {
                 return '<var class="fieldsynopsis_varname">';
             }
-            return '<var class="'.$name.'">$';
+            return '<var class="' . $name . '">$';
         }
         return '</var>';
     }
 
-    public function format_footnoteref($open, $name, $attrs, $props) {
+    public function format_footnoteref($open, $name, $attrs, $props)
+    {
         if ($open) {
             $linkend = $attrs[Reader::XMLNS_DOCBOOK]["linkend"];
-            foreach($this->cchunk["footnote"] as $k => $note) {
+            foreach ($this->cchunk["footnote"] as $k => $note) {
                 if ($note["id"] === $linkend) {
-                    return '<a href="#fnid' .$note["id"]. '"><sup>[' .($k + 1). ']</sup></a>';
+                    return '<a href="#fnid' . $note["id"] . '"><sup>[' . ($k + 1) . ']</sup></a>';
                 }
             }
             trigger_error("footnoteref ID '$linkend' not found", E_USER_WARNING);
             return "";
         }
     }
-    public function format_footnote($open, $name, $attrs, $props) {
+
+    public function format_footnote($open, $name, $attrs, $props)
+    {
         if ($open) {
             $count = count($this->cchunk["footnote"]);
             $noteid = isset($attrs[Reader::XMLNS_XML]["id"]) ? $attrs[Reader::XMLNS_XML]["id"] : $count + 1;
@@ -1518,23 +1632,28 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if ($this->cchunk["table"]) {
                 $this->cchunk["tablefootnotes"][$count] = $noteid;
             }
-            return '<a href="#fnid' .$noteid. '" name="fn'.$noteid.'"><sup>[' .($count + 1). ']</sup></a>';
+            return '<a href="#fnid' . $noteid . '" name="fn' . $noteid . '"><sup>[' . ($count + 1) . ']</sup></a>';
         }
         return "";
     }
 
     /* {{{ FIXME: These are crazy workarounds :( */
-    public function format_footnote_constant($open, $name, $attrs, $props) {
+    public function format_footnote_constant($open, $name, $attrs, $props)
+    {
         $k = count($this->cchunk["footnote"]) - 1;
         $this->cchunk["footnote"][$k]["str"] .= self::format_constant($open, $name, $attrs, $props);
         return "";
     }
-    public function format_footnote_constant_text($value, $tag) {
+
+    public function format_footnote_constant_text($value, $tag)
+    {
         $k = count($this->cchunk["footnote"]) - 1;
         $this->cchunk["footnote"][$k]["str"] .= $value;
         return "";
     }
-    public function format_footnote_para($open, $name, $attrs, $props) {
+
+    public function format_footnote_para($open, $name, $attrs, $props)
+    {
         $k = count($this->cchunk["footnote"]) - 1;
         if ($open) {
             $this->cchunk["footnote"][$k]["str"] .= '<span class="para footnote">';
@@ -1544,7 +1663,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $this->cchunk["footnote"][$k]["str"] .= "</span>";
         return "";
     }
-    public function format_footnote_para_text($value, $tag) {
+
+    public function format_footnote_para_text($value, $tag)
+    {
         $k = count($this->cchunk["footnote"]) - 1;
         $this->cchunk["footnote"][$k]["str"] .= $value;
         return "";
@@ -1552,53 +1673,65 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     /* }}} */
 
-    public function format_co($open, $name, $attrs, $props) {
+    public function format_co($open, $name, $attrs, $props)
+    {
         if (($open || $props["empty"]) && isset($attrs[Reader::XMLNS_XML]["id"])) {
             $co = ++$this->cchunk["co"];
-            return '<a name="'.$attrs[Reader::XMLNS_XML]["id"].'" id="'.$attrs[Reader::XMLNS_XML]["id"].'">' .str_repeat("*", $co) .'</a>';
+            return '<a name="' . $attrs[Reader::XMLNS_XML]["id"] . '" id="' . $attrs[Reader::XMLNS_XML]["id"] . '">' . str_repeat("*", $co) . '</a>';
         }
         /* Suppress closing tag if any */
         return "";
     }
-    public function format_calloutlist($open, $name, $attrs) {
+
+    public function format_calloutlist($open, $name, $attrs)
+    {
         if ($open) {
             $this->cchunk["callouts"] = 0;
             return '<table>';
         }
         return '</table>';
     }
-    public function format_callout($open, $name, $attrs) {
+
+    public function format_callout($open, $name, $attrs)
+    {
         if ($open) {
-            return '<tr><td><a href="#'.$attrs[Reader::XMLNS_DOCBOOK]["arearefs"].'">' .str_repeat("*", ++$this->cchunk["callouts"]). '</a></td><td>';
+            return '<tr><td><a href="#' . $attrs[Reader::XMLNS_DOCBOOK]["arearefs"] . '">' . str_repeat("*", ++$this->cchunk["callouts"]) . '</a></td><td>';
         }
         return "</td></tr>\n";
     }
 
-    public function format_manvolnum($open, $name, $attrs) {
+    public function format_manvolnum($open, $name, $attrs)
+    {
         if ($open) {
-            return '<span class="'.$name.'">(';
+            return '<span class="' . $name . '">(';
         }
         return ")</span>";
     }
-    public function format_segmentedlist($open, $name, $attrs) {
+
+    public function format_segmentedlist($open, $name, $attrs)
+    {
         $this->cchunk["segmentedlist"] = $this->dchunk["segmentedlist"];
         if ($open) {
-            return '<table class="'.$name.'">';
+            return '<table class="' . $name . '">';
         }
         return '</tbody></table>';
     }
-    public function format_segtitle_text($value, $tag) {
+
+    public function format_segtitle_text($value, $tag)
+    {
         $html = '';
         if (!$this->cchunk["segmentedlist"]["segtitleopened"]) {
             $html .= '<thead><tr>';
         }
-        $html .= '<th>'.$this->TEXT($value).'</th>';
+        $html .= '<th>' . $this->TEXT($value) . '</th>';
         $this->cchunk["segmentedlist"]["segtitleopened"] = true;
 
         // Don't close the row; we'll have to do that in the first seglistitem.
         return $html;
     }
-    public function format_seglistitem($open, $name, $attrs) {
+
+    public function format_seglistitem($open, $name, $attrs)
+    {
         if ($open) {
             $html = '';
 
@@ -1607,25 +1740,31 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 $this->cchunk["segmentedlist"]["segtitleclosed"] = true;
             }
 
-            $html .= '<tr class="'.$name.'">';
+            $html .= '<tr class="' . $name . '">';
             return $html;
         }
         return '</tr>';
     }
-    public function format_seg($open, $name, $attrs) {
+
+    public function format_seg($open, $name, $attrs)
+    {
         if ($open) {
             return '<td class="seg">';
         }
         return '</td>';
     }
-    public function format_procedure($open, $name, $attrs) {
+
+    public function format_procedure($open, $name, $attrs)
+    {
         $this->cchunk["procedure"] = false;
         if ($open) {
-            return '<div class="'.$name.'">';
+            return '<div class="' . $name . '">';
         }
         return '</ol></div>';
     }
-    public function format_step($open, $name, $attrs) {
+
+    public function format_step($open, $name, $attrs)
+    {
         if ($open) {
             $ret = "";
             if ($this->cchunk["procedure"] === false) {
@@ -1636,7 +1775,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return '</li>';
     }
-    public function format_variablelist($open, $name, $attrs, $props) {
+
+    public function format_variablelist($open, $name, $attrs, $props)
+    {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
                 $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"]);
@@ -1663,7 +1804,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $this->popRole();
         return "</" . $tagName . ">";
     }
-    public function format_varlistentry($open, $name, $attrs) {
+
+    public function format_varlistentry($open, $name, $attrs)
+    {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $this->cchunk['varlistentry']['id'] = $attrs[Reader::XMLNS_XML]["id"];
@@ -1674,7 +1817,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return ($this->getRole() === 'constant_list') ? '</tr>' : '';
     }
-    public function format_varlistentry_term($open, $name, $attrs, $props) {
+
+    public function format_varlistentry_term($open, $name, $attrs, $props)
+    {
         $tagName = ($this->getRole() === 'constant_list') ? 'td' : 'dt';
         if ($open) {
             if (isset($this->cchunk['varlistentry']['id'])) {
@@ -1687,53 +1832,67 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return "</" . $tagName . ">";
     }
-    public function format_varlistentry_listitem($open, $name, $attrs) {
+
+    public function format_varlistentry_listitem($open, $name, $attrs)
+    {
         $tagName = ($this->getRole() === 'constant_list') ? 'td' : 'dd';
         if ($open) {
             return "<" . $tagName . ">";
         }
         return "</" . $tagName . ">";
     }
-    public function format_term($open, $name, $attrs, $props) {
+
+    public function format_term($open, $name, $attrs, $props)
+    {
         if ($open) {
             if ($props["sibling"] == $name) {
-                return '<br /><span class="' .$name. '">';
+                return '<br /><span class="' . $name . '">';
             }
-            return '<span class="' .$name. '">';
+            return '<span class="' . $name . '">';
         }
         return "</span>";
     }
-    public function format_trademark($open, $name, $attrs, $props) {
+
+    public function format_trademark($open, $name, $attrs, $props)
+    {
         if ($open) {
-            return '<span class=' .$name. '">';
+            return '<span class=' . $name . '">';
         }
         return '®</span>';
     }
-    public function format_userinput($open, $name, $attrs) {
+
+    public function format_userinput($open, $name, $attrs)
+    {
         if ($open) {
-            return '<strong class="' .$name. '"><code>';
+            return '<strong class="' . $name . '"><code>';
         }
         return "</code></strong>";
     }
-    public function format_systemitem($open, $name, $attrs) {
+
+    public function format_systemitem($open, $name, $attrs)
+    {
         if ($open) {
             $val = isset($attrs[Reader::XMLNS_DOCBOOK]["role"]) ? $attrs[Reader::XMLNS_DOCBOOK]["role"] : null;
-            switch($val) {
-            case "directive":
-            /* FIXME: Different roles should probably be handled differently */
-            default:
-                return '<code class="systemitem ' .$name. '">';
+            switch ($val) {
+                case "directive":
+                    /* FIXME: Different roles should probably be handled differently */
+                default:
+                    return '<code class="systemitem ' . $name . '">';
             }
         }
         return "</code>";
     }
-    public function format_example_content($open, $name, $attrs) {
+
+    public function format_example_content($open, $name, $attrs)
+    {
         if ($open) {
             return '<div class="example-contents"><p>';
         }
         return "</p></div>";
     }
-    public function format_programlisting($open, $name, $attrs) {
+
+    public function format_programlisting($open, $name, $attrs)
+    {
         $hasAnnotations = array_key_exists('annotations', $attrs[Reader::XMLNS_DOCBOOK]);
         if ($open) {
             $this->pushRole($attrs[Reader::XMLNS_DOCBOOK]["role"] ?? null);
@@ -1748,10 +1907,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $this->popRole();
         return "</div>\n";
     }
-    public function format_programlisting_text($value, $tag) {
+
+    public function format_programlisting_text($value, $tag)
+    {
         return $this->CDATA($value);
     }
-    public function format_screen($open, $name, $attrs) {
+
+    public function format_screen($open, $name, $attrs)
+    {
         if ($open) {
             if ($this->getRole() !== "examples"
                 && $this->getRole() !== "description"
@@ -1760,7 +1923,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 && $this->getRole() !== "parameters") {
                 $this->pushRole('');
             }
-            return '<div class="example-contents ' .$name. '">';
+            return '<div class="example-contents ' . $name . '">';
         }
         if ($this->getRole() !== "examples"
             && $this->getRole() !== "description"
@@ -1771,6 +1934,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return '</div>';
     }
+
     public function format_constant($open, $name, $attrs, $props)
     {
         if ($open) {
@@ -1810,16 +1974,17 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
      * This works only with one set of <replaceable> tags in a constant
      * e.g. CURLE_<replaceable>*</replaceable> or DOM_<replaceable>*</replaceable>_NODE
      */
-    private function createReplaceableConstantLink(string $constant): string {
+    private function createReplaceableConstantLink(string $constant): string
+    {
         $pattern = "/" . preg_replace(
-            "/<replaceable.*<\/replaceable>/",
-            ".*",
-            str_replace(
-                ".",
-                "\.",
-                $this->convertConstantNameToId($constant)
-            )
-        ) ."/";
+                "/<replaceable.*<\/replaceable>/",
+                ".*",
+                str_replace(
+                    ".",
+                    "\.",
+                    $this->convertConstantNameToId($constant)
+                )
+            ) . "/";
 
         $matchingConstantId = "";
         foreach ($this->indexes as $index) {
@@ -1832,7 +1997,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $matchingConstantId === "" ? "" : $this->createLink($matchingConstantId);
     }
 
-    private function convertConstantNameToId(string $constantName): string {
+    private function convertConstantNameToId(string $constantName): string
+    {
         $tempLinkValue = str_replace(
             array("\\", "_"),
             array("-", "-"),
@@ -1850,7 +2016,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $normalizedLinkFormat;
     }
 
-    public function format_constant_text($value, $tag) {
+    public function format_constant_text($value, $tag)
+    {
         if ($this->getRole() === "constant_group") {
             return "";
         }
@@ -1865,15 +2032,18 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
         return '<a href="' . $link . '">' . $value . '</a>';
     }
-    public function format_replaceable($open, $name, $attrs, $props) {
+
+    public function format_replaceable($open, $name, $attrs, $props)
+    {
         if ($this->getRole() === "constant_group") {
             return "";
         }
         return false;
     }
 
-    public function format_property_text($value, $tag) {
-        if (! str_contains($value, '::')) {
+    public function format_property_text($value, $tag)
+    {
+        if (!str_contains($value, '::')) {
             return $value;
         }
 
@@ -1895,41 +2065,51 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '<a href="' . $link . '">' . $value . '</a>';
     }
 
-    protected function normalizeFQN(string $fqn): string {
+    protected function normalizeFQN(string $fqn): string
+    {
         return \ltrim(\strtolower($fqn), "\\");
     }
 
     public function admonition_title($title, $lang)
     {
-        return '<strong class="' .(strtolower($title)). '">' .($this->autogen($title, $lang)). '</strong>';
+        return '<strong class="' . (strtolower($title)) . '">' . ($this->autogen($title, $lang)) . '</strong>';
     }
-    public function format_admonition($open, $name, $attrs, $props) {
+
+    public function format_admonition($open, $name, $attrs, $props)
+    {
         if ($open) {
-            return '<div class="'. $name. '">' .$this->admonition_title($name, $props["lang"]);
+            return '<div class="' . $name . '">' . $this->admonition_title($name, $props["lang"]);
         }
         return "</div>";
     }
-    public function format_authorgroup_author($open, $name, $attrs, $props) {
+
+    public function format_authorgroup_author($open, $name, $attrs, $props)
+    {
         if ($open) {
             if ($props["sibling"] !== $name) {
-                return '<div class="'.$name.' vcard">' .$this->admonition_title("by", $props["lang"]). ':<br />';
+                return '<div class="' . $name . ' vcard">' . $this->admonition_title("by", $props["lang"]) . ':<br />';
             }
-            return '<div class="'.$name.' vcard">';
+            return '<div class="' . $name . ' vcard">';
         }
         return "</div>\n";
     }
-    public function format_editor($open, $name, $attrs, $props) {
+
+    public function format_editor($open, $name, $attrs, $props)
+    {
         if ($open) {
-            return '<div class="editor vcard">' .$this->admonition_title("editedby", $props["lang"]). ': ';
+            return '<div class="editor vcard">' . $this->admonition_title("editedby", $props["lang"]) . ': ';
         }
         return "</div>\n";
     }
-    public function format_note($open, $name, $attrs, $props) {
+
+    public function format_note($open, $name, $attrs, $props)
+    {
         if ($open) {
-            return '<blockquote class="note"><p>'.$this->admonition_title("note", $props["lang"]). ': ';
+            return '<blockquote class="note"><p>' . $this->admonition_title("note", $props["lang"]) . ': ';
         }
         return "</p></blockquote>";
     }
+
     public function format_note_title($open, $name, $attrs)
     {
         if ($open) {
@@ -1937,7 +2117,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return '</strong><br />';
     }
-    public function format_example($open, $name, $attrs, $props) {
+
+    public function format_example($open, $name, $attrs, $props)
+    {
         if ($open) {
             ++$this->exampleCounter;
             if (isset($props["id"])) {
@@ -1947,6 +2129,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return '</div>';
     }
+
     public function format_example_title($open, $name, $attrs, $props)
     {
         if ($props["empty"]) {
@@ -1954,10 +2137,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         if ($open) {
             return "<p><strong>" . ($this->autogen('example', $props['lang'])
-                . (isset($this->cchunk["examples"]) ? ++$this->cchunk["examples"] : "")) . " ";
+                    . (isset($this->cchunk["examples"]) ? ++$this->cchunk["examples"] : "")) . " ";
         }
         return "</strong></p>";
     }
+
     public function format_table_title($open, $name, $attrs, $props)
     {
         if ($props["empty"]) {
@@ -1968,34 +2152,41 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return "</strong></caption>";
     }
-    public function format_variablelist_title($open, $name, $attrs, $props) {
+
+    public function format_variablelist_title($open, $name, $attrs, $props)
+    {
         if ($open) {
             return ($this->getRole() === 'constant_list') ? "<caption><strong>" : "<strong>";
         }
         return ($this->getRole() === 'constant_list') ? "</strong></caption>" : "</strong>";
     }
 
-    public function format_mediaobject($open, $name, $attrs) {
+    public function format_mediaobject($open, $name, $attrs)
+    {
         $this->cchunk["mediaobject"] = $this->dchunk["mediaobject"];
         if ($open) {
-            return '<div class="'.$name.'">';
+            return '<div class="' . $name . '">';
         }
         return '</div>';
     }
-    public function format_alt_text($value, $tag) {
+
+    public function format_alt_text($value, $tag)
+    {
         $this->cchunk["mediaobject"]["alt"] = $value;
     }
-    public function format_imagedata($open, $name, $attrs) {
-        $file    = $attrs[Reader::XMLNS_DOCBOOK]["fileref"];
+
+    public function format_imagedata($open, $name, $attrs)
+    {
+        $file = $attrs[Reader::XMLNS_DOCBOOK]["fileref"];
         if ($newpath = $this->mediamanager->handleFile($file)) {
             $curfile = $this->mediamanager->findFile($file);
-            $width   = isset($attrs[Reader::XMLNS_DOCBOOK]["width"]) ? 'width="' . $attrs[Reader::XMLNS_DOCBOOK]["width"] . '"' : '';
-            $height  = isset($attrs[Reader::XMLNS_DOCBOOK]["depth"]) ? 'height="' . $attrs[Reader::XMLNS_DOCBOOK]["depth"] . '"' : '';
-            $alt     = 'alt="' . ($this->cchunk["mediaobject"]["alt"] !== false ? $this->cchunk["mediaobject"]["alt"] : basename($file)) . '"';
+            $width = isset($attrs[Reader::XMLNS_DOCBOOK]["width"]) ? 'width="' . $attrs[Reader::XMLNS_DOCBOOK]["width"] . '"' : '';
+            $height = isset($attrs[Reader::XMLNS_DOCBOOK]["depth"]) ? 'height="' . $attrs[Reader::XMLNS_DOCBOOK]["depth"] . '"' : '';
+            $alt = 'alt="' . ($this->cchunk["mediaobject"]["alt"] !== false ? $this->cchunk["mediaobject"]["alt"] : basename($file)) . '"';
 
             // Generate height and width when none are supplied.
             if ($curfile && '' === $width . $height) {
-                list(,,,$dimensions,,,,) = getimagesize($curfile);
+                list(, , , $dimensions, , , ,) = getimagesize($curfile);
             } else {
                 $dimensions = $width . ' ' . $height;
             }
@@ -2014,7 +2205,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
     }
 
-    public function format_table($open, $name, $attrs, $props) {
+    public function format_table($open, $name, $attrs, $props)
+    {
         if ($open) {
             $this->cchunk["table"] = true;
             // Initialize an empty tgroup in case we never process such element
@@ -2023,20 +2215,20 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if (isset($attrs[Reader::XMLNS_XML]["id"])) {
                 $idstr = ' id="' . $attrs[Reader::XMLNS_XML]["id"] . '"';
             }
-            return '<table' . $idstr . ' class="doctable ' .$name. '">';
+            return '<table' . $idstr . ' class="doctable ' . $name . '">';
         }
         $this->cchunk["table"] = false;
         $str = "";
         if (isset($this->cchunk["tablefootnotes"]) && $this->cchunk["tablefootnotes"]) {
             $opts = array(Reader::XMLNS_DOCBOOK => array());
 
-            $str =  $this->format_tbody(true, "footnote", $opts);
+            $str = $this->format_tbody(true, "footnote", $opts);
             $str .= $this->format_row(true, "footnote", $opts);
-            $str .= $this->format_entry(true, "footnote", $opts, $props+array("colspan" => $this->getColCount()));
+            $str .= $this->format_entry(true, "footnote", $opts, $props + array("colspan" => $this->getColCount()));
 
             foreach ($this->cchunk["tablefootnotes"] as $k => $noteid) {
                 $str .= '<div class="footnote">';
-                $str .= '<a name="fnid' .$noteid. '" href="#fn' .$noteid .'"><sup>[' .($k + 1). ']</sup></a>' .$this->cchunk["footnote"][$k]["str"];
+                $str .= '<a name="fnid' . $noteid . '" href="#fn' . $noteid . '"><sup>[' . ($k + 1) . ']</sup></a>' . $this->cchunk["footnote"][$k]["str"];
                 unset($this->cchunk["footnote"][$k]);
                 $str .= "</div>\n";
 
@@ -2049,7 +2241,9 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
         return "$str</table>\n";
     }
-    public function format_tgroup($open, $name, $attrs) {
+
+    public function format_tgroup($open, $name, $attrs)
+    {
         if ($open) {
             Format::tgroup($attrs[Reader::XMLNS_DOCBOOK]);
             return '';
@@ -2059,7 +2253,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
     private static function parse_table_entry_attributes($attrs)
     {
-        $style  = array();
+        $style = array();
         $retval = '';
         if (!empty($attrs['align'])) {
             if ('char' != $attrs['align']) {
@@ -2068,10 +2262,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                 // There's no analogue in CSS, but as this stuff isn't supported
                 // in any browser, it is unlikely to appear in DocBook anyway
                 $retval .= ' align="char" char="'
-                           . htmlspecialchars($attrs["char"], ENT_QUOTES) . '"';
+                    . htmlspecialchars($attrs["char"], ENT_QUOTES) . '"';
                 if (isset($attrs['charoff'])) {
                     $retval .= ' charoff="'
-                               . htmlspecialchars($attrs["charoff"], ENT_QUOTES) . '"';
+                        . htmlspecialchars($attrs["charoff"], ENT_QUOTES) . '"';
                 }
             }
         }
@@ -2105,7 +2299,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]['valign'])) {
                 return '<' . $name . ' style="vertical-align: '
-                       . $attrs[Reader::XMLNS_DOCBOOK]['valign'] . ';">';
+                    . $attrs[Reader::XMLNS_DOCBOOK]['valign'] . ';">';
             } else {
                 return '<' . $name . '>';
             }
@@ -2118,7 +2312,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($open) {
             if (isset($attrs[Reader::XMLNS_DOCBOOK]['valign'])) {
                 return '<tbody class="' . $name . '" style="vertical-align: '
-                       . $attrs[Reader::XMLNS_DOCBOOK]['valign'] . ';">';
+                    . $attrs[Reader::XMLNS_DOCBOOK]['valign'] . ';">';
             } else {
                 return '<tbody class="' . $name . '">';
             }
@@ -2131,12 +2325,12 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         if ($open) {
             $idstr = '';
             if (isset($attrs[Reader::XMLNS_XML]['id'])) {
-                $idstr = ' id="'. $attrs[Reader::XMLNS_XML]['id']. '"';
+                $idstr = ' id="' . $attrs[Reader::XMLNS_XML]['id'] . '"';
             }
             Format::initRow();
             if (isset($attrs[Reader::XMLNS_DOCBOOK]['valign'])) {
                 return '<tr' . $idstr . ' style="vertical-align: '
-                       . $attrs[Reader::XMLNS_DOCBOOK]['valign'] . ';">';
+                    . $attrs[Reader::XMLNS_DOCBOOK]['valign'] . ';">';
             } else {
                 return '<tr' . $idstr . '>';
             }
@@ -2144,7 +2338,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return "</tr>\n";
     }
 
-    public function format_th_entry($open, $name, $attrs, $props) {
+    public function format_th_entry($open, $name, $attrs, $props)
+    {
         if ($props["empty"]) {
             return '<th class="empty">&nbsp;</th>';
         }
@@ -2153,12 +2348,14 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             if ($colspan == 1) {
                 return '<th>';
             } else {
-                return '<th colspan="' .((int)$colspan). '">';
+                return '<th colspan="' . ((int)$colspan) . '">';
             }
         }
         return '</th>';
     }
-    public function format_entry($open, $name, $attrs, $props) {
+
+    public function format_entry($open, $name, $attrs, $props)
+    {
         if ($props["empty"]) {
             return '<td class="empty">&nbsp;</td>';
         }
@@ -2167,7 +2364,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
             $retval = "";
             if (isset($dbattrs["colname"])) {
-                for($i=Format::getEntryOffset($dbattrs); $i>0; --$i) {
+                for ($i = Format::getEntryOffset($dbattrs); $i > 0; --$i) {
                     $retval .= '<td class="empty">&nbsp;</td>';
                 }
             }
@@ -2185,16 +2382,18 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             $rowspan = Format::rowspan($dbattrs);
             $moreattrs = self::parse_table_entry_attributes($dbattrs);
 
-            $sColspan = $colspan == 1 ? '' : ' colspan="' .((int)$colspan) . '"';
-            $sRowspan = $rowspan == 1 ? '' : ' rowspan="' .((int)$rowspan). '"';
-            return $retval. '<td' . $sColspan . $sRowspan . $moreattrs. '>';
+            $sColspan = $colspan == 1 ? '' : ' colspan="' . ((int)$colspan) . '"';
+            $sRowspan = $rowspan == 1 ? '' : ' rowspan="' . ((int)$rowspan) . '"';
+            return $retval . '<td' . $sColspan . $sRowspan . $moreattrs . '>';
         }
         return "</td>";
     }
-    public function format_qandaset($open, $name, $attrs, $props) {
+
+    public function format_qandaset($open, $name, $attrs, $props)
+    {
         if ($open) {
             $xml = "<qandaset>" . $props["innerXml"] . "</qandaset>";
-            $doc = new \DOMDocument;
+            $doc = new \DOMDocument();
             $doc->loadXml($xml);
 
             $xp = new \DOMXPath($doc);
@@ -2203,7 +2402,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             $questions = $xp->query("//db:qandaentry/db:question");
 
             $retval = '<div class="qandaset"><ol class="qandaset_questions">';
-            foreach($questions as $node) {
+            foreach ($questions as $node) {
                 $id = $xp->evaluate("ancestor::db:qandaentry", $node)->item(0)->getAttributeNs(Reader::XMLNS_XML, "id");
 
                 /* FIXME: No ID? How can we create an anchor for it then? */
@@ -2211,34 +2410,40 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
                     $id = uniqid("phd");
                 }
 
-                $retval .= '<li><a href="#'.$id.'">'.htmlentities($node->textContent, ENT_QUOTES, "UTF-8").'</a></li>';
+                $retval .= '<li><a href="#' . $id . '">' . htmlentities($node->textContent, ENT_QUOTES, "UTF-8") . '</a></li>';
             }
             $retval .= "</ol></div>";
             return $retval;
         }
     }
-    public function format_question($open, $name, $attrs, $props) {
+
+    public function format_question($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '<dt><strong>';
         }
         return '</strong></dt>';
     }
-    public function format_phd_question($open, $name, $attrs, $props) {
+
+    public function format_phd_question($open, $name, $attrs, $props)
+    {
         if ($open) {
             $href = $this->createLink($attrs[Reader::XMLNS_XML]["id"]);
-            return '<li><a href="' .$href. '">';
+            return '<li><a href="' . $href . '">';
         }
         return '</a></li>';
     }
 
-    public function format_citation($open, $name, $attrs, $props) {
+    public function format_citation($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '[<span class="citation">';
         }
         return '</span>]';
     }
 
-    public function format_email_text($value) {
+    public function format_email_text($value)
+    {
         return '&lt;<a href="mailto:' . $value . '">' . $value . '</a>&gt;';
     }
 
@@ -2253,49 +2458,53 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return "</strong></p>";
     }
 
-   /**
-    * Functions from the old XHTMLPhDFormat
-    */
-    public function format_legalnotice_chunk($open, $name, $attrs) {
+    /**
+     * Functions from the old XHTMLPhDFormat
+     */
+    public function format_legalnotice_chunk($open, $name, $attrs)
+    {
         if ($open) {
             return '<div id="legalnotice">';
         }
         return "</div>\n";
     }
 
-    public function format_div($open, $name, $attrs, $props) {
+    public function format_div($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '<div class="' . $name . '">';
         }
         return '</div>';
     }
 
-    public function format_screen_text($value, $tag) {
+    public function format_screen_text($value, $tag)
+    {
         return nl2br($this->TEXT($value));
     }
 
     /**
-    * Renders  a <tag class=""> tag.
-    *
-    * @return string HTML code
-    */
-    public function format_tag($open, $name, $attrs, $props) {
+     * Renders  a <tag class=""> tag.
+     *
+     * @return string HTML code
+     */
+    public function format_tag($open, $name, $attrs, $props)
+    {
         static $arFixes = array(
-            'attribute'     => array('', ''),
-            'attvalue'      => array('"', '"'),
-            'comment'       => array('&lt;!--', '--&gt;'),
-            'element'       => array('', ''),
-            'emptytag'      => array('&lt;', '/&gt;'),
-            'endtag'        => array('&lt;/', '&gt;'),
-            'genentity'     => array('&amp;', ';'),
-            'localname'     => array('', ''),
-            'namespace'     => array('', ''),
-            'numcharref'    => array('&amp;#', ';'),
-            'paramentity'   => array('%', ';'),
-            'pi'            => array('&lt;?', '?&gt;'),
-            'prefix'        => array('', ''),
-            'starttag'      => array('&lt;', '&gt;'),
-            'xmlpi'         => array('&lt;?', '?&gt;'),
+            'attribute' => array('', ''),
+            'attvalue' => array('"', '"'),
+            'comment' => array('&lt;!--', '--&gt;'),
+            'element' => array('', ''),
+            'emptytag' => array('&lt;', '/&gt;'),
+            'endtag' => array('&lt;/', '&gt;'),
+            'genentity' => array('&amp;', ';'),
+            'localname' => array('', ''),
+            'namespace' => array('', ''),
+            'numcharref' => array('&amp;#', ';'),
+            'paramentity' => array('%', ';'),
+            'pi' => array('&lt;?', '?&gt;'),
+            'prefix' => array('', ''),
+            'starttag' => array('&lt;', '&gt;'),
+            'xmlpi' => array('&lt;?', '?&gt;'),
         );
         if ($props['empty']) {
             return '';
@@ -2317,21 +2526,24 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '<code>' . $arFixes[$class][0];
     }
 
-    public function format_dl($open, $name, $attrs, $props) {
+    public function format_dl($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '<dl class="' . $name . '">';
         }
         return '</dl>';
     }
 
-    public function format_itemizedlist($open, $name, $attrs, $props) {
+    public function format_itemizedlist($open, $name, $attrs, $props)
+    {
         if ($open) {
             return '<ul class="' . $name . '">';
         }
         return '</ul>';
     }
 
-    public function format_simplelist($open, $name, $attrs, $props) {
+    public function format_simplelist($open, $name, $attrs, $props)
+    {
         if ($open) {
             $this->cchunk["simplelist"]["type"] = $attrs[Reader::XMLNS_DOCBOOK]["type"] ?? "";
             $this->cchunk["simplelist"]["columns"] = $attrs[Reader::XMLNS_DOCBOOK]["columns"] ?? 1;
@@ -2354,13 +2566,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
 
         $list = match ($this->cchunk["simplelist"]["type"]) {
             "inline" => $this->simplelist_format_inline(),
-            "horiz"  => $this->simplelist_format_horizontal($props["depth"])
-                        . $this->indent($props["depth"] + 1) . "</tbody>\n"
-                        . $this->indent($props["depth"]) . "</table>",
-            "vert"   => $this->simplelist_format_vertical($props["depth"])
-                        . $this->indent($props["depth"] + 1) . "</tbody>\n"
-                        . $this->indent($props["depth"]) . "</table>",
-            default  => "</ul>",
+            "horiz" => $this->simplelist_format_horizontal($props["depth"])
+                . $this->indent($props["depth"] + 1) . "</tbody>\n"
+                . $this->indent($props["depth"]) . "</table>",
+            "vert" => $this->simplelist_format_vertical($props["depth"])
+                . $this->indent($props["depth"] + 1) . "</tbody>\n"
+                . $this->indent($props["depth"]) . "</table>",
+            default => "</ul>",
         };
 
         $this->cchunk["simplelist"] = $this->dchunk["simplelist"];
@@ -2368,15 +2580,18 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $list;
     }
 
-    private function indent($depth): string {
+    private function indent($depth): string
+    {
         return $depth > 0 ? str_repeat(' ', $depth) : '';
     }
 
-    private function simplelist_format_inline() {
+    private function simplelist_format_inline()
+    {
         return implode(", ", $this->cchunk["simplelist"]["members"]) . '</span>';
     }
 
-    private function simplelist_format_horizontal($depth) {
+    private function simplelist_format_horizontal($depth)
+    {
         return $this->chunkReduceTable(
             $this->processTabular(
                 $this->cchunk["simplelist"]["members"],
@@ -2392,13 +2607,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     {
         $trPadding = $this->indent($depth + 2);
         return array_reduce(
-                array_chunk(
-                    $members,
-                    $cols,
-                ),
-                fn (string $carry, array $entry) => $carry . $trPadding . "<tr>\n" . implode('', $entry) . $trPadding . "</tr>\n",
-                ''
-            );
+            array_chunk(
+                $members,
+                $cols,
+            ),
+            fn(string $carry, array $entry) => $carry . $trPadding . "<tr>\n" . implode('', $entry) . $trPadding . "</tr>\n",
+            ''
+        );
     }
 
     /** Pads $members so that number of members = columns x rows */
@@ -2406,7 +2621,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     {
         $tdPadding = $this->indent($depth + 3);
         return array_map(
-            fn (string $member) => $tdPadding . "<td>$member</td>\n",
+            fn(string $member) => $tdPadding . "<td>$member</td>\n",
             /** The padding is done by getting the additive modular inverse which is
              * ``-\count($members) % $cols`` but because PHP gives us the mod in negative we need to
              * add $cols back to get the positive
@@ -2415,7 +2630,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         );
     }
 
-    private function simplelist_format_vertical($depth) {
+    private function simplelist_format_vertical($depth)
+    {
         $members = $this->processTabular(
             $this->cchunk["simplelist"]["members"],
             $this->cchunk["simplelist"]["columns"],
@@ -2424,17 +2640,18 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         // Sort elements so that we get each correct element for the rows to display vertically
         uksort(
             $members,
-            fn (int $l, int $r) => $l % $this->cchunk["simplelist"]["columns"] <=> $r % $this->cchunk["simplelist"]["columns"]
+            fn(int $l, int $r) => $l % $this->cchunk["simplelist"]["columns"] <=> $r % $this->cchunk["simplelist"]["columns"]
         );
         return $this->chunkReduceTable($members, $this->cchunk["simplelist"]["columns"], $depth);
     }
 
-    public function format_member($open, $name, $attrs, $props) {
+    public function format_member($open, $name, $attrs, $props)
+    {
         if ($this->cchunk["simplelist"]["type"] === "inline"
             || $this->cchunk["simplelist"]["type"] === "vert"
             || $this->cchunk["simplelist"]["type"] === "horiz") {
             $this->appendToBuffer = $open;
-            if (! $open) {
+            if (!$open) {
                 $this->cchunk["simplelist"]["members"][] = $this->buffer;
             }
             $this->buffer = '';
@@ -2446,36 +2663,39 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</li>';
     }
 
-    public function format_member_text($value, $tag) {
+    public function format_member_text($value, $tag)
+    {
         return $value;
     }
 
-    public function format_orderedlist($open, $name, $attrs, $props) {
+    public function format_orderedlist($open, $name, $attrs, $props)
+    {
         if ($open) {
             $numeration = "1";
             if (isset($attrs[Reader::XMLNS_DOCBOOK]["numeration"])) {
-                switch($attrs[Reader::XMLNS_DOCBOOK]["numeration"]) {
-                case "upperalpha":
-                    $numeration = "A";
-                    break;
-                case "loweralpha":
-                    $numeration = "a";
-                    break;
-                case "upperroman":
-                    $numeration = "I";
-                    break;
-                case "lowerroman":
-                    $numeration = "i";
-                    break;
+                switch ($attrs[Reader::XMLNS_DOCBOOK]["numeration"]) {
+                    case "upperalpha":
+                        $numeration = "A";
+                        break;
+                    case "loweralpha":
+                        $numeration = "a";
+                        break;
+                    case "upperroman":
+                        $numeration = "I";
+                        break;
+                    case "lowerroman":
+                        $numeration = "i";
+                        break;
                 }
             }
-            return '<ol type="' .$numeration. '">';
+            return '<ol type="' . $numeration . '">';
         }
         return '</ol>';
     }
 
     /* Support for key inputs is coded like junk */
-    public function format_keycap($open, $name, $attrs, $props) {
+    public function format_keycap($open, $name, $attrs, $props)
+    {
         if ($open) {
             $content = '';
             if ($props['sibling']) {
@@ -2486,7 +2706,8 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</kbd>';
     }
 
-    public function format_keycombo($open, $name, $attrs, $props) {
+    public function format_keycombo($open, $name, $attrs, $props)
+    {
 
         if (isset($attrs[Reader::XMLNS_DOCBOOK]["action"])) {
             if ($attrs[Reader::XMLNS_DOCBOOK]["action"] !== "simul") {
@@ -2499,12 +2720,13 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</kbd>';
     }
 
-    public function format_whitespace($whitespace, $elementStack, $currentDepth) {
+    public function format_whitespace($whitespace, $elementStack, $currentDepth)
+    {
         /* The following if is to skip unnecessary whitespaces in the parameter list */
         if (
             in_array($elementStack[$currentDepth - 1], ['methodsynopsis', 'constructorsynopsis', 'destructorsynopsis'], true)
             && (in_array($elementStack[$currentDepth] ?? "", ["methodname", "methodparam", "type", "void"], true)
-            || count($elementStack) === $currentDepth)
+                || count($elementStack) === $currentDepth)
         ) {
             return false;
         }
@@ -2530,7 +2752,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             && ($this->cchunk["simplelist"]["type"] === "inline"
                 || $this->cchunk["simplelist"]["type"] === "vert"
                 || $this->cchunk["simplelist"]["type"] === "horiz")
-            ) {
+        ) {
             return false;
         }
 
@@ -2545,14 +2767,15 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return $whitespace;
     }
 
-    public function format_caption($open, $name, $attrs, $props) {
+    public function format_caption($open, $name, $attrs, $props)
+    {
         return $open ? '<div class="caption">' : '</div>';
     }
 
     public function getGeneratedExampleID($index)
     {
         $originalId = parent::getGeneratedExampleID($index);
-        if (! $this->exampleCounterIsPerPage) {
+        if (!$this->exampleCounterIsPerPage) {
             return $originalId;
         }
         if (preg_match('/^example\-[0-9]+$/', $originalId)) {

--- a/phpdotnet/phd/Package/IDE/API.php
+++ b/phpdotnet/phd/Package/IDE/API.php
@@ -35,14 +35,14 @@ class Package_IDE_API
      *
      * @var string
      */
-    const FUNCTIONS_DIR = 'ide-xml';
+    public const FUNCTIONS_DIR = 'ide-xml';
 
     /**
      * Output file of the funclist format in the IDE Package.
      *
      * @var string
      */
-    const FUNCLIST_FILE = 'ide-funclist.txt';
+    public const FUNCLIST_FILE = 'ide-funclist.txt';
 
     /**
      * PhD output directory.

--- a/phpdotnet/phd/Package/IDE/Base.php
+++ b/phpdotnet/phd/Package/IDE/Base.php
@@ -1,55 +1,56 @@
 <?php
 namespace phpdotnet\phd;
 
-abstract class Package_IDE_Base extends Format {
+abstract class Package_IDE_Base extends Format
+{
     protected $elementmap = array(
-        'caution'               => 'format_notes',
-        'entry'                 => 'format_changelog_entry',
-        'function'              => 'format_seealso_entry',
-        'listitem'              => 'format_parameter_desc',
-        'methodparam'           => 'format_methodparam',
-        'methodname'            => 'format_seealso_entry',
-        'member'                => 'format_member',
-        'note'                  => 'format_notes',
-        'refentry'              => 'format_refentry',
-        'refpurpose'            => 'format_refpurpose',
-        'refnamediv'            => 'format_suppressed_tags',
-        'refsect1'              => 'format_refsect1',
-        'row'                   => 'format_changelog_row',
-        'set'                   => 'format_set',
-        'tbody'                 => 'format_changelog_tbody',
-        'tip'                   => 'format_notes',
-        'warning'               => 'format_notes',
+        'caution' => 'format_notes',
+        'entry' => 'format_changelog_entry',
+        'function' => 'format_seealso_entry',
+        'listitem' => 'format_parameter_desc',
+        'methodparam' => 'format_methodparam',
+        'methodname' => 'format_seealso_entry',
+        'member' => 'format_member',
+        'note' => 'format_notes',
+        'refentry' => 'format_refentry',
+        'refpurpose' => 'format_refpurpose',
+        'refnamediv' => 'format_suppressed_tags',
+        'refsect1' => 'format_refsect1',
+        'row' => 'format_changelog_row',
+        'set' => 'format_set',
+        'tbody' => 'format_changelog_tbody',
+        'tip' => 'format_notes',
+        'warning' => 'format_notes',
     );
-    protected $textmap    = array(
-        'function'              => 'format_seealso_entry_text',
-        'initializer'           => 'format_initializer_text',
-        'methodname'            => 'format_seealso_entry_text',
-        'parameter'             => 'format_parameter_text',
-        'refname'               => 'format_refname_text',
-        'title'                 => 'format_suppressed_text',
-        'type'                  => 'format_type_text',
+    protected $textmap = array(
+        'function' => 'format_seealso_entry_text',
+        'initializer' => 'format_initializer_text',
+        'methodname' => 'format_seealso_entry_text',
+        'parameter' => 'format_parameter_text',
+        'refname' => 'format_refname_text',
+        'title' => 'format_suppressed_text',
+        'type' => 'format_type_text',
     );
     protected $cchunk = array();
     protected $dchunk = array(
-        'function'              => array(),
-        'methodparam'           => false,
-        'param'                 => array(
-            'name'                  => false,
-            'type'                  => false,
-            'description'           => false,
-            'opt'                   => false,
-            'initializer'           => false,
+        'function' => array(),
+        'methodparam' => false,
+        'param' => array(
+            'name' => false,
+            'type' => false,
+            'description' => false,
+            'opt' => false,
+            'initializer' => false,
         ),
-        'seealso'               => array(
-            'name'                  => false,
-            'type'                  => false,
-            'description'           => false,
+        'seealso' => array(
+            'name' => false,
+            'type' => false,
+            'description' => false,
         ),
-        'changelog'             => array(
-            'entry'                 => false,
-            'version'               => false,
-            'change'                => false,
+        'changelog' => array(
+            'entry' => false,
+            'version' => false,
+            'change' => false,
         ),
     );
 
@@ -58,45 +59,64 @@ abstract class Package_IDE_Base extends Format {
     protected $role = false;
     protected $versions;
 
-    protected $function  = array();
+    protected $function = array();
     protected $dfunction = array(
-        'name'                  => null,
-        'purpose'               => null,
-        'manualid'              => null,
-        'version'               => null,
-        'params'                => array(),
-        'currentParam'          => null,
-        'return'                => array(
-            'type'              => null,
-            'description'       => null,
+        'name' => null,
+        'purpose' => null,
+        'manualid' => null,
+        'version' => null,
+        'params' => array(),
+        'currentParam' => null,
+        'return' => array(
+            'type' => null,
+            'description' => null,
         ),
-        'errors'                => null,
-        'notes'                 => array(),
-        'changelog'             => array(),
-        'seealso'               => array(),
+        'errors' => null,
+        'notes' => array(),
+        'changelog' => array(),
+        'seealso' => array(),
     );
-    
+
     private array $chunkFlags = [];
 
     public function __construct(
-        Config $config,
+        Config        $config,
         OutputHandler $outputHandler
-    ) {
+    )
+    {
         parent::__construct($config, $outputHandler);
     }
 
-    public function createLink($for, &$desc = null, $type = Format::SDESC) {}
-    public function UNDEF($open, $name, $attrs, $props) {}
-    public function TEXT($value) {}
-    public function CDATA($value) {}
-    public function transformFromMap($open, $tag, $name, $attrs, $props) {}
-    public function appendData($data) {}
+    public function createLink($for, &$desc = null, $type = Format::SDESC)
+    {
+    }
 
-    public abstract function parseFunction();
+    public function UNDEF($open, $name, $attrs, $props)
+    {
+    }
 
-    function writeChunk() {
+    public function TEXT($value)
+    {
+    }
+
+    public function CDATA($value)
+    {
+    }
+
+    public function transformFromMap($open, $tag, $name, $attrs, $props)
+    {
+    }
+
+    public function appendData($data)
+    {
+    }
+
+    abstract public function parseFunction();
+
+    public function writeChunk()
+    {
         if (!isset($this->cchunk['funcname'][0])) {
-             return;
+            return;
         }
         if (false !== strpos($this->cchunk['funcname'][0], ' ')) {
             return;
@@ -109,7 +129,7 @@ abstract class Package_IDE_Base extends Format {
         file_put_contents($filename, $data);
 
         $index = 0;
-        while(isset($this->cchunk['funcname'][++$index])) {
+        while (isset($this->cchunk['funcname'][++$index])) {
             $filename = $this->getOutputDir() . $this->cchunk['funcname'][$index] . $this->getExt();
             // Replace the default function name by the alternative one
             $content = preg_replace('/' . $this->cchunk['funcname'][0] . '/',
@@ -118,7 +138,8 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function renderHTML() {
+    public function renderHTML()
+    {
         static $format = null;
         if ($format == null) {
             $format = new Package_Generic_ChunkedXHTML(
@@ -129,63 +150,70 @@ abstract class Package_IDE_Base extends Format {
         return $format->parse(trim(ReaderKeeper::getReader()->readInnerXML()));
     }
 
-    public function CHUNK($value) {
+    public function CHUNK($value)
+    {
         $this->chunkFlags = $value;
     }
 
-    public function STANDALONE($value) {
+    public function STANDALONE($value)
+    {
         $this->registerElementMap($this->elementmap);
         $this->registerTextMap($this->textmap);
     }
 
-    public function INIT($value) {
+    public function INIT($value)
+    {
         $this->loadVersionInfo();
         $this->createOutputDirectory();
     }
 
-    public function FINALIZE($value) {
+    public function FINALIZE($value)
+    {
     }
 
-    public function VERBOSE($value) {
+    public function VERBOSE($value)
+    {
         $this->outputHandler->v('Starting %s rendering', $this->getFormatName(), VERBOSE_FORMAT_RENDERING);
     }
 
-    public function update($event, $value = null) {
-        switch($event) {
-        case Render::CHUNK:
-            $this->CHUNK($value);
-            break;
-        case Render::STANDALONE:
-            $this->STANDALONE($value);
-            break;
-        case Render::INIT:
-            $this->INIT($value);
-            break;
-        case Render::FINALIZE:
-            $this->FINALIZE($value);
-            break;
-        case Render::VERBOSE:
-            $this->VERBOSE($value);
-            break;
+    public function update($event, $value = null)
+    {
+        switch ($event) {
+            case Render::CHUNK:
+                $this->CHUNK($value);
+                break;
+            case Render::STANDALONE:
+                $this->STANDALONE($value);
+                break;
+            case Render::INIT:
+                $this->INIT($value);
+                break;
+            case Render::FINALIZE:
+                $this->FINALIZE($value);
+                break;
+            case Render::VERBOSE:
+                $this->VERBOSE($value);
+                break;
         }
     }
 
-    public static function generateVersionInfo($filename) {
+    public static function generateVersionInfo($filename)
+    {
         static $info;
         if ($info) {
             return $info;
         }
-        $r = new \XMLReader;
+        $r = new \XMLReader();
         if (!$r->open($filename)) {
-            throw new \Exception;
+            throw new \Exception();
         }
         $versions = array();
-        while($r->read()) {
+        while ($r->read()) {
             if (
                 $r->moveToAttribute('name')
                 && ($funcname = str_replace(
                     array('::', '->', '__', '_', '$'),
-                    array('-',  '-',  '-',  '-', ''),
+                    array('-', '-', '-', '-', ''),
                     $r->value))
                 && $r->moveToAttribute('from')
                 && ($from = $r->value)
@@ -199,19 +227,21 @@ abstract class Package_IDE_Base extends Format {
         return $versions;
     }
 
-    public function versionInfo($funcname) {
+    public function versionInfo($funcname)
+    {
         $funcname = str_replace(
-                array('.', '::', '-&gt;', '->', '__', '_', '$', '()'),
-                array('-', '-',  '-',     '-',  '-',  '-', '',  ''),
-                strtolower($funcname));
-        if(isset($this->versions[$funcname])) {
-           return $this->versions[$funcname];
+            array('.', '::', '-&gt;', '->', '__', '_', '$', '()'),
+            array('-', '-', '-', '-', '-', '-', '', ''),
+            strtolower($funcname));
+        if (isset($this->versions[$funcname])) {
+            return $this->versions[$funcname];
         }
         $this->outputHandler->v('No version info for %s', $funcname, VERBOSE_NOVERSION);
         return false;
     }
 
-    public function loadVersionInfo() {
+    public function loadVersionInfo()
+    {
         if (file_exists($this->config->phpwebVersionFilename)) {
             $this->versions = self::generateVersionInfo($this->config->phpwebVersionFilename);
         } else {
@@ -219,34 +249,37 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function createOutputDirectory() {
+    public function createOutputDirectory()
+    {
         $this->setOutputDir($this->config->outputDir . strtolower($this->getFormatName()) . '/');
         if (file_exists($this->getOutputDir())) {
             if (!is_dir($this->getOutputDir())) {
                 trigger_error("Output directory is a file?", E_USER_ERROR);
             }
-        } else {
-            if (!mkdir($this->getOutputDir(), 0777, true)) {
-                trigger_error("Can't create output directory", E_USER_ERROR);
-            }
+        } elseif (!mkdir($this->getOutputDir(), 0777, true)) {
+            trigger_error("Can't create output directory", E_USER_ERROR);
         }
     }
 
-    public function format_suppressed_tags($open, $name, $attrs, $props) {
+    public function format_suppressed_tags($open, $name, $attrs, $props)
+    {
         return '';
     }
 
-    public function format_suppressed_text($value, $tag) {
+    public function format_suppressed_text($value, $tag)
+    {
         return '';
     }
 
-    public function format_set($open, $name, $attrs, $props) {
+    public function format_set($open, $name, $attrs, $props)
+    {
         if (isset($attrs[Reader::XMLNS_XML]['id']) && $attrs[Reader::XMLNS_XML]['id'] == 'funcref') {
             $this->isFunctionRefSet = $open;
         }
     }
 
-    public function format_refentry($open, $name, $attrs, $props) {
+    public function format_refentry($open, $name, $attrs, $props)
+    {
         if (!$this->isFunctionRefSet) {
             return;
         }
@@ -254,25 +287,28 @@ abstract class Package_IDE_Base extends Format {
             $this->function = $this->dfunction;
             $this->cchunk = $this->dchunk;
 
-            $this->function['manualid'] =  $attrs[Reader::XMLNS_XML]['id'];
+            $this->function['manualid'] = $attrs[Reader::XMLNS_XML]['id'];
             return;
         }
         $this->writeChunk();
     }
 
-    public function format_refname_text($value, $tag) {
+    public function format_refname_text($value, $tag)
+    {
         if ($this->isFunctionRefSet) {
             $this->cchunk['funcname'][] = $this->toValidName(trim($value));
         }
     }
 
-    public function format_refpurpose($open, $name, $attrs, $props) {
+    public function format_refpurpose($open, $name, $attrs, $props)
+    {
         if ($this->isFunctionRefSet && $open) {
             $this->function['purpose'] = str_replace("\n", '', trim(ReaderKeeper::getReader()->readString()));
         }
     }
 
-    public function format_refsect1($open, $name, $attrs, $props) {
+    public function format_refsect1($open, $name, $attrs, $props)
+    {
         if (!$this->isFunctionRefSet) {
             return;
         }
@@ -292,7 +328,8 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_type_text($value, $tag) {
+    public function format_type_text($value, $tag)
+    {
         if (!$this->isFunctionRefSet) {
             return;
         }
@@ -305,8 +342,9 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_methodparam($open, $name, $attrs, $props) {
-        if ($this->role != 'description' || !$this->isFunctionRefSet ) {
+    public function format_methodparam($open, $name, $attrs, $props)
+    {
+        if ($this->role != 'description' || !$this->isFunctionRefSet) {
             return;
         }
         if ($open) {
@@ -329,7 +367,8 @@ abstract class Package_IDE_Base extends Format {
         $this->function['params'][$param['name']] = $param;
     }
 
-    public function format_parameter_text($value, $tag) {
+    public function format_parameter_text($value, $tag)
+    {
         if (!$this->isFunctionRefSet) {
             return;
         }
@@ -341,7 +380,8 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_parameter_desc($open, $name, $attrs, $props) {
+    public function format_parameter_desc($open, $name, $attrs, $props)
+    {
         if ($this->role != 'parameters') {
             return;
         }
@@ -354,7 +394,8 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_initializer_text($value, $tag) {
+    public function format_initializer_text($value, $tag)
+    {
         if (!$this->isFunctionRefSet) {
             return;
         }
@@ -364,7 +405,8 @@ abstract class Package_IDE_Base extends Format {
         $this->cchunk['param']['initializer'] = $value;
     }
 
-    public function format_return($open, $name, $attrs, $props) {
+    public function format_return($open, $name, $attrs, $props)
+    {
         if ($open) {
             //Read the description
             $content = $this->renderHTML();
@@ -374,7 +416,8 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_notes($open, $name, $attrs, $props) {
+    public function format_notes($open, $name, $attrs, $props)
+    {
         if ($this->role != 'notes' || !$this->isFunctionRefSet) {
             return;
         }
@@ -388,7 +431,8 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_errors($open, $name, $attrs, $props) {
+    public function format_errors($open, $name, $attrs, $props)
+    {
         if ($open) {
             //Read the description
             $content = $this->renderHTML();
@@ -398,13 +442,15 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_changelog_tbody($open, $name, $attrs, $props) {
+    public function format_changelog_tbody($open, $name, $attrs, $props)
+    {
         if ($this->role == 'changelog' && $this->isFunctionRefSet) {
             $this->isChangelogRow = $open;
         }
     }
 
-    public function format_changelog_row($open, $name, $attrs, $props) {
+    public function format_changelog_row($open, $name, $attrs, $props)
+    {
         if ($this->isChangelogRow) {
             if ($open) {
                 $this->cchunk['changelog'] = $this->dchunk['changelog'];
@@ -416,23 +462,26 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_changelog_entry($open, $name, $attrs, $props) {
+    public function format_changelog_entry($open, $name, $attrs, $props)
+    {
         if ($this->isChangelogRow && $open) {
             $entryType = ($this->cchunk['changelog']['entry'] == 'version')
-                    ? 'change'
-                    : 'version';
+                ? 'change'
+                : 'version';
             $this->cchunk['changelog'][$entryType] = trim(ReaderKeeper::getReader()->readString());
             $this->cchunk['changelog']['entry'] = $entryType;
         }
     }
 
-    public function format_changelog_entry_text($value, $tag) {
+    public function format_changelog_entry_text($value, $tag)
+    {
         if ($this->isChangelogRow) {
             $this->cchunk['changelog'][$this->cchunk['changelog']['entry']] = $value;
         }
     }
 
-    public function format_member($open, $name, $attrs, $props) {
+    public function format_member($open, $name, $attrs, $props)
+    {
         if ($this->role == 'seealso' && $this->isFunctionRefSet) {
             if ($open) {
                 $this->cchunk['seealso'] = $this->dchunk['seealso'];
@@ -449,19 +498,22 @@ abstract class Package_IDE_Base extends Format {
         }
     }
 
-    public function format_seealso_entry($open, $name, $attrs, $props) {
+    public function format_seealso_entry($open, $name, $attrs, $props)
+    {
         if ($this->role == 'seealso' && $this->isFunctionRefSet) {
             $this->cchunk['seealso']['type'] = $name;
         }
     }
 
-    public function format_seealso_entry_text($value, $tag) {
+    public function format_seealso_entry_text($value, $tag)
+    {
         if ($this->role == 'seealso' && $this->isFunctionRefSet) {
             $this->cchunk['seealso']['name'] = $value;
         }
     }
 
-    public function toValidName($functionName) {
+    public function toValidName($functionName)
+    {
         return str_replace(array('::', '->', '()'), array('.', '.', ''), $functionName);
     }
 

--- a/phpdotnet/phd/Package/IDE/demo.php
+++ b/phpdotnet/phd/Package/IDE/demo.php
@@ -11,7 +11,7 @@ require __INSTALLDIR__ . DS . 'phpdotnet' . DS . 'phd' . DS . 'functions.php';
 spl_autoload_register(array("phpdotnet\\phd\\Autoloader", "autoload"));
 
 //FIXME Remove this call to Config
-$config = new PhD\Config;
+$config = new PhD\Config();
 $config->init(array());
 
 function usage()

--- a/phpdotnet/phd/Package/PEAR/CHM.php
+++ b/phpdotnet/phd/Package/PEAR/CHM.php
@@ -2,8 +2,8 @@
 namespace phpdotnet\phd;
 
 class Package_PEAR_CHM extends Package_PEAR_ChunkedXHTML {
-    const DEFAULT_FONT = "Arial,10,0";
-    const DEFAULT_TITLE = "PEAR Manual";
+    public const DEFAULT_FONT = "Arial,10,0";
+    public const DEFAULT_TITLE = "PEAR Manual";
 
     // Array to manual code -> HTML Help Code conversion
 	// Code list: http://www.helpware.net/htmlhelp/hh_info.htm

--- a/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
@@ -82,10 +82,8 @@ class Package_PEAR_ChunkedXHTML extends Package_PEAR_XHTML {
                 if (!is_dir($this->getOutputDir())) {
                     trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
-            } else {
-                if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
-                }
+            } elseif (!mkdir($this->getOutputDir(), 0777, true)) {
+                trigger_error("Can't create output directory", E_USER_ERROR);
             }
             if ($this->config->css) {
                 $this->fetchStylesheet();

--- a/phpdotnet/phd/Package/PEAR/XHTML.php
+++ b/phpdotnet/phd/Package/PEAR/XHTML.php
@@ -348,7 +348,7 @@ abstract class Package_PEAR_XHTML extends Package_Generic_XHTML {
     * If whitespace should be trimmed.
     * Helpful for programlistings that are encapsulated in <pre> tags
     *
-    * @var boolean
+    * @var bool
     *
     * @see CDATA()
     */
@@ -643,7 +643,7 @@ abstract class Package_PEAR_XHTML extends Package_Generic_XHTML {
             if (count($arLinkend) == 1) {
                 //link to class
                 $linktpl = '{$package}/docs/latest/{$package}/{$class}.html';
-            } else if ($arLinkend[1]{0} == '$') {
+            } elseif ($arLinkend[1]{0} == '$') {
                 //link to class variable
                 $variable = $arLinkend[1];
                 $linktpl = '{$package}/docs/latest/{$package}/{$class}.html#var{$variable}';

--- a/phpdotnet/phd/Package/PHP/CHM.php
+++ b/phpdotnet/phd/Package/PHP/CHM.php
@@ -3,8 +3,8 @@ namespace phpdotnet\phd;
 
 class Package_PHP_CHM extends Package_PHP_ChunkedXHTML
 {
-    const DEFAULT_FONT = "Arial,10,0";
-    const DEFAULT_TITLE = "PHP Manual";
+    public const DEFAULT_FONT = "Arial,10,0";
+    public const DEFAULT_TITLE = "PHP Manual";
 
     // Array to manual code -> HTML Help Code conversion
     // Code list: http://www.helpware.net/htmlhelp/hh_info.htm

--- a/phpdotnet/phd/Package/PHP/HowTo.php
+++ b/phpdotnet/phd/Package/PHP/HowTo.php
@@ -30,10 +30,8 @@ class Package_PHP_HowTo extends Package_PHP_Web {
                 if (!is_dir($this->getOutputDir())) {
                     trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
-            } else {
-                if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
-                }
+            } elseif (!mkdir($this->getOutputDir(), 0777, true)) {
+                trigger_error("Can't create output directory", E_USER_ERROR);
             }
             break;
         }

--- a/phpdotnet/phd/Package/PHP/KDevelop.php
+++ b/phpdotnet/phd/Package/PHP/KDevelop.php
@@ -2,7 +2,7 @@
 namespace phpdotnet\phd;
 
 class Package_PHP_KDevelop extends Format {
-    const DEFAULT_HREF = "http://www.php.net/manual/en/";
+    public const DEFAULT_HREF = "http://www.php.net/manual/en/";
 
     protected $elementmap = array(
         'book'                  => 'format_tocsect1',
@@ -132,10 +132,8 @@ class Package_PHP_KDevelop extends Format {
             $name = htmlspecialchars(Format::getShortDescription($id), ENT_QUOTES, 'UTF-8');
             $url = (Format::getFilename($id) ? Format::getFilename($id) : $id) . $this->getExt();
             fwrite($this->getFileStream(), "<tocsect1 name=\"{$name}\" url=\"{$url}\"" . ($hasChild ? "" : "/") . ">\n");
-        } else {
-            if ($hasChild)
-                fwrite($this->getFileStream(), "</tocsect1>\n");
-        }
+        } elseif ($hasChild)
+            fwrite($this->getFileStream(), "</tocsect1>\n");
         return "";
     }
 

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -91,10 +91,8 @@ class Package_PHP_Web extends Package_PHP_XHTML {
                 if (!is_dir($this->getOutputDir())) {
                     trigger_error("Output directory is a file?", E_USER_ERROR);
                 }
-            } else {
-                if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
-                }
+            } elseif (!mkdir($this->getOutputDir(), 0777, true)) {
+                trigger_error("Can't create output directory", E_USER_ERROR);
             }
             if ($this->getFormatName() == "PHP-Web") {
                 if (!$this->config->noToc && is_dir($this->getOutputDir() . 'toc')) {
@@ -409,7 +407,7 @@ contributors($setup);
             return array();
         }
 
-        $r = new \XMLReader;
+        $r = new \XMLReader();
         if (!$r->open($filename)) {
             trigger_error(vsprintf("Can't open the sources file (%s)", [$filename]), E_USER_ERROR);
             return array();

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -261,7 +261,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             return array();
         }
 
-        $r = new \XMLReader;
+        $r = new \XMLReader();
         if (!$r->open($filename)) {
             trigger_error(vsprintf("Can't open the version info file (%s)", [$filename]), E_USER_ERROR);
         }
@@ -298,7 +298,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             return array();
         }
 
-        $r = new \XMLReader;
+        $r = new \XMLReader();
         if (!$r->open($filename)) {
             trigger_error(vsprintf("Can't open the version info file (%s)", [$filename]), E_USER_ERROR);
         }
@@ -332,7 +332,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
             return array();
         }
 
-        $r = new \XMLReader;
+        $r = new \XMLReader();
         if (!$r->open($filename)) {
             trigger_error(vsprintf("Could not open file for accessing acronym information (%s)", [$filename]), E_USER_ERROR);
         }
@@ -347,7 +347,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
                 $r->read();
                 $k = $r->value;
                 $acronyms[$k] = "";
-            } else if ($r->name == "simpara") {
+            } elseif ($r->name == "simpara") {
                 $r->read();
                 $acronyms[$k] = $r->value;
             }
@@ -425,15 +425,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
                     "intersection" => "&amp;",
                 };
             }
-        } else {
-            if (
-                isset($attrs[Reader::XMLNS_DOCBOOK]["class"])
-                && ($attrs[Reader::XMLNS_DOCBOOK]["class"] === "union"
-                || $attrs[Reader::XMLNS_DOCBOOK]["class"] === "intersection")
-                ) {
-                $lastSeparator = array_pop($this->cchunk["methodsynopsis"]["type_separator_stack"]);
-                $this->cchunk["methodsynopsis"]["type_separator"][count($this->cchunk["methodsynopsis"]["type_separator"]) - 1] = end($this->cchunk["methodsynopsis"]["type_separator_stack"]) ?: $lastSeparator;
-            }
+        } elseif (
+            isset($attrs[Reader::XMLNS_DOCBOOK]["class"])
+            && ($attrs[Reader::XMLNS_DOCBOOK]["class"] === "union"
+            || $attrs[Reader::XMLNS_DOCBOOK]["class"] === "intersection")
+            ) {
+            $lastSeparator = array_pop($this->cchunk["methodsynopsis"]["type_separator_stack"]);
+            $this->cchunk["methodsynopsis"]["type_separator"][count($this->cchunk["methodsynopsis"]["type_separator"]) - 1] = end($this->cchunk["methodsynopsis"]["type_separator_stack"]) ?: $lastSeparator;
         }
 
         return "";
@@ -541,7 +539,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         $content = "";
         if ($this->params["paramCount"] > 3) {
             $content .= "<br>";
-        } else if ($this->params["paramCount"] === 0) {
+        } elseif ($this->params["paramCount"] === 0) {
             $content .= "(";
         }
 
@@ -652,15 +650,13 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
                     "intersection" => "&amp;",
                 };
             }
-        } else {
-            if (
-                isset($attrs[Reader::XMLNS_DOCBOOK]["class"])
-                && ($attrs[Reader::XMLNS_DOCBOOK]["class"] === "union"
-                || $attrs[Reader::XMLNS_DOCBOOK]["class"] === "intersection")
-            ) {
-                $lastSeparator = array_pop($this->cchunk["methodparam"]["type_separator_stack"]);
-                $this->cchunk["methodparam"]["type_separator"][count($this->cchunk["methodparam"]["type_separator"]) - 1] = end($this->cchunk["methodparam"]["type_separator_stack"]) ?: $lastSeparator;
-            }
+        } elseif (
+            isset($attrs[Reader::XMLNS_DOCBOOK]["class"])
+            && ($attrs[Reader::XMLNS_DOCBOOK]["class"] === "union"
+            || $attrs[Reader::XMLNS_DOCBOOK]["class"] === "intersection")
+        ) {
+            $lastSeparator = array_pop($this->cchunk["methodparam"]["type_separator_stack"]);
+            $this->cchunk["methodparam"]["type_separator"][count($this->cchunk["methodparam"]["type_separator"]) - 1] = end($this->cchunk["methodparam"]["type_separator_stack"]) ?: $lastSeparator;
         }
 
         return "";
@@ -757,7 +753,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         /* TODO This should be migrated to the annotations attribute */
         if (isset($attrs[Reader::XMLNS_DOCBOOK]["annotations"])) {
             $this->cchunk["verinfo"] = !str_contains($attrs[Reader::XMLNS_DOCBOOK]["annotations"], 'verify_info:false');
-        } else if (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
+        } elseif (isset($attrs[Reader::XMLNS_DOCBOOK]["role"])) {
             $this->cchunk["verinfo"] = !($attrs[Reader::XMLNS_DOCBOOK]["role"] == "noversion");
         } else {
             $this->cchunk["verinfo"] = true;

--- a/phpdotnet/phd/Reader.php
+++ b/phpdotnet/phd/Reader.php
@@ -3,10 +3,10 @@ namespace phpdotnet\phd;
 
 class Reader extends \XMLReader
 {
-    const XMLNS_XML     = "http://www.w3.org/XML/1998/namespace";
-    const XMLNS_XLINK   = "http://www.w3.org/1999/xlink";
-    const XMLNS_PHD     = "http://www.php.net/ns/phd";
-    const XMLNS_DOCBOOK = "http://docbook.org/ns/docbook";
+    public const XMLNS_XML = "http://www.w3.org/XML/1998/namespace";
+    public const XMLNS_XLINK = "http://www.w3.org/1999/xlink";
+    public const XMLNS_PHD = "http://www.php.net/ns/phd";
+    public const XMLNS_DOCBOOK = "http://docbook.org/ns/docbook";
     
     protected OutputHandler $outputHandler;
 

--- a/phpdotnet/phd/Reader/Partial.php
+++ b/phpdotnet/phd/Reader/Partial.php
@@ -78,15 +78,13 @@ class Reader_Partial extends Reader
                 return $ret;
             } elseif (empty($this->partial)) {
                 return false;
-            } else {
+            } elseif ($id && $this->parents) {
                 // If we are used by the indexer then we have no clue about the
                 // parents :)
-                if ($id && $this->parents) {
-                    // If this id isn't one of our ancestors we can jump
-                    // completely over it
-                    if (!in_array($id, $this->parents)) {
-                        parent::next();
-                    }
+                // If this id isn't one of our ancestors we can jump
+                // completely over it
+                if (!in_array($id, $this->parents)) {
+                    parent::next();
                 }
             }
         }

--- a/phpdotnet/phd/Render.php
+++ b/phpdotnet/phd/Render.php
@@ -3,13 +3,13 @@ namespace phpdotnet\phd;
 
 class Render extends ObjectStorage
 {
-    const CHUNK        = 0x001;
-    const OPEN         = 0x002;
-    const CLOSE        = 0x004;
-    const STANDALONE   = 0x008;
-    const INIT         = 0x010;
-    const FINALIZE     = 0x020;
-    const VERBOSE      = 0x040;
+    public const CHUNK = 0x001;
+    public const OPEN = 0x002;
+    public const CLOSE = 0x004;
+    public const STANDALONE = 0x008;
+    public const INIT = 0x010;
+    public const FINALIZE = 0x020;
+    public const VERBOSE = 0x040;
 
     private   $STACK      = array();
 

--- a/render.php
+++ b/render.php
@@ -8,7 +8,7 @@ Autoloader::setPackageDirs([__INSTALLDIR__]);
 
 spl_autoload_register(array(__NAMESPACE__ . "\\Autoloader", "autoload"));
 
-$config = new Config;
+$config = new Config();
 
 $outputHandler = new OutputHandler($config);
 
@@ -34,7 +34,7 @@ foreach ($config->getSupportedPackages() as $package) {
     }
 }
 $optionsParser = new Options_Parser(
-    new Options_Handler($config, new Package_Generic_Factory, $outputHandler),
+    new Options_Handler($config, new Package_Generic_Factory(), $outputHandler),
     ...$packageHandlers
 );
 $commandLineOptions = $optionsParser->getopt();

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -7,7 +7,7 @@ require_once __INSTALLDIR__ . DIRECTORY_SEPARATOR . "phpdotnet" . DIRECTORY_SEPA
 Autoloader::setPackageDirs([__INSTALLDIR__]);
 spl_autoload_register(["phpdotnet\\phd\\Autoloader", "autoload"]);
 
-$config = new Config;
+$config = new Config();
 
 $outputHandler = new OutputHandler($config);
 


### PR DESCRIPTION
### Summary
Apply PSR-12 fixes across the codebase:
- Replace `else if` → `elseif`.
- Ensure class instantiations always use parentheses: `new Foo()` even with no args.
- Add explicit visibility to properties, methods, and constants.
- Fix modifier order: abstract/final → visibility → static.
- Enforce short type keywords per PSR-12: `bool` (not `boolean`), `int` (not `integer`), `float` (not `double`/`real`), `string`, `array`, `object`, `callable`, `iterable`, `null`.

### Motivation
Improves readability and PSR-12 compliance. No functional changes.

### Impact
- ✅ No behavior change / BC break.
- ✅ Pure style/consistency.

### Examples
Before:
    else if ($ok) { … }
    new Foo;
    final static public function run() {}
    /** @param integer $n @return boolean */
    private const FOO = 1;

After:
    elseif ($ok) { … }
    new Foo();
    final public static function run(): void {}
    /** @param int $n @return bool */
    public const FOO = 1;

### Reference
- PSR-12: https://www.php-fig.org/psr/psr-12/
