### PR TITLE
Fix rendering of attribute constants

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1427,6 +1427,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     }
 
     public function format_fieldsynopsis_modifier_text($value, $tag) {
+        $this->cchunk["fieldsynopsis"]["modifier"] = trim($value);
         if ($this->getRole() === "attribute") {
             $attribute = trim(strtolower($value), "#[]\\");
             $href = Format::getFilename("class.$attribute");
@@ -1435,7 +1436,6 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             }
             return false;
         }
-        $this->cchunk["fieldsynopsis"]["modifier"] = trim($value);
         return $this->TEXT($value);
     }
 

--- a/tests/package/generic/attribute_formatting_003.phpt
+++ b/tests/package/generic/attribute_formatting_003.phpt
@@ -85,4 +85,21 @@ Content:
   }</div>
  </div>
 
+ <div class="section">
+  <p class="para">3. Constant of a class with attribute</p>
+  <div class="classsynopsis"><div class="classsynopsisinfo">
+   
+    <span class="attribute">#[\UnknownAttribute]</span><br>
+    <span class="modifier">class</span> <strong class="classname">ClassName</strong>
+    {</div>
+   <div class="classsynopsisinfo classsynopsisinfo_comment">/* Constants */</div>
+   <div class="fieldsynopsis">
+    <span class="modifier">public</span>
+    <span class="modifier">const</span>
+    <span class="type">string</span>
+    <var class="fieldsynopsis_varname">CONSTANT_NAME</var>;</div>
+
+  }</div>
+ </div>
+
 </div>

--- a/tests/package/generic/data/attribute_formatting_003.xml
+++ b/tests/package/generic/data/attribute_formatting_003.xml
@@ -35,4 +35,21 @@
   </classsynopsis>
  </section>
 
+ <section>
+  <para>3. Constant of a class with attribute</para>
+  <classsynopsis class="class">
+   <ooclass>
+    <modifier role="attribute">#[\UnknownAttribute]</modifier>
+    <classname>ClassName</classname>
+   </ooclass>
+   <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+   <fieldsynopsis>
+    <modifier>public</modifier>
+    <modifier>const</modifier>
+    <type>string</type>
+    <varname>CONSTANT_NAME</varname>
+   </fieldsynopsis>
+  </classsynopsis>
+ </section>
+
 </chapter>


### PR DESCRIPTION
$this->cchunk["fieldsynopsis"]["modifier"] was not set for atrributes due to the early return, but this value is needed in order to be able to decide if the fieldsynopsis refers to a constant or a property at https://github.com/php/phd/blob/d7f700463918a466705e92b4bfd4df0afa39d944/phpdotnet/phd/Package/Generic/XHTML.php#L1608