### PR TITLE
Replace trigger_error(E_USER_ERROR) with exceptions (PHP 8.4 compatibility)

### DIFF
--- a/phpdotnet/phd/Autoloader.php
+++ b/phpdotnet/phd/Autoloader.php
@@ -26,7 +26,7 @@ class Autoloader
 
                 return;
             }
-            trigger_error(vsprintf('Cannot find file for %s: %s', [$name, $file ?? $filename]), E_USER_ERROR);
+            throw new \Error(vsprintf('Cannot find file for %s: %s', [$name, $file ?? $filename]));
         }
     }
 

--- a/phpdotnet/phd/Format/Factory.php
+++ b/phpdotnet/phd/Format/Factory.php
@@ -49,7 +49,7 @@ abstract class Format_Factory {
              }
             return $obj;
         }
-        trigger_error("This format is not supported by this package", E_USER_ERROR);
+        throw new \Error('This format is not supported by this package');
     }
 
     public static final function createFactory($package) {

--- a/phpdotnet/phd/Options/Handler.php
+++ b/phpdotnet/phd/Options/Handler.php
@@ -184,10 +184,10 @@ class Options_Handler implements Options_Interface
     public function option_docbook(string $k, mixed $v): array
     {
         if (is_array($v)) {
-            trigger_error("Can only parse one file at a time", E_USER_ERROR);
+            throw new \Error('Can only parse one file at a time');
         }
         if (!file_exists($v) || is_dir($v) || !is_readable($v)) {
-            trigger_error(sprintf("'%s' is not a readable docbook file", $v), E_USER_ERROR);
+            throw new \Error(sprintf("'%s' is not a readable docbook file", $v));
         }
         return [
             'xmlRoot' => dirname($v),
@@ -209,19 +209,19 @@ class Options_Handler implements Options_Interface
     public function option_output(string $k, mixed $v): array
     {
         if (is_array($v)) {
-            trigger_error("Only a single output location can be supplied", E_USER_ERROR);
+            throw new \Error('Only a single output location can be supplied');
         }
         if (!file_exists($v)) {
             $this->outputHandler->v("Creating output directory..", VERBOSE_MESSAGES);
             if (!mkdir($v, 0777, true)) {
-                trigger_error(vsprintf("Can't create output directory : %s", [$v]), E_USER_ERROR);
+                throw new \Error(vsprintf("Can't create output directory : %s", [$v]));
             }
             $this->outputHandler->v("Output directory created", VERBOSE_MESSAGES);
         } elseif (!is_dir($v)) {
-            trigger_error("Output directory is a file?", E_USER_ERROR);
+            throw new \Error('Output directory is a file?');
         }
         if (!is_dir($v) || !is_readable($v)) {
-            trigger_error(sprintf("'%s' is not a valid directory", $v), E_USER_ERROR);
+            throw new \Error(sprintf("'%s' is not a valid directory", $v));
         }
         $v = (substr($v, strlen($v) - strlen(DIRECTORY_SEPARATOR)) === DIRECTORY_SEPARATOR) ? $v : ($v . DIRECTORY_SEPARATOR);
 
@@ -234,7 +234,7 @@ class Options_Handler implements Options_Interface
     public function option_outputfilename(string $k, mixed $v): array
     {
         if (is_array($v)) {
-            trigger_error("Only a single output location can be supplied", E_USER_ERROR);
+            throw new \Error('Only a single output location can be supplied');
         }
         $file = basename($v);
 
@@ -281,7 +281,7 @@ class Options_Handler implements Options_Interface
         foreach((array)$v as $package) {
             if (!in_array($package, $this->config->getSupportedPackages())) {
                 $supported = implode(', ', $this->config->getSupportedPackages());
-                trigger_error("Invalid Package (Tried: '$package' Supported: '$supported')", E_USER_ERROR);
+                throw new \Error("Invalid Package (Tried: '$package' Supported: '$supported')");
             }
         }
         return ['package' => (array) $v];
@@ -341,13 +341,13 @@ class Options_Handler implements Options_Interface
     public function option_saveconfig(string $k, mixed $v): array
     {
         if (is_array($v)) {
-            trigger_error(sprintf("You cannot pass %s more than once", $k), E_USER_ERROR);
+            throw new \Error(sprintf('You cannot pass %s more than once', $k));
         }
 
         $val = is_bool($v) ? true : self::boolval($v);
 
         if (!is_bool($val)) {
-            trigger_error("yes/no || on/off || true/false || 1/0 expected", E_USER_ERROR);
+            throw new \Error('yes/no || on/off || true/false || 1/0 expected');
         }
 
         return ['saveConfig' => $val];
@@ -381,7 +381,7 @@ class Options_Handler implements Options_Interface
                     $verbose = max($verbose, 1);
                     $verbose <<= 1;
                 } else {
-                    trigger_error("Unknown option passed to --$k, '$const'", E_USER_ERROR);
+                    throw new \Error("Unknown option passed to --$k, '$const'");
                 }
             }
         }
@@ -438,11 +438,11 @@ class Options_Handler implements Options_Interface
     public function option_color(string $k, mixed $v): array
     {
         if (is_array($v)) {
-            trigger_error(sprintf("You cannot pass %s more than once", $k), E_USER_ERROR);
+            throw new \Error(sprintf('You cannot pass %s more than once', $k));
         }
         $val = self::boolval($v);
         if (!is_bool($val)) {
-            trigger_error("yes/no || on/off || true/false || 1/0 expected", E_USER_ERROR);
+            throw new \Error('yes/no || on/off || true/false || 1/0 expected');
         }
         return ['colorOutput' => $val];
     }

--- a/phpdotnet/phd/Options/Parser.php
+++ b/phpdotnet/phd/Options/Parser.php
@@ -80,11 +80,11 @@ class Options_Parser
             $checkArgv = explode('=', $argv[$i]);
             if (substr($checkArgv[0], 0, 2) === '--') {
                 if (!in_array(substr($checkArgv[0], 2), $long)) {
-                    trigger_error('Invalid long option ' . $argv[$i], E_USER_ERROR);
+                    throw new \Error('Invalid long option ' . $argv[$i]);
                 }
             } elseif (substr($checkArgv[0], 0, 1) === '-') {
                 if (!in_array(substr($checkArgv[0], 1), $short)) {
-                    trigger_error('Invalid short option ' . $argv[$i], E_USER_ERROR);
+                    throw new \Error('Invalid short option ' . $argv[$i]);
                 }
            }
         }
@@ -98,7 +98,7 @@ class Options_Parser
 
         $args = getopt($this->getShortOptions(), $this->getLongOptions());
         if ($args === false) {
-            trigger_error("Something happend with getopt(), please report a bug", E_USER_ERROR);
+            throw new \Error('Something happend with getopt(), please report a bug');
         }
 
         $parsedOptions = [];
@@ -106,7 +106,7 @@ class Options_Parser
             $handler = $this->handlerForOption($k);
 
             if (!is_callable($handler)) {
-                trigger_error("Hmh, something weird has happend, I don't know this option", E_USER_ERROR);
+                throw new \Error("Hmh, something weird has happend, I don't know this option");
             }
 
             $retVal = call_user_func($handler, $k, $v);

--- a/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/Generic/ChunkedXHTML.php
@@ -77,11 +77,11 @@ class Package_Generic_ChunkedXHTML extends Package_Generic_XHTML {
             $this->postConstruct();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    trigger_error("Output directory is a file?", E_USER_ERROR);
+                    throw new \Error('Output directory is a file?');
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
+                    throw new \Error("Can't create output directory");
                 }
             }
             if ($this->config->css) {

--- a/phpdotnet/phd/Package/Generic/Manpage.php
+++ b/phpdotnet/phd/Package/Generic/Manpage.php
@@ -316,11 +316,11 @@ class Package_Generic_Manpage extends Format_Abstract_Manpage {
             $this->setOutputDir($this->config->outputDir . strtolower($this->toValidName($this->getFormatName())) . '/');
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    trigger_error("Output directory is a file?", E_USER_ERROR);
+                    throw new \Error('Output directory is a file?');
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
+                    throw new \Error("Can't create output directory");
                 }
             }
             break;

--- a/phpdotnet/phd/Package/Generic/TocFeed.php
+++ b/phpdotnet/phd/Package/Generic/TocFeed.php
@@ -224,11 +224,11 @@ abstract class Package_Generic_TocFeed extends Format
             $dir = $this->getOutputDir();
             if (file_exists($dir)) {
                 if (!is_dir($dir)) {
-                    trigger_error("Output directory is a file?", E_USER_ERROR);
+                    throw new \Error('Output directory is a file?');
                 }
             } else {
                 if (!mkdir($dir, 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
+                    throw new \Error("Can't create output directory");
                 }
             }
             break;

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -678,11 +678,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         $stylesDir .= 'styles/';
         if (file_exists($stylesDir)) {
             if (!is_dir($stylesDir)) {
-                trigger_error("The styles/ directory is a file?", E_USER_ERROR);
+                throw new \Error('The styles/ directory is a file?');
             }
         } else {
             if (!mkdir($stylesDir, 0777, true)) {
-                trigger_error("Can't create the styles/ directory.", E_USER_ERROR);
+                throw new \Error("Can't create the styles/ directory.");
             }
         }
         foreach ((array)$this->config->css as $css) {

--- a/phpdotnet/phd/Package/IDE/API.php
+++ b/phpdotnet/phd/Package/IDE/API.php
@@ -72,10 +72,10 @@ class Package_IDE_API
                         : $dir . DIRECTORY_SEPARATOR;
                 $this->funclist = file($this->dir . self::FUNCLIST_FILE, FILE_IGNORE_NEW_LINES);
             } else {
-                trigger_error('Is the PhD output directory a file?', E_USER_ERROR);
+                throw new \Error('Is the PhD output directory a file?');
             }
         } else {
-            trigger_error('The PhD output directory does not exist.', E_USER_ERROR);
+            throw new \Error('The PhD output directory does not exist.');
         }
     }
 

--- a/phpdotnet/phd/Package/IDE/Base.php
+++ b/phpdotnet/phd/Package/IDE/Base.php
@@ -215,7 +215,7 @@ abstract class Package_IDE_Base extends Format {
         if (file_exists($this->config->phpwebVersionFilename)) {
             $this->versions = self::generateVersionInfo($this->config->phpwebVersionFilename);
         } else {
-            trigger_error("Can't load the versions file", E_USER_ERROR);
+            throw new \Error("Can't load the versions file");
         }
     }
 
@@ -223,11 +223,11 @@ abstract class Package_IDE_Base extends Format {
         $this->setOutputDir($this->config->outputDir . strtolower($this->getFormatName()) . '/');
         if (file_exists($this->getOutputDir())) {
             if (!is_dir($this->getOutputDir())) {
-                trigger_error("Output directory is a file?", E_USER_ERROR);
+                throw new \Error('Output directory is a file?');
             }
         } else {
             if (!mkdir($this->getOutputDir(), 0777, true)) {
-                trigger_error("Can't create output directory", E_USER_ERROR);
+                throw new \Error("Can't create output directory");
             }
         }
     }

--- a/phpdotnet/phd/Package/IDE/demo.php
+++ b/phpdotnet/phd/Package/IDE/demo.php
@@ -64,21 +64,21 @@ foreach ($options as $k => $v) {
     case 'd':
     case 'dir':
         if (is_array($v)) {
-            trigger_error('Is not possible to pass the --dir option more then once', E_USER_ERROR);
+            throw new \Error('Is not possible to pass the --dir option more then once');
         }
         $OPTION['dir'] = $v;
         break;
     case 'f':
     case 'function':
         if (is_array($v)) {
-            trigger_error('Is not possible to pass the --function option more then once', E_USER_ERROR);
+            throw new \Error('Is not possible to pass the --function option more then once');
         }
         $OPTION['function'] = $v;
         break;
     case 'c':
     case 'class':
         if (is_array($v)) {
-            trigger_error('Is not possible to pass the --class option more then once', E_USER_ERROR);
+            throw new \Error('Is not possible to pass the --class option more then once');
         }
         $OPTION['class'] = $v;
         break;
@@ -107,7 +107,7 @@ foreach ($options as $k => $v) {
         $OPTION['help'] = true;
         break;
     default:
-        trigger_error('Invalid Option: ' . $k, E_USER_ERROR);
+        throw new \Error('Invalid Option: ' . $k);
     }
 }
 
@@ -117,11 +117,11 @@ if ($OPTION['help'] === true || !$options) {
 }
 
 if ($OPTION['dir'] == NULL) {
-    trigger_error('You must specify the PhD output directory with the --dir option.', E_USER_ERROR);
+    throw new \Error('You must specify the PhD output directory with the --dir option.');
 }
 
 if ($OPTION['function'] == NULL && $OPTION['class'] == NULL) {
-    trigger_error('You must pass either --class or --function options.', E_USER_ERROR);
+    throw new \Error('You must pass either --class or --function options.');
 }
 
 $api = new PhD\Package_IDE_API($OPTION['dir']);
@@ -129,7 +129,7 @@ $api = new PhD\Package_IDE_API($OPTION['dir']);
 if ($OPTION['class'] != NULL) {
     $methods = $api->getMethodsByClass($OPTION['class']);
     if ($methods == NULL) {
-        trigger_error('Invalid Class name: ' . $OPTION['class'], E_USER_ERROR);
+        throw new \Error('Invalid Class name: ' . $OPTION['class']);
     }
     foreach ($methods as $method) {
         echo $method . PHP_EOL;
@@ -140,7 +140,7 @@ if ($OPTION['class'] != NULL) {
 $function = $api->getFunctionByName($OPTION['function']);
 
 if ($function == NULL) {
-    trigger_error('Invalid Function: ' . $OPTION['function'], E_USER_ERROR);
+    throw new \Error('Invalid Function: ' . $OPTION['function']);
 }
 
 if ($OPTION['signature'] === true) {

--- a/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/PEAR/ChunkedXHTML.php
@@ -80,11 +80,11 @@ class Package_PEAR_ChunkedXHTML extends Package_PEAR_XHTML {
             $this->postConstruct();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    trigger_error("Output directory is a file?", E_USER_ERROR);
+                    throw new \Error('Output directory is a file?');
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
+                    throw new \Error("Can't create output directory");
                 }
             }
             if ($this->config->css) {

--- a/phpdotnet/phd/Package/PHP/ChunkedXHTML.php
+++ b/phpdotnet/phd/Package/PHP/ChunkedXHTML.php
@@ -241,12 +241,12 @@ class Package_PHP_ChunkedXHTML extends Package_PHP_Web {
     {
         if (file_exists($dir)) {
             if (!is_dir($dir)) {
-                trigger_error("The specified directory is a file: {$dir}", E_USER_ERROR);
+                throw new \Error("The specified directory is a file: {$dir}");
             }
             return;
         }
         if (!mkdir($dir, 0777, true)) {
-            trigger_error("Can't create the specified directory: {$dir}", E_USER_ERROR);
+            throw new \Error("Can't create the specified directory: {$dir}");
         }
     }
 

--- a/phpdotnet/phd/Package/PHP/EnhancedCHM.php
+++ b/phpdotnet/phd/Package/PHP/EnhancedCHM.php
@@ -26,15 +26,20 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
             // Use %TEMP%/usernotes as base directory for Usernotes.
             $temp = sys_get_temp_dir();
             if (!$temp || !is_dir($temp)) {
-                trigger_error('Unable to locate the systems temporary system directory for EnhancedCHM.', E_USER_ERROR);
+                throw new \Error('Unable to locate the systems temporary system directory for EnhancedCHM.');
                 break;
             }
 
             $this->userNotesBaseDir = $temp . DIRECTORY_SEPARATOR . 'usernotes' . DIRECTORY_SEPARATOR;
 
             // Make the usernotes directory.
-            if(!file_exists($this->userNotesBaseDir) || is_file($this->userNotesBaseDir)) {
-                mkdir($this->userNotesBaseDir, 0777, true) or trigger_error(vsprintf("Can't create the usernotes directory : %s", [$this->userNotesBaseDir]), E_USER_ERROR);
+            if (!file_exists($this->userNotesBaseDir) || is_file($this->userNotesBaseDir)) {
+                if (!mkdir($this->userNotesBaseDir, 0777, true)) {
+                    throw new \RuntimeException(sprintf(
+                        "Can't create the usernotes directory: %s",
+                        $this->userNotesBaseDir
+                    ));
+                }
             }
 
             // Get the local last-updated value.
@@ -54,7 +59,7 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
                 }
 
                 if (!extension_loaded('bz2')) {
-                    trigger_error('The BZip2 extension is not available.', E_USER_ERROR);
+                    throw new \Error('The BZip2 extension is not available.');
                     break;
                 }
 
@@ -65,7 +70,7 @@ class Package_PHP_EnhancedCHM extends Package_PHP_CHM
 
                 // Use a decompression stream filter to save having to store anything locally other than the expanded user notes.
                 if (false === ($fpNotes = fopen('http://www.php.net/backend/notes/all.bz2', 'rb'))) {
-                    trigger_error('Failed to access the usernotes archive.', E_USER_ERROR);
+                    throw new \Error('Failed to access the usernotes archive.');
                     break;
                 }
 

--- a/phpdotnet/phd/Package/PHP/HowTo.php
+++ b/phpdotnet/phd/Package/PHP/HowTo.php
@@ -28,11 +28,11 @@ class Package_PHP_HowTo extends Package_PHP_Web {
             $this->postConstruct();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    trigger_error("Output directory is a file?", E_USER_ERROR);
+                    throw new \Error('Output directory is a file?');
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
+                    throw new \Error("Can't create output directory");
                 }
             }
             break;

--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -89,11 +89,11 @@ class Package_PHP_Web extends Package_PHP_XHTML {
             $this->loadHistoryInfo();
             if (file_exists($this->getOutputDir())) {
                 if (!is_dir($this->getOutputDir())) {
-                    trigger_error("Output directory is a file?", E_USER_ERROR);
+                    throw new \Error('Output directory is a file?');
                 }
             } else {
                 if (!mkdir($this->getOutputDir(), 0777, true)) {
-                    trigger_error("Can't create output directory", E_USER_ERROR);
+                    throw new \Error("Can't create output directory");
                 }
             }
             if ($this->getFormatName() == "PHP-Web") {
@@ -411,7 +411,7 @@ contributors($setup);
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            trigger_error(vsprintf("Can't open the sources file (%s)", [$filename]), E_USER_ERROR);
+            throw new \Error(vsprintf("Can't open the sources file (%s)", [$filename]));
             return array();
         }
         $info = array();

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -263,7 +263,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            trigger_error(vsprintf("Can't open the version info file (%s)", [$filename]), E_USER_ERROR);
+            throw new \Error(vsprintf("Can't open the version info file (%s)", [$filename]));
         }
         $versions = array();
         while($r->read()) {
@@ -300,7 +300,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            trigger_error(vsprintf("Can't open the version info file (%s)", [$filename]), E_USER_ERROR);
+            throw new \Error(vsprintf("Can't open the version info file (%s)", [$filename]));
         }
         $deprecated = array();
         while($r->read()) {
@@ -334,7 +334,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
 
         $r = new \XMLReader;
         if (!$r->open($filename)) {
-            trigger_error(vsprintf("Could not open file for accessing acronym information (%s)", [$filename]), E_USER_ERROR);
+            throw new \Error(vsprintf('Could not open file for accessing acronym information (%s)', [$filename]));
         }
 
         $acronyms = array();

--- a/render.php
+++ b/render.php
@@ -47,16 +47,16 @@ if (isset($commandLineOptions["packageDirs"])) {
 
 /* If no docbook file was passed, die */
 if (!is_dir($config->xmlRoot) || !is_file($config->xmlFile)) {
-    trigger_error("No Docbook file given. Specify it on the command line with --docbook.", E_USER_ERROR);
+    throw new \Error('No Docbook file given. Specify it on the command line with --docbook.');
 }
 if (!file_exists($config->outputDir)) {
     $outputHandler->v("Creating output directory..", VERBOSE_MESSAGES);
     if (!mkdir($config->outputDir, 0777, True)) {
-        trigger_error(vsprintf("Can't create output directory : %s", [$config->outputDir]), E_USER_ERROR);
+        throw new \Error(vsprintf("Can't create output directory : %s", [$config->outputDir]));
     }
     $outputHandler->v("Output directory created", VERBOSE_MESSAGES);
 } elseif (!is_dir($config->outputDir)) {
-    trigger_error("Output directory is not a file?", E_USER_ERROR);
+    throw new \Error('Output directory is not a file?');
 }
 
 // This needs to be moved. Preferably into the PHP package.


### PR DESCRIPTION
### Summary
This PR replaces deprecated usages of `trigger_error(..., E_USER_ERROR)`
with proper exception handling.  
As of PHP 8.4, E_USER_ERROR is deprecated and will be removed in a future release.

### Motivation
- Ensures forward compatibility with PHP 8.4 and beyond.
- Improves error semantics and debuggability.
- Replaces legacy fatal error triggers with modern exception-based handling.

### Scope
- Replaced trigger_error(..., E_USER_ERROR) with:
    - `throw new RuntimeException(...)` for runtime failures (I/O, missing dirs, etc.)
    - `throw new Error(...)` for programming or internal state issues
- Left E_USER_WARNING / E_USER_NOTICE untouched.

### Example
Before:
```php
mkdir($this->userNotesBaseDir, 0777, true)
    or trigger_error("Can't create dir: $this->userNotesBaseDir", E_USER_ERROR);
After:
if (!mkdir($this->userNotesBaseDir, 0777, true)) {
    throw new \RuntimeException(sprintf(
        "Can't create the usernotes directory: %s",
        $this->userNotesBaseDir
    ));
}
