### PR TITLE
Fix GH-157: Note elements generate semantic HTML using div instead of blockquote

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -118,7 +118,6 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         ),
         'info'                  => array(
             /* DEFAULT */         'format_div',
-            'note'              => 'span',
         ),
         'informalexample'       => 'format_div',
         'informaltable'         => 'format_table',
@@ -294,7 +293,6 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         'simplesect'            => 'div',
         'simpara'               => array(
             /* DEFAULT */          'p',
-            'note'              => 'span',
             'listitem'          => 'span',
             'entry'             => 'span',
             'example'           => 'format_example_content',
@@ -2042,16 +2040,16 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
     public function format_note($open, $name, $attrs, $props) {
         if ($open) {
-            return '<blockquote class="note"><p>'.$this->admonition_title("note", $props["lang"]). ': ';
+            return '<div class="note">' .$this->admonition_title("note", $props["lang"]);
         }
-        return "</p></blockquote>";
+        return "</div>";
     }
     public function format_note_title($open, $name, $attrs)
     {
         if ($open) {
-            return '<strong>';
+            return '<h5 class="title">';
         }
-        return '</strong><br />';
+        return '</h5>';
     }
     public function format_example($open, $name, $attrs, $props) {
         if ($open) {

--- a/tests/package/generic/data/note_rendering_001.xml
+++ b/tests/package/generic/data/note_rendering_001.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xml:id="test_note" xmlns='http://docbook.org/ns/docbook'>
+<title>Note rendering test</title>
+
+<note>
+ <simpara>Simple note content</simpara>
+</note>
+
+<note>
+ <title>Custom Title</title>
+ <simpara>Note with a title</simpara>
+</note>
+
+</article>

--- a/tests/package/generic/note_rendering_001.phpt
+++ b/tests/package/generic/note_rendering_001.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Note rendering - notes use div instead of blockquote, titles use h5, simpara uses p
+--FILE--
+<?php
+namespace phpdotnet\phd;
+
+require_once __DIR__ . "/../../setup.php";
+
+$xmlFile = __DIR__ . "/data/note_rendering_001.xml";
+
+$config->xmlFile = $xmlFile;
+
+$format = new TestGenericChunkedXHTML($config, $outputHandler);
+$render = new TestRender(new Reader($outputHandler), $config, $format);
+
+$render->run();
+?>
+--EXPECT--
+Filename: test_note.html
+Content:
+<div id="test_note" class="article">
+<h1>Note rendering test</h1>
+
+<div class="note"><strong class="note">Note</strong>
+ <p class="simpara">Simple note content</p>
+</div>
+
+<div class="note"><strong class="note">Note</strong>
+ <h5 class="title">Custom Title</h5>
+ <p class="simpara">Note with a title</p>
+</div>
+
+</div>


### PR DESCRIPTION
## Summary

- Replace `<blockquote><p>` with `<div>` in `format_note()`, aligning with `format_admonition()` used by other admonitions (`<caution>`, `<warning>`, `<tip>`, `<important>`)
- Change note title from `<strong>` to `<h5 class="title">`
- Remove `'note' => 'span'` override for `simpara`, allowing proper `<p>` rendering inside notes
- Remove `'note' => 'span'` override for `info`, using default `format_div`
- `<sidebar>` (which reuses `format_note`) benefits automatically

**Before:**
```html
<blockquote class="note"><p><strong class="note">Note</strong>:
  <strong>Custom Title</strong><br />
  <span class="simpara">Content here</span>
</p></blockquote>
```

**After:**
```html
<div class="note"><strong class="note">Note</strong>
 <h5 class="title">Custom Title</h5>
 <p class="simpara">Content here</p>
</div>
```

Fixes #157