### PR TITLE
Fix GH-181: Empty title swallows sibling content

### DIFF
--- a/phpdotnet/phd/Format/Abstract/XHTML.php
+++ b/phpdotnet/phd/Format/Abstract/XHTML.php
@@ -31,7 +31,10 @@ abstract class Format_Abstract_XHTML extends Format {
                 $id = $attrs[Reader::XMLNS_XML]["id"];
                 $idstr = ' id="' .$id. '"';
             }
-            return '<' .$tag. ' class="' .$name. '"' . $idstr . ($props["empty"] ? '/' : "") . '>';
+            if ($props["empty"]) {
+                return '<' .$tag. ' class="' .$name. '"' . $idstr . '></' .$tag. '>';
+            }
+            return '<' .$tag. ' class="' .$name. '"' . $idstr . '>';
         }
         return '</' .$tag. '>';
     }

--- a/tests/package/generic/data/empty_title_001.xml
+++ b/tests/package/generic/data/empty_title_001.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xmlns="http://docbook.org/ns/docbook" xml:id="empty_title_test">
+ <section xml:id="empty-title-section">
+  <title/>
+  <simpara>Some content after empty title</simpara>
+ </section>
+</article>

--- a/tests/package/generic/empty_title_001.phpt
+++ b/tests/package/generic/empty_title_001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-181 Empty title should not swallow sibling content
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xmlFile = __DIR__ . "/data/empty_title_001.xml";
+
+$config->xmlFile = $xmlFile;
+
+$format = new TestGenericChunkedXHTML($config, $outputHandler);
+$render = new TestRender(new Reader($outputHandler), $config, $format);
+
+$render->run();
+?>
+--EXPECTF--
+Filename: empty-title-section.html
+Content:
+<div id="empty-title-section" class="section">
+  <h2 class="title"></h2>
+  <p class="simpara">Some content after empty title</p>
+ </div>
+Filename: empty_title_test.html
+Content:
+<div id="empty_title_test" class="article">
+%A
+</div>


### PR DESCRIPTION
## Summary

- When a self-closing `<title/>` element appeared in DocBook XML, `transformFromMap()` generated invalid HTML like `<h3 class="title"/>`. HTML5 parsers treat this as an unclosed `<h3>`, swallowing all sibling content.
- Changed `transformFromMap()` to emit a proper open+close pair (`<h3 class="title"></h3>`) for empty elements, fixing all map-based elements in one place.
- Added a test verifying empty `<title/>` renders correctly with sibling content placed outside the heading.

Fixes https://github.com/php/phd/issues/181