### PR TITLE
Fix: Prevent using null as array offset in Package/PHP/Web

### DIFF
--- a/phpdotnet/phd/Package/PHP/Web.php
+++ b/phpdotnet/phd/Package/PHP/Web.php
@@ -205,7 +205,13 @@ $PARENTS = ' . var_export($parents, true) . ';';
             "source" => $this->sourceInfo($id),
         );
         $history = $this->history ?? [];
-        $setup["history"] = $history[$setup["source"]["path"]] ?? [];
+
+        $sourcePath = $setup["source"]["path"] ?? null;
+
+        $setup["history"] = $sourcePath !== null
+            ? ($history[$sourcePath] ?? [])
+            : [];
+
         if ($this->getChildren($id)) {
             $lang = $this->config->language;
             $setup["extra_header_links"] = array(


### PR DESCRIPTION
Addresses the deprecation warning/error related to attempting to use a `null` value as an array.

This was primarily fixed in `phpdotnet/phd/Package/PHP/Web.php` by using `($this->property ?? [])` to ensure that the array access operator (`[]`) is always applied to a valid array, thus resolving the issues experienced with modern PHP versions (7.4+).

[Fixes #227](https://github.com/php/phd/issues/227)