### PR TITLE
Fix rendering of class method names inside packagesynopsis

### DIFF
--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -1332,11 +1332,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
 
         list($class, $method) = explode($explode, $value);
-        $thisFqcn = "";
-        if ($this->cchunk["packagesynopsis"]["namespace"]) {
-            $thisFqcn = $this->cchunk["packagesynopsis"]["namespace"] . '\\';
-        }
-        $thisFqcn .= $this->cchunk["classsynopsis"]["classname"];
+        $thisFqcn = $this->getFqcn();
 
         if ($class !== $thisFqcn) {
             return $value;
@@ -2706,5 +2702,15 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     public function onNewPage(): void
     {
         $this->perPageExampleCounter = 0;
+    }
+
+    protected function getFqcn() {
+        $fqcn = "";
+
+        if ($this->cchunk["packagesynopsis"]["namespace"]) {
+            $fqcn = $this->cchunk["packagesynopsis"]["namespace"] . "\\";
+        }
+
+        return $fqcn . $this->cchunk["classsynopsis"]["classname"];
     }
 }

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -467,6 +467,11 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
             'constant'         => 'format_suppressed_text',
         ),
         /** Those are used to retrieve the class/interface name to be able to remove it from method names */
+        'package' => [
+            /* DEFAULT */ false,
+            'packagesynopsis' => 'format_packagesynopsis_package_text'
+        ],
+        /** Those are used to retrieve the class/interface name to be able to remove it from method names */
         'classname' => [
             /* DEFAULT */ false,
             'ooclass' => [
@@ -538,7 +543,10 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     protected $cchunk      = array();
     /* Default Chunk variables */
     private $dchunk      = array(
-        "packagesynopsis" => false,
+        "packagesynopsis" => [
+            "open"         => false,
+            "namespace"    => false,
+        ],
         "classsynopsis" => [
             "close"        => false,
             "classname"    => false,
@@ -1257,7 +1265,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         /** Legacy presentation does not use the class attribute */
         $this->cchunk["classsynopsis"]['legacy'] = !isset($attrs[Reader::XMLNS_DOCBOOK]["class"]);
 
-        $inPackageSynopsis = $this->cchunk["packagesynopsis"] ?? false;
+        $inPackageSynopsis = $this->cchunk["packagesynopsis"]["open"] ?? false;
 
         if ($this->cchunk["classsynopsis"]['legacy']) {
             if ($open) {
@@ -1324,18 +1332,26 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         }
 
         list($class, $method) = explode($explode, $value);
-        if ($class !== $this->cchunk["classsynopsis"]["classname"]) {
+        $thisFqcn = "";
+        if ($this->cchunk["packagesynopsis"]["namespace"]) {
+            $thisFqcn = $this->cchunk["packagesynopsis"]["namespace"] . '\\';
+        }
+        $thisFqcn .= $this->cchunk["classsynopsis"]["classname"];
+
+        if ($class !== $thisFqcn) {
             return $value;
         }
+
         return $method;
     }
 
     public function format_packagesynopsis($open, $name, $attrs, $props) {
+        $this->cchunk["packagesynopsis"] = $this->dchunk["packagesynopsis"];
         if ($open) {
-            $this->cchunk["packagesynopsis"] = true;
+            $this->cchunk["packagesynopsis"]["open"] = true;
             return '<div class="classsynopsis"><div class="classsynopsisinfo">';
         }
-        $this->cchunk["packagesynopsis"] = false;
+        $this->cchunk["packagesynopsis"]["open"] = false;
         return '</div>';
     }
 
@@ -1346,8 +1362,16 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
         return '</strong>;</div>';
     }
 
+    public function format_packagesynopsis_package_text($value, $tag) {
+        if (!$this->cchunk["packagesynopsis"]["namespace"]) {
+            $this->cchunk["packagesynopsis"]["namespace"] = $value;
+        }
+
+        return $this->TEXT($value);
+    }
+
     public function format_enumsynopsis($open, $name, $attrs, $props) {
-        $inPackageSynopsis = $this->cchunk["packagesynopsis"] ?? false;
+        $inPackageSynopsis = $this->cchunk["packagesynopsis"]["open"] ?? false;
         if ($open) {
             if ($inPackageSynopsis) {
                 return '<div class="classsynopsisinfo">';

--- a/phpdotnet/phd/Package/Generic/XHTML.php
+++ b/phpdotnet/phd/Package/Generic/XHTML.php
@@ -545,7 +545,7 @@ abstract class Package_Generic_XHTML extends Format_Abstract_XHTML {
     private $dchunk      = array(
         "packagesynopsis" => [
             "open"         => false,
-            "namespace"    => false,
+            "namespace"    => '',
         ],
         "classsynopsis" => [
             "close"        => false,

--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -807,7 +807,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     public function format_classsynopsis_fieldsynopsis_varname_text($value, $tag) {
         if ($this->cchunk["classsynopsis"]["classname"]) {
           if (strpos($value, "::") === false && strpos($value, "->") === false) {
-                $value = $this->cchunk["classsynopsis"]["classname"] . "->" . $value;
+                $value = $this->getFqcn() . "->" . $value;
             }
         }
 
@@ -817,7 +817,7 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
     public function format_classsynopsis_methodsynopsis_methodname_text($value, $tag) {
         if ($this->cchunk["classsynopsis"]["classname"]) {
           if (strpos($value, "::") === false && strpos($value, "->") === false) {
-                $value = $this->cchunk["classsynopsis"]["classname"] . "::" . $value;
+                $value = $this->getFqcn() . "::" . $value;
             }
         }
 

--- a/tests/package/php/data/packagesynopsis_rendering.xml
+++ b/tests/package/php/data/packagesynopsis_rendering.xml
@@ -15,6 +15,17 @@
      <modifier>implements</modifier>
      <interfacename>Stringable</interfacename>
     </oointerface>
+
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>int</type>
+     <varname linkend="bcmath-number.props.scale">scale</varname>
+    </fieldsynopsis>
+
+    <methodsynopsis xmlns="http://docbook.org/ns/docbook" role="BcMath\\Number">
+     <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::floor</methodname>
+     <void/>
+    </methodsynopsis>
    </classsynopsis>
   </packagesynopsis>
  </section>

--- a/tests/package/php/packagesynopsis_rendering_001.phpt
+++ b/tests/package/php/packagesynopsis_rendering_001.phpt
@@ -34,6 +34,16 @@ Content:
     
      <span class="modifier">implements</span>
       <strong class="interfacename">Stringable</strong> {</div>
+
+    <div class="fieldsynopsis">
+     <span class="modifier">public</span>
+     <span class="type"><a href="language.types.integer.html" class="type int">int</a></span>
+      <var class="varname"><a href=".html#bcmath-number.props.scale">$<var class="varname">scale</var></a></var>;</div>
+
+
+    <div class="methodsynopsis dc-description">
+     <span class="modifier">public</span> <span class="methodname"><strong>floor</strong></span>(): <span class="type">BcMath\Number</span></div>
+
    }
   </div>
  </div>


### PR DESCRIPTION
Rendering of method names inside `packagesynopsis` tags were broken, because the the code relied on having the FQCN inside the classname tag, but this isn't the case anymore for classes inside a `packagesynopsis` tag.

Tests are TBD.

A printscreen about a namespaced class for evidence:

<img width="1115" height="757" alt="Screenshot 2026-04-23 at 23 11 48" src="https://github.com/user-attachments/assets/41373e52-0a9e-4271-bc42-e89892eafd9c" />


And another one for a non-namespaced class:

<img width="866" height="859" alt="Screenshot 2026-04-23 at 23 11 24" src="https://github.com/user-attachments/assets/312940d3-0706-4f92-931e-47a743e1fdbb" />
<img width="982" height="585" alt="Screenshot 2026-04-23 at 23 11 37" src="https://github.com/user-attachments/assets/3f373da1-74f3-4279-a53d-e235bc3472ad" />

