### PR TITLE
GH-248: Add `function` keyword to `<methodsynopsis>`.

### DIFF
--- a/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/phpdotnet/phd/Package/PHP/XHTML.php
@@ -10,7 +10,12 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         'chapter'               => 'format_container_chunk',
         'colophon'              => 'format_chunk',
         'function'              => 'format_function',
-        'methodname'            => 'format_function',
+        'methodname'            => array(
+            /* DEFAULT */          'format_function',
+            'methodsynopsis'      => 'format_methodsynopsis_function',
+            'constructorsynopsis' => 'format_methodsynopsis_function',
+            'destructorsynopsis'  => 'format_methodsynopsis_function',
+        ),
         'methodparam'           => 'format_methodparam',
         'methodsynopsis'        => 'format_methodsynopsis',
         'legalnotice'           => 'format_chunk',
@@ -838,6 +843,16 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
         }
 
         return "</span>";
+    }
+
+    public function format_methodsynopsis_function($open, $tag, $attrs, $props) {
+        if ($open) {
+            return
+                '<span class="modifier">function</span> '
+                . $this->format_function($open, $tag, $attrs, $props);
+        }
+
+        return $this->format_function($open, $tag, $attrs, $props);
     }
 
     public function format_function_text($value, $tag, $display_value = null) {

--- a/tests/package/php/bug49102-1.phpt
+++ b/tests/package/php/bug49102-1.phpt
@@ -46,23 +46,23 @@ Content:
 
         <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
         <div class="constructorsynopsis dc-description">
-            <span class="methodname"><strong>__construct</strong></span>()</div>
+            <span class="modifier">function</span> <span class="methodname"><strong>__construct</strong></span>()</div>
 
-        <div class="methodsynopsis dc-description"><span class="methodname"><strong>setIteratorMode</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$mode</code></span>): <span class="type"><a href="language.types.void.html" class="type void">void</a></span></div>
+        <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>setIteratorMode</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$mode</code></span>): <span class="type"><a href="language.types.void.html" class="type void">void</a></span></div>
 
 
         <div class="classsynopsisinfo classsynopsisinfo_comment">/* Inherited methods */</div>
-        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::bottom</strong></span>(): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
+        <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>SplDoublyLinkedList::bottom</strong></span>(): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
 
-        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::count</strong></span>(): <span class="type"><a href="language.types.integer.html" class="type int">int</a></span></div>
+        <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>SplDoublyLinkedList::count</strong></span>(): <span class="type"><a href="language.types.integer.html" class="type int">int</a></span></div>
 
-        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::current</strong></span>(): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
+        <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>SplDoublyLinkedList::current</strong></span>(): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
 
-        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::getIteratorMode</strong></span>(): <span class="type"><a href="language.types.integer.html" class="type int">int</a></span></div>
+        <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>SplDoublyLinkedList::getIteratorMode</strong></span>(): <span class="type"><a href="language.types.integer.html" class="type int">int</a></span></div>
 
-        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::offsetExists</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>): <span class="type"><a href="language.types.boolean.html" class="type bool">bool</a></span></div>
+        <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>SplDoublyLinkedList::offsetExists</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>): <span class="type"><a href="language.types.boolean.html" class="type bool">bool</a></span></div>
 
-        <div class="methodsynopsis dc-description"><span class="methodname"><strong>SplDoublyLinkedList::offsetGet</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
+        <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>SplDoublyLinkedList::offsetGet</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$index</code></span>): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
 
     }</div>
 

--- a/tests/package/php/bug_doc-en_GH-3179.phpt
+++ b/tests/package/php/bug_doc-en_GH-3179.phpt
@@ -20,7 +20,7 @@ Filename: bug_doc-en_GH-3179.html
 Content:
 <div id="bug_doc-en_GH-3179" class="refentry">
  <div class="refsect1 unknown-1" id="refsect1-bug_doc-en_GH-3179-unknown-1">
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>method_name</strong></span>(): <span class="type"><a href="language.types.void.html" class="type void">void</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>method_name</strong></span>(): <span class="type"><a href="language.types.void.html" class="type void">void</a></span></div>
 
  </div>
 

--- a/tests/package/php/class_and_method_link_rendering_001.phpt
+++ b/tests/package/php/class_and_method_link_rendering_001.phpt
@@ -64,13 +64,13 @@ Content:
  
  <div class="section">
   <p class="para">3. Class linking (non-FQN) in method/function parameter and return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">Extension\Namespace\Existing_Class</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">Extension\Namespace\Existing_Class</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">Extension\Namespace\Existing_Class</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">Extension\Namespace\Existing_Class</a></span></div>
 
  </div>
  
  <div class="section">
   <p class="para">4. Class linking (FQN) in method/function parameter and return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">\Extension\Namespace\Existing_Class</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">\Extension\Namespace\Existing_Class</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">\Extension\Namespace\Existing_Class</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="extensionname.classpage.html" class="type Extension\Namespace\Existing_Class">\Extension\Namespace\Existing_Class</a></span></div>
 
  </div>
 

--- a/tests/package/php/class_rendering_001.phpt
+++ b/tests/package/php/class_rendering_001.phpt
@@ -27,7 +27,7 @@ Content:
 
      <div class="refsect1 description" id="refsect1-classname.construct-description">
       Description
-      <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$firstParameter</code><span class="initializer"> = &quot;now&quot;</span></span>)</div>
+      <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$firstParameter</code><span class="initializer"> = &quot;now&quot;</span></span>)</div>
 
       <p class="para rdfs-comment">
        Returns new a ClassName object.

--- a/tests/package/php/class_rendering_002.phpt
+++ b/tests/package/php/class_rendering_002.phpt
@@ -27,7 +27,7 @@ Content:
 
      <div class="refsect1 description" id="refsect1-classname.construct-description">
       Description
-      <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$firstParameter</code><span class="initializer"> = &quot;now&quot;</span></span>)</div>
+      <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$firstParameter</code><span class="initializer"> = &quot;now&quot;</span></span>)</div>
 
       <p class="para rdfs-comment">
        Returns new a ClassName object.

--- a/tests/package/php/enum_link_rendering.phpt
+++ b/tests/package/php/enum_link_rendering.phpt
@@ -41,13 +41,13 @@ Content:
 
  <div class="section">
   <p class="para">2. Enum linking (non-FQN) in method/function parameter and return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">Enum\Namespace\Existing_Enum</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">Enum\Namespace\Existing_Enum</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">Enum\Namespace\Existing_Enum</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">Enum\Namespace\Existing_Enum</a></span></div>
 
  </div>
  
  <div class="section">
   <p class="para">3. Enum linking (FQN) in method/function parameter and return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">\Enum\Namespace\Existing_Enum</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">\Enum\Namespace\Existing_Enum</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>method_name</strong></span>(<span class="methodparam"><span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">\Enum\Namespace\Existing_Enum</a></span> <code class="parameter">$paramName</code></span>): <span class="type"><a href="enumname.enumpage.html" class="type Enum\Namespace\Existing_Enum">\Enum\Namespace\Existing_Enum</a></span></div>
 
  </div>
 

--- a/tests/package/php/exception_rendering_001.phpt
+++ b/tests/package/php/exception_rendering_001.phpt
@@ -27,7 +27,7 @@ Content:
 
       <div class="refsect1 description" id="refsect1-exceptionname.construct-description">
        Description
-       <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ExceptionName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$propertyName</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
+       <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ExceptionName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$propertyName</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
 
        <p class="para rdfs-comment">
         Constructs the Exception.

--- a/tests/package/php/exception_rendering_002.phpt
+++ b/tests/package/php/exception_rendering_002.phpt
@@ -27,7 +27,7 @@ Content:
 
       <div class="refsect1 description" id="refsect1-exceptionname.construct-description">
        Description
-       <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><strong>ExceptionName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$propertyName</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
+       <div class="constructorsynopsis dc-description"><span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ExceptionName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$propertyName</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
 
        <p class="para rdfs-comment">
         Constructs the Exception.

--- a/tests/package/php/packagesynopsis_rendering_001.phpt
+++ b/tests/package/php/packagesynopsis_rendering_001.phpt
@@ -42,7 +42,7 @@ Content:
 
 
     <div class="methodsynopsis dc-description">
-     <span class="modifier">public</span> <span class="methodname"><strong>floor</strong></span>(): <span class="type">BcMath\Number</span></div>
+     <span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>floor</strong></span>(): <span class="type">BcMath\Number</span></div>
 
    }
   </div>

--- a/tests/package/php/type_rendering_001.phpt
+++ b/tests/package/php/type_rendering_001.phpt
@@ -22,49 +22,49 @@ Content:
 
  <div class="section">
   <p class="para">%d. Function/method with no return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>()</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>()</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Function/method with one return type - never</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(): <span class="type"><a href="language.types.never.html" class="type never">never</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(): <span class="type"><a href="language.types.never.html" class="type never">never</a></span></div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Function/method with one return type - void</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(): <span class="type"><a href="language.types.void.html" class="type void">void</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(): <span class="type"><a href="language.types.void.html" class="type void">void</a></span></div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Function/method with one return type - mixed</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(): <span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span></div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Function/method with union return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(): <span class="type"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span>|<span class="type"><a href="language.types.float.html" class="type float">float</a></span>|<span class="type"><a href="language.types.singleton.html" class="type false">false</a></span></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(): <span class="type"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span>|<span class="type"><a href="language.types.float.html" class="type float">float</a></span>|<span class="type"><a href="language.types.singleton.html" class="type false">false</a></span></span></div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Function/method with nullable return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(): <span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.object.html" class="type object">object</a></span></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(): <span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.object.html" class="type object">object</a></span></span></div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Function/method with nullable union return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(): <span class="type"><span class="type"><a href="language.types.string.html" class="type string">string</a></span>|<span class="type"><a href="language.types.array.html" class="type array">array</a></span>|<span class="type"><a href="language.types.resource.html" class="type resource">resource</a></span>|<span class="type"><a href="language.types.callable.html" class="type callable">callable</a></span>|<span class="type"><a href="language.types.iterable.html" class="type iterable">iterable</a></span>|<span class="type"><a href="language.types.singleton.html" class="type true">true</a></span>|<span class="type"><a href="language.types.null.html" class="type null">null</a></span></span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(): <span class="type"><span class="type"><a href="language.types.string.html" class="type string">string</a></span>|<span class="type"><a href="language.types.array.html" class="type array">array</a></span>|<span class="type"><a href="language.types.resource.html" class="type resource">resource</a></span>|<span class="type"><a href="language.types.callable.html" class="type callable">callable</a></span>|<span class="type"><a href="language.types.iterable.html" class="type iterable">iterable</a></span>|<span class="type"><a href="language.types.singleton.html" class="type true">true</a></span>|<span class="type"><a href="language.types.null.html" class="type null">null</a></span></span></div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Function/method with unknown return type</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(): <span class="type">UnknownType</span></div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(): <span class="type">UnknownType</span></div>
 
  </div>
 

--- a/tests/package/php/type_rendering_002.phpt
+++ b/tests/package/php/type_rendering_002.phpt
@@ -22,61 +22,61 @@ Content:
 
  <div class="section">
   <p class="para">1. Function/method with no parameters</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>()</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>()</div>
 
  </div>
 
  <div class="section">
   <p class="para">2. Function/method with one parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$anything</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$anything</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">3. Function/method with optional parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code><span class="initializer"> = 0</span></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code><span class="initializer"> = 0</span></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">4. Function/method with nullable parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.float.html" class="type float">float</a></span></span> <code class="parameter">$value</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.float.html" class="type float">float</a></span></span> <code class="parameter">$value</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">5. Function/method with nullable optional parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.string.html" class="type string">string</a></span></span> <code class="parameter">$options</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.string.html" class="type string">string</a></span></span> <code class="parameter">$options</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">6. Function/method with reference parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter reference">&$reference</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter reference">&$reference</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">7. Function/method with union type parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.iterable.html" class="type iterable">iterable</a></span>|<span class="type"><a href="language.types.resource.html" class="type resource">resource</a></span>|<span class="type"><a href="language.types.callable.html" class="type callable">callable</a></span>|<span class="type"><a href="language.types.null.html" class="type null">null</a></span></span> <code class="parameter">$option</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.iterable.html" class="type iterable">iterable</a></span>|<span class="type"><a href="language.types.resource.html" class="type resource">resource</a></span>|<span class="type"><a href="language.types.callable.html" class="type callable">callable</a></span>|<span class="type"><a href="language.types.null.html" class="type null">null</a></span></span> <code class="parameter">$option</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">8. Function/method with intersection type parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type">Countable</span>&amp;<span class="type">Traversable</span></span> <code class="parameter">$option</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type"><span class="type">Countable</span>&amp;<span class="type">Traversable</span></span> <code class="parameter">$option</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">9. Function/method with DNF (Disjunctive Normal Form) type parameter</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type">(<span class="type">Countable</span>&amp;<span class="type">Traversable</span>)|<span class="type">DOMAttr</span></span> <code class="parameter">$option</code></span>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<span class="methodparam"><span class="type">(<span class="type">Countable</span>&amp;<span class="type">Traversable</span>)|<span class="type">DOMAttr</span></span> <code class="parameter">$option</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">10. Function/method with more than three parameters</p>
-  <div class="methodsynopsis dc-description"><span class="methodname"><strong>function_name</strong></span>(<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$name</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.boolean.html" class="type bool">bool</a></span> <code class="parameter">$isSomething</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter">$list</code></span><br>)</div>
+  <div class="methodsynopsis dc-description"><span class="modifier">function</span> <span class="methodname"><strong>function_name</strong></span>(<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$name</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.boolean.html" class="type bool">bool</a></span> <code class="parameter">$isSomething</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter">$list</code></span><br>)</div>
 
  </div>
 

--- a/tests/package/php/type_rendering_003.phpt
+++ b/tests/package/php/type_rendering_003.phpt
@@ -22,61 +22,61 @@ Content:
 
  <div class="section">
   <p class="para">%d. Constructor with no parameters, no return type</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>()</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>()</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with one parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">private</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$anything</code></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">private</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.mixed.html" class="type mixed">mixed</a></span> <code class="parameter">$anything</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with optional parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">protected</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code><span class="initializer"> = 0</span></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">protected</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code><span class="initializer"> = 0</span></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with nullable parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.float.html" class="type float">float</a></span></span> <code class="parameter">$value</code></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.float.html" class="type float">float</a></span></span> <code class="parameter">$value</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with nullable optional parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">private</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.string.html" class="type string">string</a></span></span> <code class="parameter">$options</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">private</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.null.html" class="type null">?</a></span><span class="type"><a href="language.types.string.html" class="type string">string</a></span></span> <code class="parameter">$options</code><span class="initializer"> = &quot;&quot;</span></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with reference parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">protected</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter reference">&$reference</code></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">protected</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter reference">&$reference</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with union type parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.iterable.html" class="type iterable">iterable</a></span>|<span class="type"><a href="language.types.resource.html" class="type resource">resource</a></span>|<span class="type"><a href="language.types.callable.html" class="type callable">callable</a></span>|<span class="type"><a href="language.types.null.html" class="type null">null</a></span></span> <code class="parameter">$option</code></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type"><a href="language.types.iterable.html" class="type iterable">iterable</a></span>|<span class="type"><a href="language.types.resource.html" class="type resource">resource</a></span>|<span class="type"><a href="language.types.callable.html" class="type callable">callable</a></span>|<span class="type"><a href="language.types.null.html" class="type null">null</a></span></span> <code class="parameter">$option</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with intersection type parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type">Countable</span>&amp;<span class="type">Traversable</span></span> <code class="parameter">$option</code></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type"><span class="type">Countable</span>&amp;<span class="type">Traversable</span></span> <code class="parameter">$option</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with DNF (Disjunctive Normal Form) type parameter</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type">(<span class="type">Countable</span>&amp;<span class="type">Traversable</span>)|<span class="type">DOMAttr</span></span> <code class="parameter">$option</code></span>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">public</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<span class="methodparam"><span class="type">(<span class="type">Countable</span>&amp;<span class="type">Traversable</span>)|<span class="type">DOMAttr</span></span> <code class="parameter">$option</code></span>)</div>
 
  </div>
 
  <div class="section">
   <p class="para">%d. Constructor with more than three parameters</p>
-  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">private</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$name</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.boolean.html" class="type bool">bool</a></span> <code class="parameter">$isSomething</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter">$list</code></span><br>)</div>
+  <div class="constructorsynopsis dc-description"><span class="modifier">final</span> <span class="modifier">private</span> <span class="modifier">function</span> <span class="methodname"><strong>ClassName::__construct</strong></span>(<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.integer.html" class="type int">int</a></span> <code class="parameter">$count</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.string.html" class="type string">string</a></span> <code class="parameter">$name</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.boolean.html" class="type bool">bool</a></span> <code class="parameter">$isSomething</code></span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="methodparam"><span class="type"><a href="language.types.array.html" class="type array">array</a></span> <code class="parameter">$list</code></span><br>)</div>
 
  </div>
 


### PR DESCRIPTION
Fixes #248

Not sure if this needs additional tests, since the existing tests pretty much cover it all. WDYT?

---
Function:

<img width="1056" height="228" alt="image" src="https://github.com/user-attachments/assets/4f89b52f-b029-4686-9088-b9e5b745dbf3" />

---
Class:

<img width="943" height="433" alt="image" src="https://github.com/user-attachments/assets/6e7d84df-0be6-4e2b-b01b-f5e053ed390b" />

