### PR TITLE
Switch autoloading from PSR-0 to PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,13 @@
         "easybook/geshi": "For using GeSHi as code highlighter"
     },
     "autoload": {
-        "psr-0": {
-            "phpdotnet\\": "."
+        "psr-4": {
+            "phpdotnet\\phd\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "phpdotnet\\phd\\Tests\\": "tests/"
         }
     }
 }


### PR DESCRIPTION
This PR replaces the deprecated PSR-0 autoload configuration with a minimal PSR-4 setup.

No code is moved, no files are added, and there are no functional or behavioral changes.
This follows the idea introduced in https://github.com/php/phd/pull/52 , but intentionally reduces the scope to a minimal, infrastructure-only change.