### PR TITLE
Declare unused private promoted properties as readonly (PHP 8.1+)

### DIFF
--- a/phpdotnet/phd/ErrorHandler.php
+++ b/phpdotnet/phd/ErrorHandler.php
@@ -20,7 +20,7 @@ class ErrorHandler
     private bool $recursive = false;
     
     public function __construct(
-        private OutputHandler $outputHandler
+        private readonly OutputHandler $outputHandler
     ) {}
 
     public function handleError($errno, $msg, $file, $line) {

--- a/phpdotnet/phd/IndexRepository.php
+++ b/phpdotnet/phd/IndexRepository.php
@@ -11,7 +11,7 @@ class IndexRepository
     private array $examples = [];
 
     public function __construct(
-        private \SQLite3 $db
+        private readonly \SQLite3 $db
     ) {}
 
     public function init(): void {

--- a/phpdotnet/phd/Options/Handler.php
+++ b/phpdotnet/phd/Options/Handler.php
@@ -4,9 +4,9 @@ namespace phpdotnet\phd;
 class Options_Handler implements Options_Interface
 {
     public function __construct(
-        private Config $config,
-        private Format_Factory $formatFactory,
-        private OutputHandler $outputHandler
+        private readonly Config         $config,
+        private readonly Format_Factory $formatFactory,
+        private readonly OutputHandler  $outputHandler
     ) {}
 
     /**

--- a/phpdotnet/phd/OutputHandler.php
+++ b/phpdotnet/phd/OutputHandler.php
@@ -24,7 +24,7 @@ class OutputHandler
     ];
     
     public function __construct(
-        private Config $config
+        private readonly Config $config
     ) {}
 
     /**


### PR DESCRIPTION
### Summary
This PR marks all private promoted properties that are never reassigned as `readonly`.

### Motivation
- Improves immutability guarantees for internal classes.
- Helps static analyzers (PHPStan, Psalm) infer data flow more accurately.
- Aligns PhD with modern PHP conventions and safety features introduced in PHP 8.1.

### Scope
- Scanned all constructor-promoted properties.
- Identified private ones never written to outside the constructor.
- Declared them `readonly`.

### Example
Before:
    class Reader {
        public function __construct(private string $path) {}
    }

After:
    class Reader {
        public function __construct(private readonly string $path) {}
    }

### Impact
- ✅ No behavior change.
- ✅ Pure internal safety improvement.
- ✅ Forward-compatible with PHP 8.4+.
- 🧠 Enables better static analysis and type inference.

### References
- [PHP 8.1: readonly properties RFC](https://wiki.php.net/rfc/readonly_properties_v2)
