### PR TITLE
Replace deprecated SplObjectStorage::attach() usage for PHP 8.5

### DIFF
--- a/phpdotnet/phd/ObjectStorage.php
+++ b/phpdotnet/phd/ObjectStorage.php
@@ -3,23 +3,18 @@ namespace phpdotnet\phd;
 
 class ObjectStorage extends \SplObjectStorage
 {
-	public function attach(object $object, mixed $info = array()): void {
+	public function attach(object $object, mixed $info = []): void {
 		if (!($object instanceof Format)) {
 			throw new \InvalidArgumentException(
                 'Only classess inheriting ' . __NAMESPACE__ . '\\Format supported'
             );
 		}
 		if (empty($info)) {
-			$info = array(
+			$info = [
 				\XMLReader::ELEMENT => $object->getElementMap(),
 				\XMLReader::TEXT    => $object->getTextMap(),
-			);
+            ];
 		}
-		parent::attach($object, $info);
-
-        if (PHP_VERSION_ID < 80500) {
-            parent::attach($object, $info);
-        }
 
         $this->offsetSet($object, $info);
 	}


### PR DESCRIPTION
PHP 8.5 deprecates SplObjectStorage::attach().

Actual runtime message:
`"Method SplObjectStorage::attach() is deprecated since 8.5, use method SplObjectStorage::offsetSet() instead"`

PhD still calls these methods internally, producing E_DEPRECATED during builds.
This patch switches to offsetSet() on PHP >= 8.5 while keeping behavior unchanged on older versions.
